### PR TITLE
Standardise process↔model binding on AppConfig.ready() (#100)

### DIFF
--- a/.cursor/rules/django-logic.mdc
+++ b/.cursor/rules/django-logic.mdc
@@ -83,7 +83,8 @@ These rules are distilled from a full production-style validation on Heroku
 ## Minimal example
 
 ```python
-from django_logic import Process, Transition, ProcessManager
+# process.py
+from django_logic import Process, Transition
 from django_logic.background import BackgroundTransition
 
 class OrderProcess(Process):
@@ -99,9 +100,28 @@ class OrderProcess(Process):
             callbacks=[notify_customer],                 # best-effort
         ),
     ]
+```
 
-ProcessManager.bind_model_process(Order, OrderProcess, state_field='status')
-# drive it: order.process.fulfill(user=request.user)
+**Bind in exactly one place — the app's `AppConfig.ready()`** — never at module
+import time in `models.py`/`process.py` (that forces a
+`model → process → actions → model` circular import; issue #100). `ready()`
+runs after all models are loaded, so the cycle never forms and actions can
+import the model at the top level.
+
+```python
+# apps.py
+from django.apps import AppConfig
+from django_logic import ProcessManager
+
+class OrdersConfig(AppConfig):
+    name = 'orders'
+
+    def ready(self):
+        from .models import Order
+        from .process import OrderProcess
+        ProcessManager.bind_model_process(Order, OrderProcess, state_field='status')
+
+# drive it from a view/task/method: order.process.fulfill(user=request.user)
 ```
 
 For the parent/child (order → many fulfillments) pattern and full error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@
 
 ### Changed
 
+- **Standardised process↔model binding on `AppConfig.ready()` (issue #100).**
+  `ProcessManager.bind_model_process(...)` is now documented and practised in
+  exactly one place — the app's `AppConfig.ready()` — instead of at module
+  import time in `models.py`/`process.py`. Binding at import time forced a
+  `model → process → actions → model` circular import (the process and its
+  side-effect/condition/permission functions both reference the model), whose
+  only workaround was scattering `from .models import X` calls inside every
+  action function. Binding in `ready()` (which runs after every app's models are
+  loaded) removes the cycle, so action modules import their model at the top
+  level normally. No library API change — `bind_model_process` is unchanged;
+  the README, `CLAUDE.md`, the Cursor rule, and the bundled test apps
+  (`tests/background`, `tests/stability`) now bind in `ready()` only.
 - **`_validate_unique_background_action_names` is relaxed to a single
   invariant.** It previously rejected *any* two background transitions sharing
   an `action_name` across a process and its nested tree, and any background

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,9 +13,17 @@ workers + induced worker crashes, deploys, broker loss, and pgbouncer).
 Model a workflow as a `Process` subclass: a list of `transitions` (edges).
 Each transition has `sources`, `target`, and optional `conditions`,
 `permissions`, `side_effects`, `callbacks`, `failure_side_effects`,
-`failure_callbacks`. Bind it with
-`ProcessManager.bind_model_process(Model, MyProcess, state_field='status')`,
-then drive it via `instance.process.<action>(...)`.
+`failure_callbacks`. **Bind the model to its process in exactly one place — the
+app's `AppConfig.ready()`** — with
+`ProcessManager.bind_model_process(Model, MyProcess, state_field='status')`
+(import the model and process *inside* `ready()`). Never bind at module import
+time in `models.py`/`process.py`: that forces a
+`model → process → actions → model` circular import (issue #100), because the
+process and its action functions both reference the model. `ready()` runs after
+every app's models are loaded, so the cycle never forms and action modules can
+import the model at the top level. Then drive it via
+`instance.process.<action>(...)` from request/task/method bodies (never at
+module top or in another app's `ready()`).
 
 Use `BackgroundTransition` (durable, runs side-effects on a Celery worker,
 writes target/`failed_state`) or `BackgroundAction` (same durability, no state

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ class Order(models.Model):
     # ... other fields
 
 # process.py
-from django_logic import Process, Transition, ProcessManager
+from django_logic import Process, Transition
 
 class OrderProcess(Process):
     transitions = [
@@ -102,7 +102,21 @@ class OrderProcess(Process):
         ),
     ]
 
-ProcessManager.bind_model_process(Order, OrderProcess, state_field='status')
+# apps.py — bind the process in your app's AppConfig.ready(). This is the one
+# supported place to bind: ready() runs after every app's models are loaded, so
+# it avoids the model→process→actions→model circular import that binding at
+# module import time (in models.py or process.py) creates. See "Bind the
+# process" below.
+from django.apps import AppConfig
+from django_logic import ProcessManager
+
+class OrdersConfig(AppConfig):
+    name = 'orders'
+
+    def ready(self):
+        from .models import Order
+        from .process import OrderProcess
+        ProcessManager.bind_model_process(Order, OrderProcess, state_field='status')
 
 # Usage
 order = Order.objects.create()
@@ -176,21 +190,42 @@ class MyProcess(BaseProcess):
     ]
 ```
 
-### 4. Bind the process with a model
+### 4. Bind the process in your app's `AppConfig.ready()`
+
+**Binding happens in exactly one place: your app's `AppConfig.ready()`.** Do
+**not** bind at module import time (in `models.py` or `process.py`).
+
+A process references its model (and its side-effect/condition/permission
+functions reference it too), so binding `Model ⇄ Process` at import time forces
+`models.py → process.py → actions.py → models.py` — a circular import
+(issue #100). The only escape is scattering `from .models import X` calls inside
+every action function. `ready()` removes the cycle entirely: Django imports
+**all** apps' models before running **any** `ready()`, so by the time you bind,
+every model already exists and your action modules can import the model at the
+top level like normal code.
+
 ```python
-from django_logic import Process as BaseProcess, Transition, ProcessManager, Action
-from .models import Invoice, MY_STATE_CHOICES
+# apps.py
+from django.apps import AppConfig
+from django_logic import ProcessManager
 
 
-class MyProcess(BaseProcess):
-    transitions = [
-        Transition(action_name='approve', sources=['draft'], target='approved'),
-        Transition(action_name='void', sources=['draft', 'approved'], target='void'),
-        Action(action_name='update', sources=['draft', 'approved'], side_effects=[update_data]),
-    ]
+class InvoicingConfig(AppConfig):
+    name = 'invoicing'
 
-ProcessManager.bind_model_process(Invoice, MyProcess, state_field='my_state')
-``` 
+    def ready(self):
+        # Import inside ready() — never at module top in apps.py.
+        from .models import Invoice
+        from .process import MyProcess
+        ProcessManager.bind_model_process(Invoice, MyProcess, state_field='my_state')
+```
+
+Then drive it from request/task/method bodies via `invoice.process.<action>(...)`
+— never at module-import time or in another app's `ready()`.
+
+> Make sure the app is wired so `ready()` runs — list it in `INSTALLED_APPS`
+> (Django auto-discovers the single `AppConfig` in `apps.py`).
+
 
 ### 5. Advance your process with conditions, side-effects, and callbacks
 Use next_transition to automatically continue the process. 
@@ -390,7 +425,7 @@ def send_shipping_notification(instance, **kwargs):
     pass
 
 # process.py
-from django_logic import Process, Transition, ProcessManager
+from django_logic import Process, Transition
 
 class OrderProcess(Process):
     process_name = 'order_process'
@@ -444,7 +479,18 @@ class OrderProcess(Process):
         ),
     ]
 
-ProcessManager.bind_model_process(Order, OrderProcess, state_field='status')
+# apps.py — bind in AppConfig.ready() (the one supported place; see "Bind the
+# process"). Never bind at module import time.
+from django.apps import AppConfig
+from django_logic import ProcessManager
+
+class ShopConfig(AppConfig):
+    name = 'shop'
+
+    def ready(self):
+        from .models import Order
+        from .process import OrderProcess
+        ProcessManager.bind_model_process(Order, OrderProcess, state_field='status')
 
 # views.py
 from django.shortcuts import render, redirect
@@ -540,7 +586,7 @@ If you're migrating from Django FSM, the main changes are:
 1. Replace `@transition` decorator with `Transition` class
 2. Move transition logic to side effects and callbacks
 3. Group related transitions into Process classes
-4. Update state field management to use ProcessManager
+4. Bind each model to its process with `ProcessManager.bind_model_process(...)` in your app's `AppConfig.ready()` (see [Bind the process](#4-bind-the-process-in-your-apps-appconfigready))
 
 ## Advanced Features
 
@@ -651,7 +697,7 @@ CACHES = {
 ### Declare a background transition
 
 ```python
-from django_logic import Process, Transition, ProcessManager
+from django_logic import Process, Transition
 from django_logic.background import BackgroundTransition, BackgroundAction
 
 
@@ -691,7 +737,17 @@ class OrderProcess(Process):
     ]
 
 
-ProcessManager.bind_model_process(Order, OrderProcess, state_field='status')
+# apps.py — bind in AppConfig.ready() (the one supported place; see "Bind the process").
+from django.apps import AppConfig
+from django_logic import ProcessManager
+
+class ShopConfig(AppConfig):
+    name = 'shop'
+
+    def ready(self):
+        from .models import Order
+        from .process import OrderProcess
+        ProcessManager.bind_model_process(Order, OrderProcess, state_field='status')
 ```
 
 ### Call it
@@ -740,7 +796,17 @@ class DummyConversationProcess(Process):
 class ConversationProcess(Process):
     nested_processes = [GmailConversationProcess, DummyConversationProcess]
 
-ProcessManager.bind_model_process(Conversation, ConversationProcess, state_field='status')
+# apps.py — bind in AppConfig.ready() (the one supported place; see "Bind the process").
+from django.apps import AppConfig
+from django_logic import ProcessManager
+
+class MessagingConfig(AppConfig):
+    name = 'messaging'
+
+    def ready(self):
+        from .models import Conversation
+        from .process import ConversationProcess
+        ProcessManager.bind_model_process(Conversation, ConversationProcess, state_field='status')
 
 # Generic caller — routes by source_integration, no integration knowledge here:
 conversation.process.send_message_via_integration(user=request.user)

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -189,7 +189,8 @@ workspace). The single-task model below replaces both.
 ### 2.2 API
 
 ```python
-from django_logic import Process, Transition, ProcessManager
+# process.py
+from django_logic import Process, Transition
 from django_logic.background import BackgroundTransition, BackgroundAction
 
 class OrderProcess(Process):
@@ -235,7 +236,19 @@ class OrderProcess(Process):
         ),
     ]
 
-ProcessManager.bind_model_process(Order, OrderProcess, state_field='status')
+# apps.py — bind in AppConfig.ready() (the single supported binding site;
+# binding at module import time creates a model→process→actions→model cycle,
+# issue #100).
+from django.apps import AppConfig
+from django_logic import ProcessManager
+
+class OrdersConfig(AppConfig):
+    name = 'orders'
+
+    def ready(self):
+        from .models import Order
+        from .process import OrderProcess
+        ProcessManager.bind_model_process(Order, OrderProcess, state_field='status')
 ```
 
 Omitting `queue=` raises `ImproperlyConfigured` at import time.

--- a/tests/background/apps.py
+++ b/tests/background/apps.py
@@ -1,7 +1,42 @@
 from django.apps import AppConfig
 
+from django_logic import ProcessManager
+
 
 class BackgroundTestsConfig(AppConfig):
     name = 'tests.background'
     label = 'bg_tests'
     default_auto_field = 'django.db.models.BigAutoField'
+
+    def ready(self):
+        # The single binding site for this app. ready() runs after every app's
+        # models are imported (Django app-loading phase 3), so binding here can
+        # never trigger the model→process→actions→model import cycle (issue
+        # #100). Keep model/process imports inside ready(), not at module top.
+        from .models import (
+            AmbiguousConversationProcess,
+            ArchivableProcess,
+            ArchivableWidget,
+            Conversation,
+            ConversationProcess,
+            MixedSyncBgProcess,
+            ScenarioGuardProcess,
+            SharedActionConversationProcess,
+            Widget,
+            WidgetAuditProcess,
+            WidgetChainProcess,
+            WidgetParentProcess,
+            WidgetProcess,
+        )
+
+        ProcessManager.bind_model_process(Widget, WidgetProcess, state_field='status')
+        ProcessManager.bind_model_process(Widget, WidgetAuditProcess, state_field='audit_status')
+        ProcessManager.bind_model_process(Widget, WidgetParentProcess, state_field='status')
+        ProcessManager.bind_model_process(ArchivableWidget, ArchivableProcess, state_field='status')
+        ProcessManager.bind_model_process(Conversation, ConversationProcess, state_field='status')
+        ProcessManager.bind_model_process(Conversation, AmbiguousConversationProcess, state_field='status')
+        ProcessManager.bind_model_process(Conversation, SharedActionConversationProcess, state_field='status')
+        ProcessManager.bind_model_process(Conversation, MixedSyncBgProcess, state_field='status')
+        # Test-local processes attached to Widget (see models.py).
+        ProcessManager.bind_model_process(Widget, ScenarioGuardProcess, state_field='status')
+        ProcessManager.bind_model_process(Widget, WidgetChainProcess, state_field='status')

--- a/tests/background/models.py
+++ b/tests/background/models.py
@@ -1,7 +1,14 @@
-"""Models + processes for background-transition tests."""
+"""Models + processes for background-transition tests.
+
+Process↔model binding for this app happens in one place only —
+``tests/background/apps.py`` (``BackgroundTestsConfig.ready()``). Binding at
+module import time here would re-create the model→process→actions→model
+circular import (issue #100); ``ready()`` runs after every app's models are
+loaded, so it is the single supported binding site.
+"""
 from django.db import models
 
-from django_logic import Process, ProcessManager, Transition
+from django_logic import Process, Transition
 from django_logic.background import BackgroundAction, BackgroundTransition
 
 
@@ -133,9 +140,6 @@ class WidgetProcess(Process):
     ]
 
 
-ProcessManager.bind_model_process(Widget, WidgetProcess, state_field='status')
-
-
 def bg_audit_ok(instance, **kwargs):
     """Harmless side-effect for the audit process (R5 fixtures)."""
     instance.se_log = (instance.se_log or '') + 'audit_ok,'
@@ -160,9 +164,6 @@ class WidgetAuditProcess(Process):
             side_effects=[bg_audit_ok],
         ),
     ]
-
-
-ProcessManager.bind_model_process(Widget, WidgetAuditProcess, state_field='audit_status')
 
 
 # --- Filtered-default-manager fixtures (issue #90) -------------------------
@@ -207,9 +208,6 @@ class ArchivableProcess(Process):
             side_effects=[bg_noop],
         ),
     ]
-
-
-ProcessManager.bind_model_process(ArchivableWidget, ArchivableProcess, state_field='status')
 
 
 # --- Nested-process background transitions ---------------------------------
@@ -289,9 +287,6 @@ class WidgetParentProcess(Process):
 
     process_name = 'parent_process'
     nested_processes = [NestedBgChildProcess, NestedBgMidProcess]
-
-
-ProcessManager.bind_model_process(Widget, WidgetParentProcess, state_field='status')
 
 
 # --- Condition-disambiguated nested background transitions (issue #98) ------
@@ -399,9 +394,6 @@ class ConversationProcess(Process):
     nested_processes = [GmailConversationProcess, DummyConversationProcess]
 
 
-ProcessManager.bind_model_process(Conversation, ConversationProcess, state_field='status')
-
-
 # Overlapping-condition sibling background transitions (issue #98). The relaxed
 # validator allows a shared background action_name across distinct nested
 # classes regardless of whether the conditions are mutually exclusive — so a
@@ -448,11 +440,6 @@ class AmbiguousBProcess(Process):
 class AmbiguousConversationProcess(Process):
     process_name = 'ambiguous_process'
     nested_processes = [AmbiguousAProcess, AmbiguousBProcess]
-
-
-ProcessManager.bind_model_process(
-    Conversation, AmbiguousConversationProcess, state_field='status'
-)
 
 
 # Two nested BackgroundActions that SHARE an action_name with IDENTICAL sources
@@ -503,11 +490,6 @@ class SharedActionConversationProcess(Process):
     nested_processes = [SharedActionAProcess, SharedActionBProcess]
 
 
-ProcessManager.bind_model_process(
-    Conversation, SharedActionConversationProcess, state_field='status'
-)
-
-
 # A synchronous transition and a background transition SHARING an action_name in
 # one process, routed by a condition on the instance (issue #98: this is allowed
 # now that phase 2 filters to is_background — the sync namesake is invisible to
@@ -546,6 +528,66 @@ class MixedSyncBgProcess(Process):
     ]
 
 
-ProcessManager.bind_model_process(
-    Conversation, MixedSyncBgProcess, state_field='status'
-)
+# --- Test-local processes attached to Widget -------------------------------
+# These were previously defined and bound inside their test modules. They live
+# here so that every bind_model_process call for this app is centralised in
+# apps.py (the single binding site); the tests import these symbols.
+
+
+# Used by tests/test_scenario.py::GuardedApprovalScenario — a minimal process
+# with a condition + permission, bound under the `guard` process name.
+
+def _stock_ok(instance):
+    return getattr(instance, '_stock_available', True)
+
+
+def _is_staff(instance, user):
+    return bool(user and getattr(user, 'is_staff', False))
+
+
+class ScenarioGuardProcess(Process):
+    process_name = 'guard'
+    transitions = [
+        Transition(
+            action_name='approve',
+            sources=['draft'],
+            target='approved',
+            conditions=[_stock_ok],
+            permissions=[_is_staff],
+        ),
+    ]
+
+
+# Used by tests/test_issue_fixes_testing.py (#96) — `approve` chains into
+# `notify` via next_transition; the follow-up's side-effect must be tracked
+# even though only `approve` was driven. ``RAN`` records call order for the
+# test's assertions.
+
+RAN: list = []
+
+
+def chain_first(instance, **kwargs):
+    RAN.append('chain_first')
+
+
+def chain_followup(instance, **kwargs):
+    RAN.append('chain_followup')
+
+
+class WidgetChainProcess(Process):
+    process_name = 'chain_process'
+    transitions = [
+        Transition(
+            action_name='approve',
+            sources=['draft'],
+            target='approved',
+            side_effects=[chain_first],
+            next_transition='notify',
+        ),
+        Transition(
+            action_name='notify',
+            sources=['approved'],
+            target='notified',
+            side_effects=[chain_followup],
+        ),
+    ]

--- a/tests/stability/apps.py
+++ b/tests/stability/apps.py
@@ -1,7 +1,30 @@
 from django.apps import AppConfig
 
+from django_logic import ProcessManager
+
 
 class StabilityConfig(AppConfig):
     name = 'tests.stability'
     label = 'stability'
     default_auto_field = 'django.db.models.BigAutoField'
+
+    def ready(self):
+        # The single binding site for this app. ready() runs after all models
+        # are loaded, so binding here can never trigger the import cycle that
+        # module-level binding in models.py would (issue #100). Keep the
+        # model/process imports inside ready().
+        from .models import (
+            FulfillmentProcess,
+            MultiProcessOrder,
+            Order,
+            OrderProcess,
+            PaymentProcess,
+        )
+
+        ProcessManager.bind_model_process(Order, OrderProcess, state_field='status')
+        ProcessManager.bind_model_process(
+            MultiProcessOrder, FulfillmentProcess, state_field='fulfillment_status'
+        )
+        ProcessManager.bind_model_process(
+            MultiProcessOrder, PaymentProcess, state_field='payment_status'
+        )

--- a/tests/stability/models.py
+++ b/tests/stability/models.py
@@ -6,7 +6,10 @@ concurrency, crash recovery, and locking behavior, not business logic.
 """
 from django.db import models
 
-from django_logic import Process, Transition, Action, ProcessManager
+from django_logic import Process, Transition, Action
+
+# Process↔model binding for this app happens only in tests/stability/apps.py
+# (StabilityConfig.ready()) — the single binding site. See issue #100.
 
 
 # ---------------------------------------------------------------------------
@@ -181,12 +184,3 @@ class PaymentProcess(Process):
             side_effects=[side_effect_two],
         ),
     ]
-
-
-ProcessManager.bind_model_process(Order, OrderProcess, state_field='status')
-ProcessManager.bind_model_process(
-    MultiProcessOrder, FulfillmentProcess, state_field='fulfillment_status'
-)
-ProcessManager.bind_model_process(
-    MultiProcessOrder, PaymentProcess, state_field='payment_status'
-)

--- a/tests/stability/test_deadlocks.py
+++ b/tests/stability/test_deadlocks.py
@@ -19,7 +19,7 @@ from unittest.mock import patch
 from django.core.cache import cache
 from django.test import override_settings, tag
 
-from django_logic import Transition, Process, ProcessManager
+from django_logic import Transition
 from django_logic.exceptions import TransitionNotAllowed
 from django_logic.state import State, RedisState
 
@@ -58,23 +58,21 @@ class TestNestedTransitionLockContention(StabilityTestCase):
         state = State(order, 'status', process_name='process')
         self.track_lock(state)
 
-        ProcessManager.bind_model_process(
-            Order, OrderProcessWithNestedCallback, state_field='status'
+        # OrderProcessWithNestedCallback shares the 'process' name with the
+        # app-bound OrderProcess, so we drive it directly without rebinding the
+        # model. Its fulfill callback (trigger_nested_transition) calls
+        # order.process.complete(), which resolves to the OrderProcess bound in
+        # tests/stability/apps.py — the single binding site — and succeeds
+        # because the lock is already released before callbacks run.
+        process = OrderProcessWithNestedCallback(
+            field_name='status', instance=order
         )
-        try:
-            process = OrderProcessWithNestedCallback(
-                field_name='status', instance=order
-            )
-            process.fulfill()
+        process.fulfill()
 
-            order.refresh_from_db()
-            # Callback triggers complete() which succeeds because lock is released
-            self.assertEqual(order.status, 'completed')
-            self.assert_unlocked(state)
-        finally:
-            ProcessManager.bind_model_process(
-                Order, OrderProcess, state_field='status'
-            )
+        order.refresh_from_db()
+        # Callback triggers complete() which succeeds because lock is released
+        self.assertEqual(order.status, 'completed')
+        self.assert_unlocked(state)
 
     def test_side_effect_nested_same_instance_rejected(self):
         """

--- a/tests/test_issue_fixes_testing.py
+++ b/tests/test_issue_fixes_testing.py
@@ -12,10 +12,14 @@ attributes are DB-coerced field types.
 """
 from django.test import override_settings
 
-from django_logic import Process, ProcessManager, Transition
 from django_logic.testing import ProcessScenario
 from django_logic.testing.snapshot import _jsonable, from_snapshot, snapshot
-from tests.background.models import Widget, WidgetProcess
+# WidgetChainProcess (approve chains into notify via next_transition) and its
+# RAN call-order log live in tests.background.models and are bound in
+# tests/background/apps.py — the single binding site for the app.
+from tests.background.models import (
+    RAN, Widget, WidgetChainProcess, WidgetProcess,
+)
 
 
 _SYNC_SETTINGS = {
@@ -26,42 +30,6 @@ _SYNC_SETTINGS = {
     'TRANSITION_MESSAGE_RETRY_MINUTES': 2,
     'TRANSITION_MESSAGE_CLEANUP_DAYS': 7,
 }
-
-
-RAN: list = []
-
-
-def chain_first(instance, **kwargs):
-    RAN.append('chain_first')
-
-
-def chain_followup(instance, **kwargs):
-    RAN.append('chain_followup')
-
-
-class WidgetChainProcess(Process):
-    """approve chains into notify via next_transition — the follow-up's
-    side-effect must be tracked even though only 'approve' was driven."""
-
-    process_name = 'chain_process'
-    transitions = [
-        Transition(
-            action_name='approve',
-            sources=['draft'],
-            target='approved',
-            side_effects=[chain_first],
-            next_transition='notify',
-        ),
-        Transition(
-            action_name='notify',
-            sources=['approved'],
-            target='notified',
-            side_effects=[chain_followup],
-        ),
-    ]
-
-
-ProcessManager.bind_model_process(Widget, WidgetChainProcess, state_field='status')
 
 
 @override_settings(DJANGO_LOGIC=_SYNC_SETTINGS)

--- a/tests/test_scenario.py
+++ b/tests/test_scenario.py
@@ -11,36 +11,12 @@ process bound under `guard` (no new migrations).
 from django.conf import settings
 from django.contrib.auth import get_user_model
 
-from django_logic import Process, ProcessManager, Transition
 from django_logic.background.models import TransitionMessage
 from django_logic.testing import ProcessScenario
-from tests.background.models import Widget, WidgetProcess
-
-
-# --- a minimal process with a condition + permission, bound under `guard` ---
-
-def _stock_ok(instance):
-    return getattr(instance, '_stock_available', True)
-
-
-def _is_staff(instance, user):
-    return bool(user and getattr(user, 'is_staff', False))
-
-
-class ScenarioGuardProcess(Process):
-    process_name = 'guard'
-    transitions = [
-        Transition(
-            action_name='approve',
-            sources=['draft'],
-            target='approved',
-            conditions=[_stock_ok],
-            permissions=[_is_staff],
-        ),
-    ]
-
-
-ProcessManager.bind_model_process(Widget, ScenarioGuardProcess, state_field='status')
+# ScenarioGuardProcess (a minimal process with a condition + permission, bound
+# under the `guard` process name) lives in tests.background.models and is bound
+# in tests/background/apps.py — the single binding site for the app.
+from tests.background.models import ScenarioGuardProcess, Widget, WidgetProcess
 
 
 class WidgetFulfilmentScenario(ProcessScenario):


### PR DESCRIPTION
Closes #100.

## Problem

Binding a model to its process at **module import time** (`models.py` builds the model from a process reference, or calls `ProcessManager.bind_model_process(...)` right after the model) forces a circular import:

```
models.py → process.py → actions.py → models.py
```

The process and its `side_effects` / `conditions` / `permissions` / `callbacks` all reference the model, so the only escape was scattering `from .models import X` calls **inside every action function** — noise that drifts out of sync and accumulates dead imports.

## Fix

**Bind in exactly one place — the app's `AppConfig.ready()`.** Django imports *all* apps' models (phase 2) before running *any* `ready()` (phase 3), so by bind time every model exists. Moving the bind there removes the `model → process` edge, the cycle never forms, and action modules import the model at the top level like normal code.

This is **option 2** from the issue discussion. No library API change — `ProcessManager.bind_model_process` is unchanged; this PR moves call sites and updates the docs/tests so there is **one and only one** documented and practised way to bind.

## Changes

- **`tests/background`, `tests/stability`** — bind in `apps.py` `ready()`. Relocated the test-local `ScenarioGuardProcess` / `WidgetChainProcess` (plus helpers and the `RAN` log) from their test modules into `tests/background/models.py` so every `bind_model_process` call lives in an `apps.py`. Removed the runtime rebind in `test_deadlocks.py` (the `apps.py`-bound `OrderProcess` already declares the `complete` transition the callback drives).
- **Docs / instructions** — `README.md` (every example now binds in `ready()`, plus a new authoritative *"Bind the process"* section explaining the cycle), `CLAUDE.md`, `.cursor/rules/django-logic.mdc`, `docs/PLAN.md`.
- **`CHANGELOG.md`** — documented under `[Unreleased]`.

## Validation

- Library suite green: **233 tests pass** (SQLite; 13 infra-skips) including the relocated `guard`/`chain_process` binds and the modified deadlock test; full background+stability runs pass.
- End-to-end on **live Heroku** infra (PostgreSQL + RabbitMQ + Redis + 4 dynos, celery mode) via the `django-logic-test` harness with binding moved to `apps.py`: the **full TC-01…TC-18 matrix passed, 0 failures** — happy paths, worker crashes, retries, terminal/MAX_ERRORS, phase-1/phase-2 concurrency, broker-loss recovery, watchdog, stuck-finalize, cleanup, and queue isolation. On the deployed slug every bind lives in `apps.py` (none in `models.py`) and the previous lazy in-function model import is gone.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and test layout only; `ProcessManager.bind_model_process` behavior is unchanged. Consumers should move existing import-time binds to `ready()` to avoid circular imports.
> 
> **Overview**
> **Standardises where models attach to processes:** `ProcessManager.bind_model_process(...)` must run only in each app's `AppConfig.ready()` (with model/process imported inside `ready()`), not at import time in `models.py` or `process.py`. That avoids the `model → process → actions → model` circular import (issue #100) so action modules can import models at module top level.
> 
> **No library API change** — `bind_model_process` is unchanged. Updates are docs (`README`, `CLAUDE.md`, Cursor rule, `docs/PLAN.md`, `CHANGELOG`) and test apps: `tests/background` and `tests/stability` centralise all binds in `apps.py`; test-only processes (`ScenarioGuardProcess`, `WidgetChainProcess`) move into `tests/background/models.py`; `test_deadlocks.py` drops runtime rebind and drives `OrderProcessWithNestedCallback` directly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59e8e47a65ce07b9f69a338afef9d754bf4edb94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->