### PR TITLE
feat(testing): scenario-based testing framework (django_logic.testing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Django Logic is a lightweight workflow framework for Django that makes it easy t
 - [Complete Example](#complete-example)
 - [Django-Logic vs Django FSM](#django-logic-vs-django-fsm)
 - [Background Transitions](#background-transitions)
+- [Testing Your Processes](#testing-your-processes)
 - [Contributing](#contributing)
 - [License](#license)
 
@@ -26,6 +27,7 @@ Django Logic is a lightweight workflow framework for Django that makes it easy t
 - 🏗️ **Nested Processes** - Build complex workflows with sub-processes
 - ⚡ **Built-in Locking** - Cache/Redis-based locking to prevent race conditions
 - ⏳ **Durable Background Transitions** - Queue-routed, retryable side-effects via Celery (see [Background Transitions](#background-transitions))
+- 🧪 **Scenario-Based Testing** - Test whole workflows — including background jobs, failures, and retries — as ordinary unit tests via `django_logic.testing`, no Celery needed (see [Testing Your Processes](#testing-your-processes))
 - 🔍 **Structured Logging** - State changes flow through the standard `django-logic` / `django-logic.transition` Python loggers, configured via Django `LOGGING` (see [docs/logger.md](docs/logger.md))
 
 ## Requirements
@@ -835,6 +837,99 @@ SELECT count(*) FROM django_logic_background_transitionmessage
 Also alert on beat liveness — if beat stops, the safety net stops.
 
 **Migrating an existing deployment.** Migration `0005` widens `instance_id` from integer to `varchar(255)` via `ALTER COLUMN ... TYPE` (Django emits the `USING ...::varchar` cast, so existing integer rows convert in place). On a very large `TransitionMessage` table this rewrites the column under a lock — run it in a maintenance window or with your usual online-migration tooling.
+
+## Testing Your Processes
+
+FSM workflows are notoriously hard to test well — state transitions,
+conditions, permissions, side-effects, background jobs, failures, retries, and
+locking all interact. `django_logic.testing` gives you a **scenario-based** test
+base class that reads like the business process itself and runs everything —
+including background transitions — **inline, with no Celery broker**.
+
+```python
+from django_logic.testing import ProcessScenario
+
+
+class TestOrderFulfilment(ProcessScenario):
+    """Order lifecycle: draft -> approved -> fulfilling -> fulfilled."""
+    process_class = OrderProcess
+    model = Order
+    state_field = 'status'      # default: 'status'
+    process_name = 'process'    # default: 'process'
+
+    def test_happy_path(self):
+        order = self.create_instance(status='approved')
+        self.assert_available(order, ['fulfil', 'cancel'])
+
+        self.background_transition(order, 'fulfil')      # phase 1 + phase 2, no Celery
+        self.assert_state(order, 'fulfilled')
+        self.assert_side_effects_ran(['reserve_stock', 'call_courier'])
+        self.assert_callbacks_ran(['send_confirmation_email'])
+
+    def test_courier_failure_then_retry(self):
+        order = self.create_instance(status='approved')
+
+        # Make ONE named side-effect raise — the real failure path runs.
+        self.background_transition(
+            order, 'fulfil',
+            fail_side_effect='call_courier',
+            fail_with=ConnectionError('Aramex timeout'))
+
+        self.assert_state(order, 'fulfilling')           # left in-progress
+        self.assert_error_recorded(order, 'Aramex timeout')
+        self.assert_error_count(order, 1)
+        self.assert_side_effects_not_ran(['call_courier'])
+
+        self.retry_transition(order)                      # what the starter would do
+        self.assert_state(order, 'fulfilled')
+
+    def test_only_staff_can_approve(self):
+        order = self.create_instance(status='draft')
+        self.assert_available(order, ['approve'], user=self.staff)
+        self.assert_not_available(order, ['approve'], user=self.customer)
+```
+
+**Driving the process**
+
+| Method | What it does |
+|--------|--------------|
+| `create_instance(**fields)` | Create a model instance (state via the `state_field` kwarg) |
+| `transition(obj, action, **kwargs)` | Run a synchronous transition |
+| `background_transition(obj, action, **kwargs)` | Run a `BackgroundTransition`/`BackgroundAction` phase 1 **and** phase 2 inline |
+| `retry_transition(obj)` | Re-run the instance's uncompleted transition — simulates the periodic starter |
+
+Add `fail_side_effect='name'`, `fail_with=SomeError(...)` to `background_transition`/`retry_transition`/`transition` to make a named side-effect raise. Only that side-effect is wrapped — every other one runs for real, so you exercise the true failure path. The injected exception is absorbed so you can assert on the recorded error.
+
+**Assertions**
+
+`assert_state` · `assert_available` / `assert_not_available` (optional `user=`) · `assert_side_effects_ran` / `assert_side_effects_not_ran` · `assert_callbacks_ran` · `assert_error_recorded` · `assert_error_count`.
+
+Side-effects and callbacks are **tracked, not mocked** (identified by function `__name__`) — the real code runs; the framework just records what executed.
+
+**Snapshot & replay — turn a production bug into a test**
+
+```python
+from django_logic.testing import snapshot, from_snapshot
+
+data = snapshot(order)          # JSON-able: fields, state, TransitionMessage, process status
+```
+
+Capture it from a Django shell, admin action, Sentry, or a log, then reproduce:
+
+```python
+class TestStuckOrder(ProcessScenario):
+    process_class, model, state_field = OrderProcess, Order, 'status'
+
+    def test_reproduce_and_fix(self):
+        order = self.from_snapshot('fixtures/bug_12345.json')  # rebuilds instance + TransitionMessage
+        self.assert_state(order, 'fulfilling')
+        self.retry_transition(order)        # prove the fix
+        self.assert_state(order, 'fulfilled')
+```
+
+**AI-readable failure output.** When an assertion fails, the error includes a numbered timeline of every step, the relevant `TransitionMessage`, and (with `snapshot_on_failure = True` on the class) a reproducible snapshot — so a person or an AI agent can see exactly where the process diverged without reading stack traces.
+
+`ProcessScenario` extends `TransactionTestCase`, so it works with the durable `TransitionMessage` + atomic-block machinery. Full design: [docs/design/TESTING_SCENARIOS.md](docs/design/TESTING_SCENARIOS.md).
 
 ## Contributing
 Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.

--- a/django_logic/testing/__init__.py
+++ b/django_logic/testing/__init__.py
@@ -1,0 +1,34 @@
+"""Scenario-based testing for Django Logic processes.
+
+Test FSM workflows the way they read in a business document — state
+transitions, conditions, permissions, side-effects, background jobs, failures
+and retries — as ordinary unit tests, **without a Celery broker**.
+
+    from django_logic.testing import ProcessScenario
+
+    class TestOrders(ProcessScenario):
+        process_class = OrderProcess
+        model = Order
+        state_field = 'status'
+
+        def test_happy_path(self):
+            order = self.create_instance(status='approved')
+            self.background_transition(order, 'fulfil')
+            self.assert_state(order, 'fulfilled')
+
+``snapshot()`` / ``from_snapshot()`` capture a production instance's state as
+JSON and rebuild it in a test, turning a production bug into a regression test.
+
+See ``docs/design/TESTING_SCENARIOS.md`` for the full design.
+"""
+from django_logic.testing.scenario import ProcessScenario
+from django_logic.testing.snapshot import from_snapshot, snapshot, to_json
+from django_logic.testing.tracking import ExecutionTracker
+
+__all__ = [
+    'ProcessScenario',
+    'snapshot',
+    'from_snapshot',
+    'to_json',
+    'ExecutionTracker',
+]

--- a/django_logic/testing/assertions.py
+++ b/django_logic/testing/assertions.py
@@ -1,0 +1,123 @@
+"""Business-level assertions for :class:`ProcessScenario`.
+
+Each assertion reads from the DB / the last tracked transition and, on failure,
+raises with the AI-readable timeline (and optionally a snapshot) attached.
+Mixed into ``ProcessScenario``; relies on the host providing ``state_field``,
+``process_name``, ``_timeline``, ``_last_tracker``, ``_fail`` and ``_process``.
+"""
+from __future__ import annotations
+
+from django_logic.testing.runner import latest_message
+
+
+class ScenarioAssertions:
+    # --- state -----------------------------------------------------------
+
+    def assert_state(self, instance, expected):
+        instance.refresh_from_db()
+        actual = getattr(instance, self.state_field)
+        if actual != expected:
+            try:
+                avail = self._process(instance).get_available_actions()
+            except Exception:
+                avail = '(unknown)'
+            self._record_assert(f"assert_state({expected!r})", ok=False)
+            self._fail(
+                f'Expected state {expected!r}, but {self.state_field}={actual!r}.\n'
+                f'  Available actions from {actual!r}: {avail}',
+                instance=instance,
+            )
+        self._record_assert(f"assert_state({expected!r})", ok=True,
+                            detail=f'{self.state_field}={actual!r}')
+
+    # --- availability ----------------------------------------------------
+
+    def _available(self, instance, user=None):
+        return self._process(instance).get_available_actions(user=user)
+
+    def assert_available(self, instance, actions, user=None):
+        avail = self._available(instance, user=user)
+        missing = [a for a in actions if a not in avail]
+        if missing:
+            self._record_assert(f'assert_available({actions})', ok=False)
+            self._fail(
+                f'Expected actions {missing} to be available'
+                f'{" for user" if user is not None else ""}, '
+                f'but available actions are {sorted(avail)}.',
+                instance=instance,
+            )
+        self._record_assert(f'assert_available({actions})', ok=True)
+
+    def assert_not_available(self, instance, actions, user=None):
+        avail = self._available(instance, user=user)
+        present = [a for a in actions if a in avail]
+        if present:
+            self._record_assert(f'assert_not_available({actions})', ok=False)
+            self._fail(
+                f'Expected actions {present} to be UNavailable'
+                f'{" for user" if user is not None else ""}, '
+                f'but they are available (all available: {sorted(avail)}).',
+                instance=instance,
+            )
+        self._record_assert(f'assert_not_available({actions})', ok=True)
+
+    # --- side-effect / callback tracking ---------------------------------
+
+    def _tracker(self):
+        if self._last_tracker is None:
+            self.fail('No tracked transition yet — call transition() / '
+                      'background_transition() before asserting side effects.')
+        return self._last_tracker
+
+    def assert_side_effects_ran(self, names):
+        ran = self._tracker().side_effects_ran
+        missing = [n for n in names if n not in ran]
+        if missing:
+            self._record_assert(f'assert_side_effects_ran({names})', ok=False)
+            self._fail(f'Expected side-effects {missing} to have run; '
+                       f'side-effects that ran: {ran}.')
+        self._record_assert(f'assert_side_effects_ran({names})', ok=True)
+
+    def assert_side_effects_not_ran(self, names):
+        ran = self._tracker().side_effects_ran
+        present = [n for n in names if n in ran]
+        if present:
+            self._record_assert(f'assert_side_effects_not_ran({names})', ok=False)
+            self._fail(f'Expected side-effects {present} NOT to have run; '
+                       f'side-effects that ran: {ran}.')
+        self._record_assert(f'assert_side_effects_not_ran({names})', ok=True)
+
+    def assert_callbacks_ran(self, names):
+        ran = self._tracker().callbacks_ran
+        missing = [n for n in names if n not in ran]
+        if missing:
+            self._record_assert(f'assert_callbacks_ran({names})', ok=False)
+            self._fail(f'Expected callbacks {missing} to have run; '
+                       f'callbacks that ran: {ran}.')
+        self._record_assert(f'assert_callbacks_ran({names})', ok=True)
+
+    # --- background error state ------------------------------------------
+
+    def assert_error_recorded(self, instance, contains):
+        tm = latest_message(instance)
+        if tm is None or contains not in (tm.last_error_message or ''):
+            self._record_assert(f'assert_error_recorded({contains!r})', ok=False)
+            self._fail(
+                f'Expected a recorded error containing {contains!r}, but '
+                + ('no TransitionMessage exists for this instance.'
+                   if tm is None else f'last_error={tm.last_error_message!r}.'),
+                instance=instance,
+            )
+        self._record_assert(f'assert_error_recorded({contains!r})', ok=True)
+
+    def assert_error_count(self, instance, expected):
+        tm = latest_message(instance)
+        actual = None if tm is None else tm.errors_count
+        if actual != expected:
+            self._record_assert(f'assert_error_count({expected})', ok=False)
+            self._fail(
+                f'Expected errors_count={expected}, but '
+                + ('no TransitionMessage exists.' if tm is None else f'got {actual}.'),
+                instance=instance,
+            )
+        self._record_assert(f'assert_error_count({expected})', ok=True)

--- a/django_logic/testing/output.py
+++ b/django_logic/testing/output.py
@@ -1,0 +1,51 @@
+"""AI-readable failure output.
+
+Formats a scenario's recorded timeline (plus the relevant TransitionMessage and,
+optionally, a reproducible snapshot) into a structured block that a human — or
+an AI agent — can read to see exactly where the process diverged, without
+parsing stack traces or Django internals.
+"""
+from __future__ import annotations
+
+import json
+
+
+def format_timeline(entries: list[dict]) -> str:
+    if not entries:
+        return '  Timeline: (empty)'
+    lines = ['  Timeline:']
+    width = max(len(e.get('label', '')) for e in entries)
+    for i, e in enumerate(entries, 1):
+        label = e.get('label', '').ljust(width)
+        outcome = e.get('outcome', '')
+        detail = e.get('detail', '')
+        line = f'    [{i}] {label}  -> {outcome}'
+        if detail:
+            line += f'  {detail}'
+        lines.append(line)
+    return '\n'.join(lines)
+
+
+def format_tm(tm) -> str:
+    if tm is None:
+        return ''
+    return (
+        '\n  TransitionMessage:\n'
+        f'    transition: {tm.transition_name}\n'
+        f'    is_completed: {tm.is_completed}\n'
+        f'    errors_count: {tm.errors_count}\n'
+        f'    last_error: {tm.last_error_message or "(none)"}'
+    )
+
+
+def format_failure(message: str, timeline: list[dict], *, tm=None, snapshot=None) -> str:
+    parts = [message, '', format_timeline(timeline)]
+    tm_block = format_tm(tm)
+    if tm_block:
+        parts.append(tm_block)
+    if snapshot is not None:
+        parts.append(
+            '\n  Snapshot (copy to reproduce with from_snapshot()):\n    '
+            + json.dumps(snapshot, default=str)
+        )
+    return '\n'.join(parts)

--- a/django_logic/testing/runner.py
+++ b/django_logic/testing/runner.py
@@ -1,0 +1,83 @@
+"""Synchronous execution helpers — run background transitions and their
+retries inline, without Celery.
+
+Built on the library's own ``sync_execution()`` context manager (which forces
+phase 2 to run in-process) so tests exercise the *real* phase-1 + phase-2 code,
+not a reimplementation.
+"""
+from __future__ import annotations
+
+
+def transitions_for(process_class, action_name) -> list:
+    """All class-level ``Transition`` objects named ``action_name`` reachable
+    from ``process_class`` (including nested processes). Usually one."""
+    found = []
+    seen = set()
+
+    def walk(cls):
+        if id(cls) in seen:
+            return
+        seen.add(id(cls))
+        for t in getattr(cls, 'transitions', None) or []:
+            if t.action_name == action_name:
+                found.append(t)
+        for sub in getattr(cls, 'nested_processes', None) or []:
+            walk(sub)
+
+    walk(process_class)
+    return found
+
+
+def run_sync(instance, process_name, action_name, kwargs):
+    """Drive a (synchronous) transition through the normal process entrypoint."""
+    process = getattr(instance, process_name)
+    return getattr(process, action_name)(**kwargs)
+
+
+def run_background_sync(instance, process_name, action_name, kwargs):
+    """Run a BackgroundTransition's phase 1 + phase 2 inline (no broker)."""
+    from django_logic.background import sync_execution
+    with sync_execution():
+        process = getattr(instance, process_name)
+        return getattr(process, action_name)(**kwargs)
+
+
+def uncompleted_message(instance):
+    """The instance's uncompleted ``TransitionMessage`` (what the periodic
+    starter would re-dispatch), or ``None``."""
+    from django_logic.background.models import TransitionMessage
+    return (
+        TransitionMessage.objects
+        .filter(
+            app_label=instance._meta.app_label,
+            model_name=instance._meta.model_name,
+            instance_id=str(instance.pk),
+            is_completed=False,
+        )
+        .order_by('-id')
+        .first()
+    )
+
+
+def latest_message(instance):
+    """The instance's most recent ``TransitionMessage`` (completed or not)."""
+    from django_logic.background.models import TransitionMessage
+    return (
+        TransitionMessage.objects
+        .filter(
+            app_label=instance._meta.app_label,
+            model_name=instance._meta.model_name,
+            instance_id=str(instance.pk),
+        )
+        .order_by('-id')
+        .first()
+    )
+
+
+def rerun_message(message_id):
+    """Re-run a specific TransitionMessage inline — what the periodic starter
+    does, but synchronous and immediate (ignores the recency guard)."""
+    from django_logic.background import sync_execution
+    from django_logic.background.runner import run_background_transition
+    with sync_execution():
+        run_background_transition(message_id)

--- a/django_logic/testing/scenario.py
+++ b/django_logic/testing/scenario.py
@@ -1,0 +1,186 @@
+"""``ProcessScenario`` — write FSM tests that read like a business story.
+
+Subclass it, point it at your Process + model, and drive the workflow with
+``transition`` / ``background_transition`` / ``retry_transition``, asserting
+behaviour (state, availability, side-effects, recorded errors) instead of
+poking framework internals. Background transitions run **inline, without
+Celery**. On failure you get an AI-readable timeline (and, opt-in, a
+reproducible snapshot).
+
+    class TestOrderFulfilment(ProcessScenario):
+        process_class = OrderProcess
+        model = Order
+        state_field = 'status'
+
+        def test_happy_path(self):
+            order = self.create_instance(status='approved')
+            self.background_transition(order, 'fulfil')
+            self.assert_state(order, 'fulfilled')
+            self.assert_side_effects_ran(['reserve_stock', 'call_courier'])
+"""
+from __future__ import annotations
+
+from django.test import TransactionTestCase
+
+from django_logic.testing.assertions import ScenarioAssertions
+from django_logic.testing.output import format_failure
+from django_logic.testing.runner import (
+    rerun_message,
+    run_background_sync,
+    transitions_for,
+    uncompleted_message,
+)
+from django_logic.testing.runner import latest_message
+from django_logic.testing.snapshot import from_snapshot as _from_snapshot
+from django_logic.testing.snapshot import snapshot as _snapshot
+from django_logic.testing.tracking import track
+
+
+class ProcessScenario(ScenarioAssertions, TransactionTestCase):
+    """Base class for scenario-based Process tests (no Celery required)."""
+
+    process_class = None        # type[Process]
+    model = None                # type[Model]
+    state_field = 'status'
+    process_name = 'process'
+    snapshot_on_failure = False
+
+    def setUp(self):
+        super().setUp()
+        self._timeline: list[dict] = []
+        self._last_tracker = None
+
+    # --- internals -------------------------------------------------------
+
+    def _process(self, instance):
+        return getattr(instance, self.process_name)
+
+    def _record(self, label, outcome, detail=''):
+        self._timeline.append({'label': label, 'outcome': outcome, 'detail': detail})
+
+    def _record_assert(self, label, ok, detail=''):
+        self._record(label, 'OK' if ok else 'FAILED', detail)
+
+    def _snapshot_if_enabled(self, instance):
+        if not self.snapshot_on_failure or instance is None:
+            return None
+        try:
+            return _snapshot(instance, state_field=self.state_field,
+                             process_name=self.process_name)
+        except Exception:
+            return None
+
+    def _fail(self, message, instance=None):
+        tm = latest_message(instance) if instance is not None else None
+        self.fail(format_failure(message, self._timeline, tm=tm,
+                                 snapshot=self._snapshot_if_enabled(instance)))
+
+    def _state(self, instance):
+        return getattr(instance, self.state_field)
+
+    # --- instance creation ----------------------------------------------
+
+    def create_instance(self, **kwargs):
+        """Create a model instance (state via the ``state_field`` kwarg).
+        Override for factories / related setup."""
+        instance = self.model.objects.create(**kwargs)
+        self._record('create_instance', 'OK',
+                     f'{self.model.__name__}(pk={instance.pk}, '
+                     f'{self.state_field}={self._state(instance)!r})')
+        return instance
+
+    def from_snapshot(self, data_or_path):
+        """Rebuild an instance (and its TransitionMessage) from a snapshot."""
+        instance = _from_snapshot(data_or_path, model=self.model)
+        self._record('from_snapshot', 'OK',
+                     f'{self.model.__name__}(pk={instance.pk}, '
+                     f'{self.state_field}={self._state(instance)!r})')
+        return instance
+
+    def snapshot(self, instance):
+        return _snapshot(instance, state_field=self.state_field,
+                         process_name=self.process_name)
+
+    # --- driving the process --------------------------------------------
+
+    def transition(self, instance, action, *, fail_side_effect=None,
+                   fail_with=None, **kwargs):
+        """Run a synchronous transition through the normal process entrypoint."""
+        return self._drive(instance, action, background=False,
+                           fail_side_effect=fail_side_effect, fail_with=fail_with,
+                           kwargs=kwargs)
+
+    def background_transition(self, instance, action, *, fail_side_effect=None,
+                             fail_with=None, **kwargs):
+        """Run a BackgroundTransition's phase 1 + phase 2 inline (no Celery).
+
+        ``fail_side_effect`` / ``fail_with`` make the named side-effect raise,
+        exercising the real failure path; the injected exception is absorbed so
+        you can assert on the recorded error."""
+        return self._drive(instance, action, background=True,
+                           fail_side_effect=fail_side_effect, fail_with=fail_with,
+                           kwargs=kwargs)
+
+    def retry_transition(self, instance, *, fail_side_effect=None, fail_with=None):
+        """Re-run the instance's uncompleted transition inline — what the
+        periodic starter would do."""
+        tm = uncompleted_message(instance)
+        if tm is None:
+            self._record('retry_transition', 'FAILED', 'no uncompleted TransitionMessage')
+            self._fail('retry_transition(): no uncompleted TransitionMessage for '
+                       'this instance — nothing to retry.', instance=instance)
+        transitions = transitions_for(self.process_class, tm.transition_name)
+        before = self._state(instance)
+        with track(transitions, fail_side_effect=fail_side_effect,
+                   fail_with=fail_with) as tracker:
+            raised = self._call(lambda: rerun_message(tm.pk))
+        self._finish('retry_transition', instance, tracker, raised, before)
+        return instance
+
+    # --- shared execution path ------------------------------------------
+
+    def _drive(self, instance, action, *, background, fail_side_effect, fail_with, kwargs):
+        transitions = transitions_for(self.process_class, action)
+        if not transitions:
+            self._record(f'{"background_" if background else ""}transition({action!r})',
+                         'FAILED', 'no such transition')
+            self._fail(f'No transition named {action!r} on '
+                       f'{self.process_class.__name__} (or its nested processes).',
+                       instance=instance)
+        before = self._state(instance)
+        with track(transitions, fail_side_effect=fail_side_effect,
+                   fail_with=fail_with) as tracker:
+            if background:
+                raised = self._call(
+                    lambda: run_background_sync(instance, self.process_name, action, kwargs))
+            else:
+                raised = self._call(
+                    lambda: getattr(self._process(instance), action)(**kwargs))
+        label = f'{"background_" if background else ""}transition({action!r})'
+        self._finish(label, instance, tracker, raised, before)
+        return instance
+
+    @staticmethod
+    def _call(fn):
+        try:
+            fn()
+            return None
+        except Exception as exc:  # noqa: BLE001 — re-raised below unless injected
+            return exc
+
+    def _finish(self, label, instance, tracker, raised, before):
+        self._last_tracker = tracker
+        instance.refresh_from_db()
+        after = self._state(instance)
+        detail = f'{self.state_field}: {before} -> {after}'
+        if tracker.side_effects_ran:
+            detail += f'; ran={tracker.side_effects_ran}'
+        if tracker.failed_side_effect:
+            detail += f'; failed={tracker.failed_side_effect}'
+        # An exception is expected only when it's the one we injected; anything
+        # else is a real, unexpected failure and fails the test loudly.
+        if raised is not None and raised is not tracker.injected_exception:
+            self._record(label, 'FAILED', f'{type(raised).__name__}: {raised}')
+            self._fail(f'{label} raised unexpectedly: '
+                       f'{type(raised).__name__}: {raised}', instance=instance)
+        self._record(label, 'OK' if raised is None else 'FAILED(injected)', detail)

--- a/django_logic/testing/snapshot.py
+++ b/django_logic/testing/snapshot.py
@@ -1,0 +1,133 @@
+"""State capture & restore — close the loop between production bugs and tests.
+
+``snapshot(instance)`` serialises an instance (its concrete fields, current
+state, the related ``TransitionMessage`` if any, and process status) to a plain
+JSON-able dict. ``from_snapshot(data)`` rebuilds that instance — and restores
+the ``TransitionMessage`` — so a production bug can be reproduced in a test and
+kept as a regression guard.
+
+Scope: own concrete fields + the TransitionMessage are captured and restored.
+Arbitrary related graphs are not auto-created — pass them through the optional
+``related`` key yourself, or build them in the test, when a repro needs them.
+"""
+from __future__ import annotations
+
+import datetime
+import decimal
+import json
+import uuid
+
+
+def _jsonable(value):
+    if isinstance(value, (datetime.datetime, datetime.date, datetime.time)):
+        return value.isoformat()
+    if isinstance(value, decimal.Decimal):
+        return str(value)
+    if isinstance(value, uuid.UUID):
+        return str(value)
+    if isinstance(value, (str, int, float, bool, type(None))):
+        return value
+    return str(value)
+
+
+def snapshot(instance, *, state_field: str = 'status', process_name: str = 'process') -> dict:
+    """Capture the full reproducible state of ``instance`` as a JSON-able dict."""
+    fields = {}
+    for field in instance._meta.concrete_fields:
+        fields[field.attname] = _jsonable(field.value_from_object(instance))
+
+    data = {
+        'model': instance._meta.label,                       # "app.Model"
+        'pk': _jsonable(instance.pk),
+        'state_field': state_field,
+        'state': getattr(instance, state_field, None),
+        'fields': fields,
+    }
+
+    # The most recent TransitionMessage for this instance (if the background
+    # app is installed and a row exists).
+    try:
+        from django_logic.testing.runner import latest_message
+        tm = latest_message(instance)
+        if tm is not None:
+            data['transition_message'] = {
+                'transition_name': tm.transition_name,
+                'process_name': tm.process_name,
+                'queue_name': tm.queue_name,
+                'is_completed': tm.is_completed,
+                'errors_count': tm.errors_count,
+                'last_error_message': tm.last_error_message,
+                'timeout_seconds': tm.timeout_seconds,
+                'kwargs': tm.kwargs,
+            }
+    except Exception:
+        pass
+
+    # Best-effort process status.
+    try:
+        process = getattr(instance, process_name)
+        data['process'] = {
+            'class': f'{type(process).__module__}.{type(process).__name__}',
+            'available_actions': process.get_available_actions(),
+            'is_locked': process.state.is_locked(),
+        }
+    except Exception:
+        pass
+
+    return data
+
+
+def to_json(instance, **kwargs) -> str:
+    """``snapshot()`` rendered as an indented JSON string (for logs/Sentry)."""
+    return json.dumps(snapshot(instance, **kwargs), indent=2, default=str)
+
+
+def _load(data_or_path):
+    if isinstance(data_or_path, dict):
+        return data_or_path
+    with open(data_or_path) as fh:
+        return json.load(fh)
+
+
+def from_snapshot(data_or_path, *, model=None):
+    """Rebuild an instance (and its TransitionMessage, if captured) from a
+    snapshot. Returns the saved instance."""
+    data = _load(data_or_path)
+
+    if model is None:
+        from django.apps import apps
+        model = apps.get_model(data['model'])
+
+    instance = model()
+    for attname, value in (data.get('fields') or {}).items():
+        try:
+            setattr(instance, attname, value)
+        except Exception:
+            pass
+    # Ensure the state field reflects the snapshot even if it wasn't a concrete
+    # field name match.
+    state_field = data.get('state_field', 'status')
+    if 'state' in data and data['state'] is not None:
+        setattr(instance, state_field, data['state'])
+    if data.get('pk') is not None:
+        instance.pk = data['pk']
+    instance.save(force_insert=True)
+
+    tm_data = data.get('transition_message')
+    if tm_data:
+        from django_logic.background.models import TransitionMessage
+        TransitionMessage.objects.create(
+            app_label=instance._meta.app_label,
+            model_name=instance._meta.model_name,
+            instance_id=str(instance.pk),
+            process_name=tm_data.get('process_name', 'process'),
+            transition_name=tm_data['transition_name'],
+            queue_name=tm_data.get('queue_name', 'django_logic.critical'),
+            is_completed=tm_data.get('is_completed', False),
+            errors_count=tm_data.get('errors_count', 0),
+            last_error_message=tm_data.get('last_error_message', ''),
+            timeout_seconds=tm_data.get('timeout_seconds'),
+            kwargs=tm_data.get('kwargs') or {},
+        )
+
+    return instance

--- a/django_logic/testing/tracking.py
+++ b/django_logic/testing/tracking.py
@@ -1,0 +1,101 @@
+"""Side-effect / callback execution tracking and failure injection.
+
+We do not mock. During a tracked transition we temporarily replace the
+callables on the transition's hook bundles (``side_effects``, ``callbacks``,
+``failure_side_effects``, ``failure_callbacks``) with thin wrappers that:
+
+* record the hook's ``__name__`` *after* it runs successfully, and
+* (for ``side_effects`` only) optionally raise a chosen exception instead of
+  running a named hook — exercising the real failure path.
+
+Transition objects are class-level and shared, and both the synchronous
+``SideEffects.execute`` path and the background phase-2 runner iterate
+``transition.side_effects.commands`` — so wrapping ``_commands`` instruments
+both execution modes. Everything is restored on exit.
+"""
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+
+_HOOK_SLOTS = (
+    ('side_effects', 'side_effects_ran'),
+    ('callbacks', 'callbacks_ran'),
+    ('failure_side_effects', 'failure_side_effects_ran'),
+    ('failure_callbacks', 'failure_callbacks_ran'),
+)
+
+
+class ExecutionTracker:
+    """Records what ran during one tracked transition attempt."""
+
+    def __init__(self):
+        self.side_effects_ran: list[str] = []
+        self.callbacks_ran: list[str] = []
+        self.failure_side_effects_ran: list[str] = []
+        self.failure_callbacks_ran: list[str] = []
+        # The exception raised by an injected side-effect, if any.
+        self.injected_exception: BaseException | None = None
+        self.failed_side_effect: str | None = None
+
+
+def _name(fn) -> str:
+    return getattr(fn, '__name__', repr(fn))
+
+
+def _coerce_exception(fail_with, hook_name) -> BaseException:
+    if isinstance(fail_with, BaseException):
+        return fail_with
+    if isinstance(fail_with, type) and issubclass(fail_with, BaseException):
+        return fail_with()
+    if callable(fail_with):
+        return fail_with()
+    return Exception(f'injected failure in side-effect {hook_name!r}')
+
+
+def _make_wrapper(fn, tracker, sink_attr, fail_side_effect, fail_with):
+    name = _name(fn)
+    inject = fail_side_effect is not None and name == fail_side_effect
+
+    def wrapper(instance, **kwargs):
+        if inject:
+            exc = _coerce_exception(fail_with, name)
+            tracker.injected_exception = exc
+            tracker.failed_side_effect = name
+            raise exc  # real hook never runs → it did NOT "run"
+        result = fn(instance, **kwargs)
+        getattr(tracker, sink_attr).append(name)  # record only after success
+        return result
+
+    # Preserve __name__ so django-logic's own logging (command.__name__) works.
+    wrapper.__name__ = name
+    return wrapper
+
+
+@contextmanager
+def track(transitions, *, fail_side_effect=None, fail_with=None):
+    """Instrument the given transition objects for the duration of the block.
+
+    ``transitions`` is the list of class-level ``Transition`` objects matching
+    the action under test (usually one). Yields an :class:`ExecutionTracker`.
+    Injection only targets ``side_effects`` hooks.
+    """
+    tracker = ExecutionTracker()
+    saved: list[tuple] = []
+    for transition in transitions:
+        for slot, sink_attr in _HOOK_SLOTS:
+            bundle = getattr(transition, slot, None)
+            if bundle is None:
+                continue
+            original = bundle._commands
+            saved.append((bundle, original))
+            inject_here = fail_side_effect if slot == 'side_effects' else None
+            bundle._commands = [
+                _make_wrapper(fn, tracker, sink_attr, inject_here, fail_with)
+                for fn in original
+            ]
+    try:
+        yield tracker
+    finally:
+        for bundle, original in saved:
+            bundle._commands = original

--- a/tests/test_scenario.py
+++ b/tests/test_scenario.py
@@ -1,0 +1,174 @@
+"""Exercises the scenario-based testing framework (`django_logic.testing`).
+
+Demonstrates the full surface — synchronous transitions, background happy/
+failure/retry/terminal paths, BackgroundAction (no state change), availability
+with conditions + permissions, side-effect/callback tracking, snapshot capture
++ replay, and AI-readable failure output — all without Celery.
+
+Driven against the existing Widget/WidgetProcess fixtures plus a tiny guarded
+process bound under `guard` (no new migrations).
+"""
+from django.conf import settings
+from django.contrib.auth import get_user_model
+
+from django_logic import Process, ProcessManager, Transition
+from django_logic.background.models import TransitionMessage
+from django_logic.testing import ProcessScenario
+from tests.background.models import Widget, WidgetProcess
+
+
+# --- a minimal process with a condition + permission, bound under `guard` ---
+
+def _stock_ok(instance):
+    return getattr(instance, '_stock_available', True)
+
+
+def _is_staff(instance, user):
+    return bool(user and getattr(user, 'is_staff', False))
+
+
+class ScenarioGuardProcess(Process):
+    process_name = 'guard'
+    transitions = [
+        Transition(
+            action_name='approve',
+            sources=['draft'],
+            target='approved',
+            conditions=[_stock_ok],
+            permissions=[_is_staff],
+        ),
+    ]
+
+
+ProcessManager.bind_model_process(Widget, ScenarioGuardProcess, state_field='status')
+
+
+class WidgetFulfilmentScenario(ProcessScenario):
+    process_class = WidgetProcess
+    model = Widget
+    state_field = 'status'
+    process_name = 'process'
+
+    def test_background_happy_path(self):
+        """draft -> fulfilling -> fulfilled, side-effects + callback run."""
+        widget = self.create_instance(status='draft')
+        self.assert_available(widget, ['fulfil', 'cancel'])
+
+        self.background_transition(widget, 'fulfil')
+        self.assert_state(widget, 'fulfilled')
+        self.assert_side_effects_ran(['bg_ok', 'bg_record_kwargs'])
+        self.assert_callbacks_ran(['bg_callback'])
+
+    def test_failure_records_error_and_stays_in_progress(self):
+        """A side-effect fails -> error recorded, instance left in_progress."""
+        widget = self.create_instance(status='draft')
+        self.background_transition(
+            widget, 'fulfil',
+            fail_side_effect='bg_ok', fail_with=ValueError('courier down'))
+
+        self.assert_state(widget, 'fulfilling')
+        self.assert_error_recorded(widget, 'courier down')
+        self.assert_error_count(widget, 1)
+        self.assert_side_effects_not_ran(['bg_ok', 'bg_record_kwargs'])
+
+    def test_failure_then_retry_succeeds(self):
+        """A transient failure is recovered by the retry path."""
+        widget = self.create_instance(status='draft')
+        self.background_transition(
+            widget, 'fulfil', fail_side_effect='bg_ok', fail_with=ValueError('blip'))
+        self.assert_state(widget, 'fulfilling')
+
+        self.retry_transition(widget)  # no injection this time -> succeeds
+        self.assert_state(widget, 'fulfilled')
+        self.assert_error_count(widget, 1)
+
+    def test_max_retries_exhausted_moves_to_failed_state(self):
+        """After MAX_ERRORS failures the instance lands in failed_state."""
+        max_errors = settings.DJANGO_LOGIC['TRANSITION_MESSAGE_MAX_ERRORS']
+        widget = self.create_instance(status='draft')
+        self.background_transition(
+            widget, 'fulfil', fail_side_effect='bg_ok', fail_with=ValueError('persistent'))
+        for _ in range(max_errors - 1):
+            self.retry_transition(
+                widget, fail_side_effect='bg_ok', fail_with=ValueError('persistent'))
+
+        self.assert_state(widget, 'fulfilment_failed')
+        self.assert_error_count(widget, max_errors)
+
+    def test_synchronous_transition(self):
+        widget = self.create_instance(status='draft')
+        self.transition(widget, 'cancel')
+        self.assert_state(widget, 'cancelled')
+
+    def test_background_action_does_not_change_state(self):
+        widget = self.create_instance(status='fulfilled')
+        self.background_transition(widget, 'sync_inventory')
+        self.assert_state(widget, 'fulfilled')  # action: no target write
+        self.assert_side_effects_ran(['bg_ok'])
+        self.assert_callbacks_ran(['bg_callback'])
+
+    def test_not_available_from_wrong_state(self):
+        widget = self.create_instance(status='draft')
+        self.assert_not_available(widget, ['generate_export'])  # needs 'fulfilled'
+
+    def test_snapshot_capture_and_replay(self):
+        """Capture a stuck instance, rebuild it from the snapshot, fix it."""
+        widget = self.create_instance(status='draft')
+        self.background_transition(
+            widget, 'fulfil', fail_side_effect='bg_ok', fail_with=ValueError('snap'))
+
+        snap = self.snapshot(widget)
+        self.assertEqual(snap['state'], 'fulfilling')
+        self.assertIn('transition_message', snap)
+
+        # Remove the original so from_snapshot can recreate it with the same pk.
+        TransitionMessage.objects.filter(instance_id=str(widget.pk)).delete()
+        Widget.objects.filter(pk=widget.pk).delete()
+
+        restored = self.from_snapshot(snap)
+        self.assert_state(restored, 'fulfilling')
+        self.assert_error_count(restored, 1)
+
+        self.retry_transition(restored)  # the "fix" works
+        self.assert_state(restored, 'fulfilled')
+
+    def test_ai_readable_failure_output(self):
+        """A failed assertion produces the structured timeline output."""
+        widget = self.create_instance(status='draft')
+        self.transition(widget, 'cancel')
+        with self.assertRaises(AssertionError) as ctx:
+            self.assert_state(widget, 'fulfilled')  # actual is 'cancelled'
+        msg = str(ctx.exception)
+        self.assertIn('Timeline:', msg)
+        self.assertIn("Expected state 'fulfilled'", msg)
+        self.assertIn('cancel', msg)  # the timeline records the cancel step
+
+
+class GuardedApprovalScenario(ProcessScenario):
+    process_class = ScenarioGuardProcess
+    model = Widget
+    state_field = 'status'
+    process_name = 'guard'
+
+    def test_permission_gate(self):
+        User = get_user_model()
+        staff = User.objects.create(username='sc_staff', is_staff=True)
+        customer = User.objects.create(username='sc_customer', is_staff=False)
+
+        widget = self.create_instance(status='draft')
+        self.assert_available(widget, ['approve'], user=staff)
+        self.assert_not_available(widget, ['approve'], user=customer)
+
+        self.transition(widget, 'approve', user=staff)
+        self.assert_state(widget, 'approved')
+
+    def test_condition_gate(self):
+        User = get_user_model()
+        staff = User.objects.create(username='sc_staff2', is_staff=True)
+        widget = self.create_instance(status='draft')
+
+        widget._stock_available = False
+        self.assert_not_available(widget, ['approve'], user=staff)
+
+        widget._stock_available = True
+        self.assert_available(widget, ['approve'], user=staff)


### PR DESCRIPTION
Implements the planned ProcessScenario / snapshot-replay system (docs/design/TESTING_SCENARIOS.md): test FSM workflows incl. background jobs/failures/retries as unit tests with no Celery. Adds django_logic.testing (ProcessScenario, tracking, runner, assertions, snapshot, AI-readable output), tests/test_scenario.py (11 scenarios), and a README 'Testing Your Processes' section. Full suite: 210 passing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive test-only API and documentation; production transition code is unchanged aside from temporary class-level hook wrapping during tracked test runs (restored in `finally`).
> 
> **Overview**
> Adds **`django_logic.testing`**, a scenario-style test layer so FSM workflows (sync transitions, background phase 1+2, retries, permissions, and failures) can be exercised **without Celery**, on top of existing **`sync_execution()`** and **`run_background_transition`**.
> 
> **`ProcessScenario`** (`TransactionTestCase`) drives **`transition`**, **`background_transition`**, and **`retry_transition`**, with business assertions (state, action availability, **`TransitionMessage`** errors) and **hook tracking by `__name__`** (real side-effects run; optional **`fail_side_effect`** injection). Failures get a **numbered timeline** and optional **`snapshot_on_failure`**.
> 
> **`snapshot` / `from_snapshot`** serialize model fields plus the latest **`TransitionMessage`** for production-to-test replay. README gains a **Testing Your Processes** section; **`tests/test_scenario.py`** covers happy path, failure/retry/max-errors, snapshots, and guarded transitions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e5b557fb30704b311da1d9e889123e7e47c0fab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->