### PR TITLE
Update binding process

### DIFF
--- a/demo/choices.py
+++ b/demo/choices.py
@@ -1,8 +1,0 @@
-from model_utils import Choices
-
-
-LOCK_STATES = Choices(
-    ('maintenance', 'Under maintenance'),
-    ('locked', 'Locked'),
-    ('open', 'Open'),
-)

--- a/demo/choices.py
+++ b/demo/choices.py
@@ -1,0 +1,8 @@
+from model_utils import Choices
+
+
+LOCK_STATES = Choices(
+    ('maintenance', 'Under maintenance'),
+    ('locked', 'Locked'),
+    ('open', 'Open'),
+)

--- a/demo/models.py
+++ b/demo/models.py
@@ -1,6 +1,12 @@
 from django.db import models
+from model_utils import Choices
 
-from demo.choices import LOCK_STATES
+
+LOCK_STATES = Choices(
+    ('maintenance', 'Under maintenance'),
+    ('locked', 'Locked'),
+    ('open', 'Open'),
+)
 
 
 class Lock( models.Model):

--- a/demo/models.py
+++ b/demo/models.py
@@ -1,10 +1,10 @@
 from django.db import models
-from demo.process import LockerProcess
-from django_logic.process import ProcessManager
+
+from demo.choices import LOCK_STATES
 
 
-class Lock(ProcessManager.bind_state_fields(status=LockerProcess), models.Model):
-    status = models.CharField(choices=LockerProcess.states, default=LockerProcess.states.open, max_length=16, blank=True)
+class Lock( models.Model):
+    status = models.CharField(choices=LOCK_STATES, default=LOCK_STATES.open, max_length=16, blank=True)
     customer_received_notice = models.BooleanField(default=False)
     is_available = models.BooleanField(default=True)
 

--- a/demo/process.py
+++ b/demo/process.py
@@ -1,13 +1,7 @@
-from model_utils import Choices
-
+from demo.choices import LOCK_STATES
 from demo.conditions import is_user, is_staff, is_planned, is_lock_available
-from django_logic import Process, Transition, Action
-
-LOCK_STATES = Choices(
-    ('maintenance', 'Under maintenance'),
-    ('locked', 'Locked'),
-    ('open', 'Open'),
-)
+from demo.models import Lock
+from django_logic import Process, Transition, Action, ProcessManager
 
 
 class UserLockerProcess(Process):
@@ -63,3 +57,6 @@ class LockerProcess(Process):
         StaffLockerProcess,
         UserLockerProcess,
     ]
+
+
+ProcessManager.bind_model_process(Lock, LockerProcess, 'status')

--- a/demo/process.py
+++ b/demo/process.py
@@ -1,6 +1,5 @@
-from demo.choices import LOCK_STATES
 from demo.conditions import is_user, is_staff, is_planned, is_lock_available
-from demo.models import Lock
+from demo.models import Lock, LOCK_STATES
 from django_logic import Process, Transition, Action, ProcessManager
 
 

--- a/django_logic/process.py
+++ b/django_logic/process.py
@@ -1,4 +1,5 @@
 import logging
+import warnings
 from functools import partial
 
 from django_logic.commands import Conditions, Permissions
@@ -119,7 +120,20 @@ class Process(object):
 
 class ProcessManager:
     @classmethod
+    def bind_model_process(cls, model, process_class, state_field: str = 'state') -> None:
+        def make_process_getter(field_name, field_class):
+            return lambda self: field_class(field_name=field_name, instance=self)
+
+        setattr(model, process_class.process_name, property(make_process_getter(state_field, process_class)))
+
+    @classmethod
     def bind_state_fields(cls, **kwargs):
+        warnings.warn(
+            "bind_state_fields is deprecated and will be removed in future versions. "
+            "Use bind_model_process instead",
+            DeprecationWarning
+        )
+
         def make_process_getter(field_name, field_class):
             return lambda self: field_class(field_name=field_name, instance=self)
 


### PR DESCRIPTION
To avoid cyclical import errors we need to move binding process out of models file. 

* Added ProcessManager.bind_model_process method
* Deprecated old ProcessManager.bind_state_fields method
* Updated readme