### PR TITLE
#23 Implement failure callbacks

### DIFF
--- a/demo/process.py
+++ b/demo/process.py
@@ -9,6 +9,7 @@ class InProgressTransition(Transition):
 class ProgressTransition(Transition):
     side_effects = SideEffectTasks()
     callbacks = CallbacksTasks()
+    failure_callbacks = CallbacksTasks()
 
 
 class InvoiceProcess(Process):
@@ -17,21 +18,42 @@ class InvoiceProcess(Process):
         ('paid', 'Paid'),
         ('void', 'Void'),
         ('sent', 'Sent'),
+        ('failed', 'Failed'),
     )
 
     transitions = [
-        Transition(action_name='approve',sources=['draft'], target='approved'),
-        InProgressTransition(action_name='send_to_customer',
-                             sources=['approved'],
-                             side_effects=['demo.tasks.send_to_a_customer'],
-                             target='sent'),
-        Transition(action_name='void', sources=['draft', 'paid'], target='voided'),
-        ProgressTransition(action_name='demo', sources=['draft'], target='sent',
-                           in_progress_state='in_progress',
-                           side_effects=['demo.tasks.demo_task_1',
-                                         'demo.tasks.demo_task_2',
-                                         'demo.tasks.demo_task_3'],
-                           callbacks=['demo.tasks.demo_task_4',
-                                      'demo.tasks.demo_task_5'])
+        Transition(
+            action_name='approve',
+            sources=['draft'],
+            target='approved'
+        ),
+        InProgressTransition(
+            action_name='send_to_customer',
+            sources=['approved'],
+            side_effects=['demo.tasks.send_to_a_customer'],
+            target='sent'
+        ),
+        Transition(
+            action_name='void',
+            sources=['draft', 'paid'],
+            target='voided'
+        ),
+        ProgressTransition(
+            action_name='demo',
+            sources=['draft'],
+            target='sent',
+            in_progress_state='in_progress',
+            side_effects=['demo.tasks.demo_task_1', 'demo.tasks.demo_task_2', 'demo.tasks.demo_task_3'],
+            callbacks=['demo.tasks.demo_task_4', 'demo.tasks.demo_task_5']
+        ),
+        ProgressTransition(
+            action_name='failing_transition',
+            sources=['draft'],
+            target='sent',
+            in_progress_state='in_progress',
+            failed_state='failed',
+            side_effects=['demo.tasks.demo_task_1', 'demo.tasks.demo_task_exception', 'demo.tasks.demo_task_2'],
+            failure_callbacks=['demo.tasks.demo_task_3', 'demo.tasks.demo_task_4']
+        )
 
     ]

--- a/demo/tasks.py
+++ b/demo/tasks.py
@@ -17,32 +17,39 @@ def send_to_a_customer(*args, **kwargs):
 def demo_task_1(*args, **kwargs):
     invoice = Invoice.objects.get(pk=kwargs['instance_id'])
     time.sleep(5)
-    print('TASK 1, Invoice status', invoice.status)
+    print('TASK 1, Invoice status', invoice.status, args, kwargs)
 
 
 @shared_task(acks_late=True)
 def demo_task_2(*args, **kwargs):
     invoice = Invoice.objects.get(pk=kwargs['instance_id'])
     time.sleep(5)
-    print('TASK 2, Invoice status', invoice.status)
+    print('TASK 2, Invoice status', invoice.status, args, kwargs)
 
 
 @shared_task(acks_late=True)
 def demo_task_3(*args, **kwargs):
     invoice = Invoice.objects.get(pk=kwargs['instance_id'])
     time.sleep(5)
-    print('TASK 3, Invoice status', invoice.status)
+    print('TASK 3, Invoice status', invoice.status, args, kwargs)
 
 
 @shared_task(acks_late=True)
 def demo_task_4(*args, **kwargs):
     invoice = Invoice.objects.get(pk=kwargs['instance_id'])
     time.sleep(5)
-    print('TASK 4, Invoice status', invoice.status)
+    print('TASK 4, Invoice status', invoice.status, args, kwargs)
 
 
 @shared_task(acks_late=True)
 def demo_task_5(*args, **kwargs):
     invoice = Invoice.objects.get(pk=kwargs['instance_id'])
     time.sleep(5)
-    print('TASK 5, Invoice status', invoice.status)
+    print('TASK 5, Invoice status', invoice.status, args, kwargs)
+
+
+@shared_task(acks_late=True)
+def demo_task_exception(*args, **kwargs):
+    invoice = Invoice.objects.get(pk=kwargs['instance_id'])
+    print('EXCEPTION TASK', invoice.status, args, kwargs)
+    raise Exception

--- a/demo/tests/test_api.py
+++ b/demo/tests/test_api.py
@@ -13,7 +13,7 @@ class InvoiceAPITestCase(APITestCase):
         invoice = Invoice.objects.last()
         self.assertEqual(response.json(), {'id': invoice.pk,
                                            'status': 'draft',
-                                           'actions': ['approve', 'demo', 'void'],
+                                           'actions': ['approve', 'demo', 'failing_transition', 'void'],
                                            'customer_received': False,
                                            'is_available': True})
 
@@ -24,6 +24,6 @@ class InvoiceAPITestCase(APITestCase):
         self.assertEqual(response.json(),
                          [{'id': invoice.pk,
                            'status': 'draft',
-                           'actions': ['approve', 'demo', 'void'],
+                           'actions': ['approve', 'demo', 'failing_transition', 'void'],
                            'customer_received': False,
                            'is_available': True}])

--- a/django_logic/commands.py
+++ b/django_logic/commands.py
@@ -40,8 +40,7 @@ class SideEffects(BaseCommand):
             for command in self.commands:
                 command(instance, **kwargs)
         except Exception:
-            # TODO: handle exception
-            self.transition.fail_transition(instance, field_name)
+            self.transition.fail_transition(instance, field_name, **kwargs)
         else:
             self.transition.complete_transition(instance, field_name, **kwargs)
 

--- a/django_logic/tasks.py
+++ b/django_logic/tasks.py
@@ -20,8 +20,9 @@ else:
         model = app.get_model(kwargs['model_name'])
         instance = model.objects.get(id=kwargs['instance_id'])
         transition = kwargs['transition']
+        field_name = kwargs.pop('field_name')
 
-        transition.complete_transition(instance, kwargs['field_name'])
+        transition.complete_transition(instance, field_name, **kwargs)
 
 
     @shared_task(acks_late=True)
@@ -38,7 +39,8 @@ else:
             app = apps.get_app_config(kwargs['app_label'])
             model = app.get_model(kwargs['model_name'])
             instance = model.objects.get(id=kwargs['instance_id'])
-            transition.fail_transition(instance, kwargs['field_name'])
+            field_name = kwargs.pop('field_name')
+            transition.fail_transition(instance, field_name, **kwargs)
         except Exception:
             # TODO: add logger
             print('Exception')

--- a/django_logic/transition.py
+++ b/django_logic/transition.py
@@ -15,6 +15,7 @@ class Transition(object):
     """
     side_effects = SideEffects()
     callbacks = Callbacks()
+    failure_callbacks = Callbacks()
     permissions = Permissions()
     conditions = Conditions()
     state = State()
@@ -25,7 +26,7 @@ class Transition(object):
         self.sources = sources
         self.in_progress_state = kwargs.get('in_progress_state')
         self.failed_state = kwargs.get('failed_state')
-        self.failure_handler = kwargs.get('failure_handler')
+        self.failure_callbacks = kwargs.get('failure_callbacks', [])
         self.side_effects = kwargs.get('side_effects', [])
         self.callbacks = kwargs.get('callbacks', [])
         self.permissions = kwargs.get('permissions', [])
@@ -76,7 +77,7 @@ class Transition(object):
         self.state.unlock(instance, field_name)
         self.callbacks.execute(instance, field_name, **kwargs)
     
-    def fail_transition(self, instance, field_name):
+    def fail_transition(self, instance, field_name, **kwargs):
         """
         It triggers fail transition in case of any failure during the side effects execution.
         :param instance: any
@@ -85,3 +86,4 @@ class Transition(object):
         if self.failed_state:
             self.state.set_state(instance, field_name, self.failed_state)
         self.state.unlock(instance, field_name)
+        self.failure_callbacks.execute(instance, field_name, **kwargs)


### PR DESCRIPTION
Implements failure callbacks
- Defined via `failure_callbacks` attribute
- Uses already existing `Callbacks` class, since it already does what is needed
- This allows to define different execution methods as well (synchronous/celery/etc)
- In case of synchronous handlers, any arguments passed to transitions get passed to failure callbacks too, as with regular callbacks