### PR TITLE
Remove LogType commas and fix empty string comparison

### DIFF
--- a/django_logic/constants.py
+++ b/django_logic/constants.py
@@ -2,8 +2,8 @@ from enum import Enum
 
 
 class LogType(Enum):
-    TRANSITION_DEBUG = 'transition_debug',
-    TRANSITION_ERROR = 'transition_error',
+    TRANSITION_DEBUG = 'transition_debug'
+    TRANSITION_ERROR = 'transition_error'
     TRANSITION_IN_PROGRESS = 'transition_in_progress'
     TRANSITION_COMPLETED = 'transition_completed'
     TRANSITION_FAILED = 'transition_failed'

--- a/django_logic/process.py
+++ b/django_logic/process.py
@@ -36,7 +36,7 @@ class Process(object):
         """
         self.field_name = field_name
         self.instance = instance
-        if field_name is '' or instance is None:
+        if field_name == '' or instance is None:
             assert state is not None
             self.state = state
         elif state is None:


### PR DESCRIPTION
Typos fixes:

* removed LogType commas
* fixed empty string comparison