### PR TITLE
#31 Fix permissions bug

### DIFF
--- a/django_logic/commands.py
+++ b/django_logic/commands.py
@@ -16,12 +16,24 @@ class BaseCommand(object):
 
 class Conditions(BaseCommand):
     def execute(self, instance: any, **kwargs):
+        """
+        It checks every condition for the provided instance by executing every command
+        :param instance: any
+        :return: True or False
+        """
         return all(command(instance, **kwargs) for command in self._commands)
 
 
 class Permissions(BaseCommand):
     def execute(self, instance: any, user: any, **kwargs):
-        return all(command(instance,  user, **kwargs) for command in self._commands)
+        """
+        It checks the permissions for the provided user and instance by executing evey command
+        If user is None then permissions passed
+        :param instance: any
+        :param user: any or None
+        :return: True or False
+        """
+        return user is None or all(command(instance,  user, **kwargs) for command in self._commands)
 
 
 class SideEffects(BaseCommand):

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -48,7 +48,7 @@ class ValidateProcessTestCase(TestCase):
         class MyProcess(Process):
             permissions = [allow]
 
-        self.assertFalse(MyProcess('state').validate())
+        self.assertTrue(MyProcess('state').validate())
         self.assertTrue(MyProcess('state').validate(self.user))
 
     def test_permission_fail(self):
@@ -58,14 +58,14 @@ class ValidateProcessTestCase(TestCase):
             permissions = [allow]
 
         process = MyProcess(field_name='status', instance=Invoice(status='draft'))
-        self.assertFalse(process.validate())
+        self.assertTrue(process.validate())
         self.assertFalse(process.validate(self.user))
 
         class AnotherProcess(Process):
             permissions = [allow, disallow]
 
         process = AnotherProcess(field_name='status', instance=Invoice(status='draft'))
-        self.assertFalse(process.validate())
+        self.assertTrue(process.validate())
         self.assertFalse(process.validate(self.user))
 
     def test_empty_conditions(self):
@@ -107,7 +107,7 @@ class ValidateProcessTestCase(TestCase):
             conditions = [is_editable]
 
         process = MyProcess(field_name='status', instance=Invoice(status='draft'))
-        self.assertFalse(process.validate())
+        self.assertTrue(process.validate())
         self.assertTrue(process.validate(self.user))
 
     def test_permissions_and_conditions_fail(self):
@@ -116,7 +116,7 @@ class ValidateProcessTestCase(TestCase):
             conditions = [is_editable]
 
         process = MyProcess(field_name='status', instance=Invoice(status='draft'))
-        self.assertFalse(process.validate())
+        self.assertTrue(process.validate())
         self.assertFalse(process.validate(self.user))
 
         class AnotherProcess(Process):


### PR DESCRIPTION
It skips permissions if a user is None. Useful for internal use only. 