### PR TITLE
Process journey/contract testing: harness, engine contracts, restored coverage, docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1027,6 +1027,19 @@ locking all interact. `django_logic.testing` gives you a **scenario-based** test
 base class that reads like the business process itself and runs everything —
 including background transitions — **inline, with no Celery broker**.
 
+Two principles keep these tests worth writing (full rationale in
+[docs/TESTING_GUIDE.md](docs/TESTING_GUIDE.md#journeys-not-mirrors)):
+
+- **Test your process, not the machinery.** Delivery, retries and durability
+  are the library's guarantees (its own regression + stability + Heroku
+  suites), so your tests never need a broker.
+- **Test the object's journey, not the wiring.** Assert what the object
+  *became* — its state trajectory, the fields the side-effects changed, and
+  what reaches the caller on failure — not merely that a hook you declared got
+  called. A test that only checks "the side-effect ran" passes even when the
+  side-effect does the wrong thing (and an AI regenerating the code regenerates
+  that test too). Journey assertions fail when behaviour regresses.
+
 ```python
 from django_logic.testing import ProcessScenario
 
@@ -1070,6 +1083,27 @@ class TestOrderFulfilment(ProcessScenario):
         order = self.create_instance(status='draft')
         self.assert_available(order, ['approve'], user=self.staff)
         self.assert_not_available(order, ['approve'], user=self.customer)
+
+    def test_approve_produces_the_right_outcome(self):
+        # Assert what the object BECAME, not just that a hook ran.
+        order = self.create_instance(status='draft')
+        before = self.capture(order, ['status', 'approved_at'])
+        self.transition(order, 'approve', user=self.staff)
+        self.assert_side_effects_ran(['validate_order'])        # wiring
+        self.assert_changed(order, before, {                    # outcome
+            'status': ('draft', 'approved'),
+            'approved_at': (None, order.approved_at),
+        })
+
+    def test_fulfil_failure_reaches_the_caller(self):
+        order = self.create_instance(status='approved')
+        # A failing side-effect runs the failure path AND re-raises — pin both.
+        self.background_transition(order, 'fulfil',
+                                   fail_side_effect='call_courier',
+                                   fail_with=ConnectionError('down'),
+                                   expect_raises=ConnectionError)
+        self.assert_state(order, 'fulfilling')                  # left in-progress
+        self.assert_raised(ConnectionError, match='down')
 ```
 
 **Driving the process**
@@ -1081,13 +1115,17 @@ class TestOrderFulfilment(ProcessScenario):
 | `background_transition(obj, action, **kwargs)` | Run a `BackgroundTransition`/`BackgroundAction` phase 1 **and** phase 2 inline |
 | `retry_transition(obj)` | Re-run the instance's uncompleted transition — simulates the periodic starter |
 
-Add `fail_side_effect='name'`, `fail_with=SomeError(...)` to `background_transition`/`retry_transition`/`transition` to make a named side-effect raise. Only that side-effect is wrapped — every other one runs for real, so you exercise the true failure path. The injected exception is absorbed so you can assert on the recorded error.
+Add `fail_side_effect='name'`, `fail_with=SomeError(...)` to `background_transition`/`retry_transition`/`transition` to make a named side-effect raise. Only that side-effect is wrapped — every other one runs for real, so you exercise the true failure path. Add `expect_raises=SomeError` to assert the failure **propagated to the caller** (the `side_effects` re-raise contract), or `expect_raises=False` to assert it was **swallowed** (`callbacks` / `next_transition` / `failure_side_effects`); omit it to absorb the injected exception and assert on the recorded error instead.
 
 **Assertions**
 
-`assert_state` · `assert_available` / `assert_not_available` (optional `user=`) · `assert_side_effects_ran` / `assert_side_effects_not_ran` · `assert_callbacks_ran` · `assert_error_recorded` · `assert_error_count`.
+- *State & availability:* `assert_state` · `assert_state_trace` · `assert_available` / `assert_not_available` (optional `user=`).
+- *Domain outcome* — what the object *became*: `capture` → `assert_changed` / `assert_unchanged` · `assert_related_count`.
+- *Wiring* — that a hook ran (pair with an outcome assertion): `assert_side_effects_ran` / `assert_side_effects_not_ran` · `assert_callbacks_ran` · `assert_failure_side_effects_ran` / `assert_failure_callbacks_ran`.
+- *Caller boundary & durable row:* `assert_raised` / `assert_not_raised` · `assert_error_recorded` · `assert_error_count` · `assert_transition_owner`.
+- *The whole journey:* `assert_journey([JourneyStep(...)])`.
 
-Side-effects and callbacks are **tracked, not mocked** (identified by function `__name__`) — the real code runs; the framework just records what executed.
+Side-effects and callbacks are **tracked, not mocked** (identified by function `__name__`) — the real code runs; the framework just records what executed. `assert_side_effects_ran` / `assert_callbacks_ran` are *wiring* checks (a hook ran, not that it did the right thing) — pair them with `assert_changed` / `assert_related_count` / `assert_state`.
 
 **Snapshot & replay — turn a production bug into a test**
 

--- a/django_logic/testing/__init__.py
+++ b/django_logic/testing/__init__.py
@@ -21,12 +21,13 @@ JSON and rebuild it in a test, turning a production bug into a regression test.
 
 See ``docs/design/TESTING_SCENARIOS.md`` for the full design.
 """
-from django_logic.testing.scenario import ProcessScenario
+from django_logic.testing.scenario import ProcessScenario, JourneyStep
 from django_logic.testing.snapshot import from_snapshot, snapshot, to_json
 from django_logic.testing.tracking import ExecutionTracker
 
 __all__ = [
     'ProcessScenario',
+    'JourneyStep',
     'snapshot',
     'from_snapshot',
     'to_json',

--- a/django_logic/testing/assertions.py
+++ b/django_logic/testing/assertions.py
@@ -7,7 +7,7 @@ Mixed into ``ProcessScenario``; relies on the host providing ``state_field``,
 """
 from __future__ import annotations
 
-from django_logic.testing.runner import latest_message
+from django_logic.testing.runner import latest_message, message_for
 
 
 class ScenarioAssertions:
@@ -139,3 +139,148 @@ class ScenarioAssertions:
                 instance=instance,
             )
         self._record_assert(f'assert_error_count({expected})', ok=True)
+
+    # --- caller-boundary exception (re-raise / swallow contract) ---------
+
+    def assert_raised(self, exc_type=None, *, match=None):
+        """Assert the last drive propagated an exception to the CALLER of the
+        entrypoint — the SideEffects re-raise contract.
+
+        ``exc_type`` optionally constrains the exception class (or tuple of
+        classes); ``match`` optionally requires a substring of ``str(exc)``.
+        Reads the exception the harness captured, so it pins that a failing
+        side-effect surfaces to the caller — a swallow-vs-reraise regression
+        (the 0.1.6->0.2.0 flip) makes this assertion fail.
+        """
+        raised = self._last_raised
+        if raised is None:
+            self._record_assert('assert_raised', ok=False, detail='nothing raised')
+            self._fail(
+                'Expected the drive to propagate an exception to the caller, '
+                'but nothing was raised — a failure that must re-raise was '
+                'swallowed, or no failure occurred.')
+        if exc_type is not None and not isinstance(raised, exc_type):
+            self._record_assert('assert_raised', ok=False,
+                                detail=f'{type(raised).__name__}')
+            self._fail(
+                f'Expected the drive to raise {exc_type}, but it raised '
+                f'{type(raised).__name__}: {raised}.')
+        if match is not None and match not in str(raised):
+            self._record_assert('assert_raised', ok=False,
+                                detail=f'{raised!r} lacks {match!r}')
+            self._fail(
+                f'Expected the raised exception to contain {match!r}, but it '
+                f'was {type(raised).__name__}: {raised}.')
+        self._record_assert('assert_raised', ok=True,
+                            detail=f'{type(raised).__name__}: {raised}')
+
+    def assert_not_raised(self):
+        """Assert the last drive did NOT propagate an exception to the caller
+        — the swallow contract (Callbacks / NextTransition /
+        FailureSideEffects). A regression that starts re-raising a best-effort
+        failure makes this assertion fail."""
+        raised = self._last_raised
+        if raised is not None:
+            self._record_assert('assert_not_raised', ok=False,
+                                detail=f'{type(raised).__name__}: {raised}')
+            self._fail(
+                f'Expected the failure to be swallowed at the caller boundary, '
+                f'but {type(raised).__name__} propagated to the caller: '
+                f'{raised}.')
+        self._record_assert('assert_not_raised', ok=True)
+
+    # --- object journey --------------------------------------------------
+
+    def assert_state_trace(self, expected):
+        """Assert the ordered sequence of states the object passed through
+        during the last drive (in_progress -> target, plus next_transition
+        follow-ups and failed_state writes).
+
+        This is the direct expression of *how the object changed as it went
+        through the action* — e.g. a background chain drive yields
+        ``['fulfilling', 'fulfilled', 'exporting', 'exported']``. Captured
+        by ``track()`` wrapping ``State.set_state``.
+        """
+        trace = list(self._tracker().state_trace)
+        if trace != expected:
+            self._record_assert(f'assert_state_trace({expected})', ok=False,
+                                detail=f'got {trace}')
+            self._fail(
+                f'Expected the object to pass through states {expected}, '
+                f'but the recorded state trace is {trace}.',
+                instance=None,
+            )
+        self._record_assert(f'assert_state_trace({expected})', ok=True,
+                            detail=f'got {trace}')
+
+    def assert_journey(self, expected_steps):
+        """Assert the full ordered journey the object took across all drives
+        in this test. Each ``JourneyStep`` pins one drive's observable
+        transformation (action, before -> after, side-effects, callbacks,
+        failed). One assertion locks the whole end-to-end behaviour."""
+        from django_logic.testing.scenario import JourneyStep
+        actual = self._journey
+        if len(actual) != len(expected_steps):
+            self._record_assert(f'assert_journey({len(expected_steps)} steps)',
+                                ok=False, detail=f'got {len(actual)} steps')
+            self._fail(
+                f'Expected a journey of {len(expected_steps)} steps, but '
+                f'the recorded journey has {len(actual)} steps.',
+                instance=None,
+            )
+        for i, (exp, got) in enumerate(zip(expected_steps, actual), 1):
+            if isinstance(exp, JourneyStep):
+                if not exp.matches(got):
+                    self._record_assert(f'assert_journey(step {i})', ok=False,
+                                        detail=f'expected {exp}, got {got}')
+                    self._fail(
+                        f'Journey step {i} did not match.\n'
+                        f'  expected: {exp}\n'
+                        f'  got:      {got}',
+                        instance=None,
+                    )
+            else:
+                # Allow a plain dict for ergonomics.
+                exp_step = JourneyStep(**exp)
+                if not exp_step.matches(got):
+                    self._record_assert(f'assert_journey(step {i})', ok=False,
+                                        detail=f'expected {exp_step}, got {got}')
+                    self._fail(
+                        f'Journey step {i} did not match.\n'
+                        f'  expected: {exp_step}\n'
+                        f'  got:      {got}',
+                        instance=None,
+                    )
+        self._record_assert(f'assert_journey({len(expected_steps)} steps)',
+                            ok=True)
+
+    # --- background owner (phase-2 restore discriminator) ---------------
+
+    def assert_transition_owner(self, instance, owner, *, transition_name=None):
+        """Assert the recorded ``owning_process_class`` on the instance's
+        latest ``TransitionMessage`` (or the one named ``transition_name``
+        when given). Pins the phase-2 owner discriminator — critical for
+        chained/nested background transitions, where the follow-up must
+        record its OWN owner, not the predecessor's.
+        """
+        if transition_name is not None:
+            tm = message_for(instance, transition_name)
+            label = f'assert_transition_owner({transition_name!r}, {owner!r})'
+        else:
+            tm = latest_message(instance)
+            label = f'assert_transition_owner({owner!r})'
+        actual = None if tm is None else tm.owning_process_class
+        if actual != owner:
+            self._record_assert(label, ok=False,
+                                detail=f'got {actual!r}')
+            if transition_name is None:
+                where = 'the latest TransitionMessage'
+            else:
+                where = f'TransitionMessage for {transition_name!r}'
+            suffix = '' if tm is not None else ' (no TransitionMessage exists.)'
+            self._fail(
+                f'Expected owning_process_class={owner!r} on {where}, '
+                f'but got {actual!r}.{suffix}',
+                instance=instance,
+            )
+        self._record_assert(label, ok=True, detail=f'got {actual!r}')

--- a/django_logic/testing/assertions.py
+++ b/django_logic/testing/assertions.py
@@ -70,6 +70,11 @@ class ScenarioAssertions:
         return self._last_tracker
 
     def assert_side_effects_ran(self, names):
+        """WIRING check: assert the named side-effects executed. This proves
+        the hook is listed and got called — NOT that it produced the right
+        domain change. Pair it with assert_changed / assert_unchanged /
+        assert_related_count (or a direct DB assertion) to pin the OUTCOME the
+        side-effect is supposed to produce (issue #103)."""
         ran = self._tracker().side_effects_ran
         missing = [n for n in names if n not in ran]
         if missing:
@@ -88,6 +93,10 @@ class ScenarioAssertions:
         self._record_assert(f'assert_side_effects_not_ran({names})', ok=True)
 
     def assert_callbacks_ran(self, names):
+        """WIRING check: assert the named callbacks executed — not that they
+        did the right thing. For a callback whose whole purpose is a domain
+        effect (e.g. deleting related rows), also assert the effect with
+        assert_related_count / assert_changed (issue #103)."""
         ran = self._tracker().callbacks_ran
         missing = [n for n in names if n not in ran]
         if missing:
@@ -139,6 +148,89 @@ class ScenarioAssertions:
                 instance=instance,
             )
         self._record_assert(f'assert_error_count({expected})', ok=True)
+
+    # --- domain outcome (before/after delta, issue #103) -----------------
+
+    def capture(self, instance, fields):
+        """Snapshot the named fields of ``instance`` NOW, as a baseline for a
+        later ``assert_changed`` / ``assert_unchanged``. Reads a fresh row
+        from the DB (via ``_base_manager`` so a filtered default manager can't
+        hide it) and does NOT mutate the instance you pass in.
+
+        The point (issue #103): a scenario should assert what the object
+        *became*, not merely that a hook ran. ``capture`` records the "before"
+        so the "after" delta is checkable.
+        """
+        fields = list(fields)
+        fresh = type(instance)._base_manager.get(pk=instance.pk)
+        snap = {f: getattr(fresh, f) for f in fields}
+        self._record('capture', 'OK', f'{fields} = {snap}')
+        return snap
+
+    def assert_changed(self, instance, before, expected):
+        """Assert the domain OUTCOME of the drive: each field in ``expected``
+        (``{field: (old, new)}``) held ``old`` in the ``before`` snapshot and
+        holds ``new`` now. Refreshes ``instance`` from the DB first.
+
+        Unlike ``assert_side_effects_ran`` (a wiring check), this fails if the
+        hook was called but produced the wrong change — the gap issue #103
+        describes.
+        """
+        instance.refresh_from_db()
+        problems = []
+        for field, pair in expected.items():
+            old, new = pair
+            was = before.get(field)
+            now = getattr(instance, field)
+            if was != old:
+                problems.append(
+                    f'{field}: baseline was {was!r}, test expected {old!r}')
+            if now != new:
+                problems.append(f'{field}: is now {now!r}, expected {new!r}')
+        if problems:
+            self._record_assert(f'assert_changed({sorted(expected)})',
+                                ok=False, detail='; '.join(problems))
+            self._fail('Domain outcome did not match:\n  ' +
+                       '\n  '.join(problems), instance=instance)
+        self._record_assert(f'assert_changed({sorted(expected)})', ok=True)
+
+    def assert_unchanged(self, instance, before, fields):
+        """Assert the named fields still hold their ``before`` values — the
+        drive must NOT have touched them (e.g. a failed transition must leave
+        business fields intact). Refreshes ``instance`` from the DB first."""
+        instance.refresh_from_db()
+        problems = []
+        for field in fields:
+            was = before.get(field)
+            now = getattr(instance, field)
+            if was != now:
+                problems.append(f'{field}: {was!r} -> {now!r}')
+        if problems:
+            self._record_assert(f'assert_unchanged({list(fields)})',
+                                ok=False, detail='; '.join(problems))
+            self._fail('Expected these fields to be unchanged, but:\n  ' +
+                       '\n  '.join(problems), instance=instance)
+        self._record_assert(f'assert_unchanged({list(fields)})', ok=True)
+
+    def assert_related_count(self, queryset, expected):
+        """Assert a queryset / related manager currently has ``expected`` rows.
+
+        For a hook whose whole effect is on related tables — a ``delete_*``
+        callback that must drop child rows, a side-effect that must generate
+        N records — this pins the related-row delta the wiring check can't see
+        (issue #103). Pass the queryset AFTER the drive; capture the
+        before-count with ``queryset.count()`` yourself if you need the delta.
+        """
+        actual = queryset.count()
+        if actual != expected:
+            self._record_assert(f'assert_related_count({expected})', ok=False,
+                                detail=f'got {actual}')
+            self._fail(
+                f'Expected {expected} related row(s) for '
+                f'{getattr(queryset, "model", queryset)!r}, but found '
+                f'{actual}.')
+        self._record_assert(f'assert_related_count({expected})', ok=True,
+                            detail=f'count={actual}')
 
     # --- caller-boundary exception (re-raise / swallow contract) ---------
 

--- a/django_logic/testing/runner.py
+++ b/django_logic/testing/runner.py
@@ -78,6 +78,27 @@ def latest_message(instance):
     )
 
 
+def message_for(instance, transition_name):
+    """The instance's most recent ``TransitionMessage`` for a given action.
+
+    Used by ``assert_transition_owner`` to pin the recorded
+    ``owning_process_class`` of a specific transition in a chained/next-
+    transition workflow, where several TMs exist for one instance.
+    """
+    from django_logic.background.models import TransitionMessage
+    return (
+        TransitionMessage.objects
+        .filter(
+            app_label=instance._meta.app_label,
+            model_name=instance._meta.model_name,
+            instance_id=str(instance.pk),
+            transition_name=transition_name,
+        )
+        .order_by('-id')
+        .first()
+    )
+
+
 def rerun_message(message_id):
     """Re-run a specific TransitionMessage inline — what the periodic starter
     does, but synchronous and immediate (ignores the recency guard)."""

--- a/django_logic/testing/scenario.py
+++ b/django_logic/testing/scenario.py
@@ -20,6 +20,7 @@ reproducible snapshot).
 """
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from django.test import TransactionTestCase
 
 from django_logic.testing.assertions import ScenarioAssertions
@@ -37,6 +38,49 @@ from django_logic.testing.snapshot import snapshot as _snapshot
 from django_logic.testing.tracking import track
 
 
+@dataclass
+class JourneyStep:
+    """One observable step of an object's journey through a workflow.
+
+    A *journey* is the ordered sequence of drives a test applied to one
+    instance and what each drive did to it — the action taken, the state
+    before and after, which side-effects/callbacks ran, and whether it
+    failed. ``assert_journey`` pins the whole end-to-end behaviour in one
+    assertion, so a test reads like a business story instead of mirroring
+    framework return values.
+    """
+
+    action: str
+    before: str
+    after: str
+    side_effects: list[str] = field(default_factory=list)
+    callbacks: list[str] = field(default_factory=list)
+    # ``failed`` means an exception PROPAGATED TO THE CALLER of this drive —
+    # not merely that something went wrong internally. SideEffects re-raise
+    # (failed=True); Callbacks / NextTransition / FailureSideEffects swallow
+    # (failed=False even though a hook failed). That distinction is the
+    # re-raise/swallow contract, so pinning ``failed`` in assert_journey
+    # detects a swallow-vs-reraise flip.
+    failed: bool = False
+
+    def matches(self, other: 'JourneyStep') -> bool:
+        return (
+            self.action == other.action
+            and self.before == other.before
+            and self.after == other.after
+            and self.side_effects == other.side_effects
+            and self.callbacks == other.callbacks
+            and self.failed == other.failed
+        )
+
+
+def _exc_names(exc) -> str:
+    """Human-readable name(s) for an expected-exception type or tuple."""
+    if isinstance(exc, tuple):
+        return ' or '.join(getattr(e, '__name__', repr(e)) for e in exc)
+    return getattr(exc, '__name__', repr(exc))
+
+
 class ProcessScenario(ScenarioAssertions, TransactionTestCase):
     """Base class for scenario-based Process tests (no Celery required)."""
 
@@ -50,6 +94,15 @@ class ProcessScenario(ScenarioAssertions, TransactionTestCase):
         super().setUp()
         self._timeline: list[dict] = []
         self._last_tracker = None
+        # The exception (if any) the last drive propagated to the caller of
+        # the entrypoint — None when nothing escaped. Exposed via
+        # assert_raised / assert_not_raised so a failure test can pin the
+        # re-raise/swallow contract at the caller boundary.
+        self._last_raised: BaseException | None = None
+        # The accumulated object journey across all drives in this test —
+        # each transition()/background_transition()/retry_transition() call
+        # appends one JourneyStep (built in _finish). assert_journey pins it.
+        self._journey: list[JourneyStep] = []
 
     # --- internals -------------------------------------------------------
 
@@ -105,24 +158,39 @@ class ProcessScenario(ScenarioAssertions, TransactionTestCase):
     # --- driving the process --------------------------------------------
 
     def transition(self, instance, action, *, fail_side_effect=None,
-                   fail_with=None, **kwargs):
-        """Run a synchronous transition through the normal process entrypoint."""
+                   fail_with=None, expect_raises=None, **kwargs):
+        """Run a synchronous transition through the normal process entrypoint.
+
+        ``expect_raises`` pins the caller-boundary contract:
+
+        * an exception type (or tuple) — assert that exception PROPAGATED to
+          the caller (the SideEffects re-raise contract). Works for both an
+          injected failure and a hook that genuinely raises.
+        * ``False`` — assert NO exception propagated even though a failure
+          occurred (the Callbacks / NextTransition / FailureSideEffects
+          swallow contract).
+        * ``None`` (default) — legacy: an injected failure is absorbed
+          silently; any other exception fails the test loudly.
+        """
         return self._drive(instance, action, background=False,
                            fail_side_effect=fail_side_effect, fail_with=fail_with,
-                           kwargs=kwargs)
+                           expect_raises=expect_raises, kwargs=kwargs)
 
     def background_transition(self, instance, action, *, fail_side_effect=None,
-                             fail_with=None, **kwargs):
+                             fail_with=None, expect_raises=None, **kwargs):
         """Run a BackgroundTransition's phase 1 + phase 2 inline (no Celery).
 
         ``fail_side_effect`` / ``fail_with`` make the named side-effect raise,
-        exercising the real failure path; the injected exception is absorbed so
-        you can assert on the recorded error."""
+        exercising the real failure path. ``expect_raises`` pins the
+        caller-boundary contract exactly as for :meth:`transition`; by default
+        the injected exception is absorbed so you can assert on the recorded
+        error."""
         return self._drive(instance, action, background=True,
                            fail_side_effect=fail_side_effect, fail_with=fail_with,
-                           kwargs=kwargs)
+                           expect_raises=expect_raises, kwargs=kwargs)
 
-    def retry_transition(self, instance, *, fail_side_effect=None, fail_with=None):
+    def retry_transition(self, instance, *, fail_side_effect=None, fail_with=None,
+                         expect_raises=None):
         """Re-run the instance's uncompleted transition inline — what the
         periodic starter would do."""
         tm = uncompleted_message(instance)
@@ -144,12 +212,14 @@ class ProcessScenario(ScenarioAssertions, TransactionTestCase):
                    fail_side_effect=fail_side_effect,
                    fail_with=fail_with) as tracker:
             raised = self._call(lambda: rerun_message(tm.pk))
-        self._finish('retry_transition', instance, tracker, raised, before)
+        self._finish('retry_transition', instance, tracker, raised, before,
+                     action=tm.transition_name, expect_raises=expect_raises)
         return instance
 
     # --- shared execution path ------------------------------------------
 
-    def _drive(self, instance, action, *, background, fail_side_effect, fail_with, kwargs):
+    def _drive(self, instance, action, *, background, fail_side_effect, fail_with,
+               expect_raises, kwargs):
         if not transitions_for(self.process_class, action):
             self._record(f'{"background_" if background else ""}transition({action!r})',
                          'FAILED', 'no such transition')
@@ -171,7 +241,8 @@ class ProcessScenario(ScenarioAssertions, TransactionTestCase):
                 raised = self._call(
                     lambda: getattr(self._process(instance), action)(**kwargs))
         label = f'{"background_" if background else ""}transition({action!r})'
-        self._finish(label, instance, tracker, raised, before)
+        self._finish(label, instance, tracker, raised, before, action=action,
+                     expect_raises=expect_raises)
         return instance
 
     @staticmethod
@@ -182,8 +253,10 @@ class ProcessScenario(ScenarioAssertions, TransactionTestCase):
         except Exception as exc:  # noqa: BLE001 — re-raised below unless injected
             return exc
 
-    def _finish(self, label, instance, tracker, raised, before):
+    def _finish(self, label, instance, tracker, raised, before, *, action=None,
+                expect_raises=None):
         self._last_tracker = tracker
+        self._last_raised = raised
         instance.refresh_from_db()
         after = self._state(instance)
         detail = f'{self.state_field}: {before} -> {after}'
@@ -191,12 +264,47 @@ class ProcessScenario(ScenarioAssertions, TransactionTestCase):
             detail += f'; ran={tracker.side_effects_ran}'
         if tracker.failed_side_effect:
             detail += f'; failed={tracker.failed_side_effect}'
-        # An exception is expected only when it's the one we injected; anything
-        # else is a real, unexpected failure and fails the test loudly.
-        if raised is not None and raised is not tracker.injected_exception:
-            self._record(label, 'FAILED', f'{type(raised).__name__}: {raised}')
-            self._fail(f'{label} raised unexpectedly: '
-                       f'{type(raised).__name__}: {raised}', instance=instance)
+        # Whether an exception reaching the CALLER of the entrypoint was
+        # expected — the re-raise/swallow contract. SideEffects re-raise (the
+        # caller sees the exception); Callbacks / NextTransition /
+        # FailureSideEffects swallow (the caller sees nothing). A failure test
+        # that does not declare which it expects cannot tell the two apart —
+        # the exact blind spot that let the 0.1.6->0.2.0 swallow flip pass.
+        if expect_raises is not None and expect_raises is not False:
+            if raised is None:
+                self._record(label, 'FAILED',
+                             f'expected {_exc_names(expect_raises)} to reach caller')
+                self._fail(
+                    f'{label}: expected {_exc_names(expect_raises)} to '
+                    f'propagate to the caller, but the drive completed without '
+                    f'raising. Either a failure that the contract says must '
+                    f're-raise was swallowed, or no failure occurred.',
+                    instance=instance)
+            elif not isinstance(raised, expect_raises):
+                self._record(label, 'FAILED',
+                             f'{type(raised).__name__} != {_exc_names(expect_raises)}')
+                self._fail(
+                    f'{label}: expected {_exc_names(expect_raises)} to '
+                    f'propagate to the caller, but got '
+                    f'{type(raised).__name__}: {raised}.', instance=instance)
+        elif expect_raises is False:
+            if raised is not None:
+                self._record(label, 'FAILED',
+                             f'{type(raised).__name__} propagated (expected swallow)')
+                self._fail(
+                    f'{label}: expected the failure to be SWALLOWED at the '
+                    f'caller boundary (best-effort callback / follow-up / '
+                    f'failure side-effect), but {type(raised).__name__} '
+                    f'propagated to the caller: {raised}.', instance=instance)
+        else:
+            # Legacy default: an injected exception is expected (absorbed
+            # silently); anything else is a real, unexpected failure and fails
+            # the test loudly. Prefer expect_raises= in new failure tests so
+            # the caller-boundary contract is pinned explicitly.
+            if raised is not None and raised is not tracker.injected_exception:
+                self._record(label, 'FAILED', f'{type(raised).__name__}: {raised}')
+                self._fail(f'{label} raised unexpectedly: '
+                           f'{type(raised).__name__}: {raised}', instance=instance)
         # A requested injection that never fired silently turns a failure
         # test into a happy-path run (issue #94). track() already rejects
         # names that exist nowhere; this catches a hook that exists but did
@@ -213,3 +321,16 @@ class ProcessScenario(ScenarioAssertions, TransactionTestCase):
                 f'the transition completed as a happy path instead of the '
                 f'failure scenario this test intends.', instance=instance)
         self._record(label, 'OK' if raised is None else 'FAILED(injected)', detail)
+        # Record the journey step: the observable transformation this drive
+        # applied to the object. For a background chain the follow-up runs
+        # inside this same drive (one tracker), so its side-effects appear
+        # in the same step and assert_state_trace captures the intermediate
+        # states.
+        self._journey.append(JourneyStep(
+            action=action or label,
+            before=before,
+            after=after,
+            side_effects=list(tracker.side_effects_ran),
+            callbacks=list(tracker.callbacks_ran),
+            failed=raised is not None,
+        ))

--- a/django_logic/testing/tracking.py
+++ b/django_logic/testing/tracking.py
@@ -41,6 +41,12 @@ class ExecutionTracker:
         # injection that never fired (issue #94: a silent no-op would turn
         # a failure test into a happy-path run).
         self.requested_fail_side_effect: str | None = None
+        # Ordered sequence of states written to the instance during this
+        # drive (in_progress -> target, plus any next_transition follow-ups
+        # and failed_state writes). Captured by wrapping State.set_state in
+        # track(); lets a test assert HOW the object changed as the workflow
+        # progressed, not just its final state.
+        self.state_trace: list = []
 
 
 def _name(fn) -> str:
@@ -123,8 +129,28 @@ def track(transitions, *, fail_side_effect=None, fail_with=None):
                 _make_wrapper(fn, tracker, sink_attr, inject_here, fail_with)
                 for fn in original
             ]
+
+    # Record every persisted state write during the drive — the ordered
+    # sequence of states the object passed through (in_progress -> target,
+    # and any next_transition follow-ups, and failed_state on failure).
+    # RedisState.set_state delegates to super(), so wrapping the base
+    # State.set_state captures exactly one append per write for both. The
+    # wrap is restored on exit alongside the hook bundles. Patching the
+    # class method is safe because tests are single-threaded and the patch
+    # is scoped to this contextmanager.
+    from django_logic.state import State as _State
+    original_set_state = _State.set_state
+
+    def _recording_set_state(self, state):
+        result = original_set_state(self, state)
+        tracker.state_trace.append(state)
+        return result
+    _recording_set_state.__name__ = 'set_state'
+    _State.set_state = _recording_set_state
+
     try:
         yield tracker
     finally:
+        _State.set_state = original_set_state
         for bundle, original in saved:
             bundle._commands = original

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -14,6 +14,8 @@ dl/
 └── docs/
     ├── INDEX.md                      ← you are here
     ├── PLAN.md                       ← master execution plan (stages 1–5)
+    ├── TESTING_GUIDE.md              ← how to test your processes:
+    │                                   journeys-not-mirrors + scenario catalog
     │
     ├── design/                       ← active design decisions
     │   ├── BACKGROUND_TRANSITION_ANALYSIS.md   ← chosen design, crash
@@ -51,7 +53,13 @@ For someone new to this project, read in this order:
    `ProcessScenario` API, AI-readable output, state snapshots.
    Primary input for Stage 3.
 
-5. **[research/](research/)** — Historical notes: PR #75 review
+5. **[TESTING_GUIDE.md](TESTING_GUIDE.md)** — The practical how-to for
+   testing your own processes: the *journeys, not mirrors* principle and
+   guardrails, the full scenario catalog (gating, failure paths, the
+   re-raise/swallow contract, domain-outcome assertions, the cross-machine
+   cascade), and the `ProcessScenario` API reference.
+
+6. **[research/](research/)** — Historical notes: PR #75 review
    (Stage 1 complete), race-condition investigation, monitoring ideas.
 
 ---

--- a/docs/TESTING_GUIDE.md
+++ b/docs/TESTING_GUIDE.md
@@ -1,20 +1,91 @@
 # Testing Guide — how to test django-logic processes
 
-> The one rule this whole guide follows: **you test your process, not the
-> background machinery.** Delivery, retries, durability, crash recovery and
-> queue routing are the library's job — guaranteed by its own regression
-> suite, a PostgreSQL + Redis stability suite, and a production-style Heroku
-> validation matrix (see [How the library itself is tested](#how-the-library-itself-is-tested)).
-> Your tests run the *business process* — every transition, condition,
-> permission, failure and retry — **entirely without Celery**.
+> Two rules this whole guide follows:
+>
+> 1. **You test your process, not the background machinery.** Delivery,
+>    retries, durability, crash recovery and queue routing are the library's
+>    job — guaranteed by its own regression suite, a PostgreSQL + Redis
+>    stability suite, and a production-style Heroku validation matrix (see
+>    [How the library itself is tested](#how-the-library-itself-is-tested)).
+>    Your tests run the *business process* **entirely without Celery**.
+> 2. **You test the object's journey, not the wiring.** Assert what the object
+>    *became* as it moved through the process — its state trajectory, the
+>    fields the side-effects changed, and what happens to the caller on failure
+>    — not merely that a hook you declared got called. See
+>    [Journeys, not mirrors](#journeys-not-mirrors).
 
 ## Table of contents
 
-1. [Setup](#setup)
-2. [The scenario catalog](#the-scenario-catalog)
-3. [ProcessScenario API reference](#processscenario-api-reference)
-4. [Testing without ProcessScenario](#testing-without-processscenario)
-5. [How the library itself is tested](#how-the-library-itself-is-tested)
+1. [Journeys, not mirrors](#journeys-not-mirrors)
+2. [Setup](#setup)
+3. [The scenario catalog](#the-scenario-catalog)
+4. [ProcessScenario API reference](#processscenario-api-reference)
+5. [Testing without ProcessScenario](#testing-without-processscenario)
+6. [How the library itself is tested](#how-the-library-itself-is-tested)
+
+---
+
+## Journeys, not mirrors
+
+A process test is only worth writing if it can *fail* when the process
+misbehaves. Two kinds of test live in most FSM suites — one of them can't:
+
+**Mirror tests** restate the definition or the implementation. They assert
+that the transition you declared is available, that the side-effect you listed
+got called, or they `patch` an engine internal and check it was invoked. They
+pass whenever the code and the test were written from the same source — the
+code itself — so a regression that keeps the wiring intact but changes the
+*behaviour* sails straight through. Worse: when an AI regenerates the
+implementation it regenerates the matching mirror test in the same pass, so the
+suite becomes self-fulfilling and prevents nothing.
+
+**Journey tests** drive a real, persisted object through a transition and
+assert what happened *to it*: the state before → after (including the
+in-progress and failed states, not just the happy target), the fields the
+side-effects changed, the order effects ran in, and — on failure — where the
+object landed, which failure hooks ran, and **what reached the caller**. These
+express intent the code doesn't contain, so they still fail when the engine (or
+a refactor, or an AI rewrite) changes behaviour.
+
+> The real-world proof: the `0.1.6 → 0.2.0` upgrade flipped one line
+> (`SideEffects.execute` began swallowing the exception instead of re-raising
+> it), cascading into double failure-hook runs and changed HTTP semantics —
+> while every definition-mirroring test stayed green. A journey test that
+> pinned *"a failing charge must re-raise to the caller"* would have caught it
+> before the upgrade shipped. See `tests/test_exception_semantics.py`.
+
+### The rule for every process test
+
+Assert at least:
+
+1. the **before → after state** of a real, persisted instance;
+2. at least one **field / DB effect** the side-effects produced (via
+   `assert_changed` / `assert_related_count`, or a direct DB read — not a mock);
+3. for any transition with a `failed_state` or failure hooks, one
+   **failure-path** variant showing where the object lands, which failure hooks
+   ran, and — with `expect_raises` — what propagates to the caller.
+
+Mock only true externals (an HTTP client, a courier API, a payment gateway),
+**never the process machinery itself**.
+
+### Guardrails (worth enforcing in review, human or AI)
+
+Reject a process test that:
+
+- **(a)** asserts `get_available_transitions` / the transition list back
+  against the definition instead of asserting *availability behaviour* (a
+  blocked-by-condition or permission-denied journey — see scenarios
+  [2](#2-condition-gating), [3](#3-permission-gating),
+  [14](#14-conditions-in-the-blocking-direction));
+- **(b)** `patch`es any `django_logic` internal (use `fail_side_effect=` to
+  inject a failure into the real path instead);
+- **(c)** contains no assertion against a persisted instance (a test that only
+  checks a module global or a mock can pass while the object is wrong).
+
+`assert_side_effects_ran` / `assert_callbacks_ran` are **wiring** checks — they
+prove a hook was called, not that it did the right thing. Always pair them with
+an outcome assertion (`assert_changed`, `assert_related_count`, `assert_state`,
+or a direct DB read).
 
 ---
 
@@ -151,19 +222,31 @@ def test_only_staff_can_approve(self):
 > denial with an explicit unauthorized user, and make sure your views always
 > pass `user=request.user`.
 
-### 4. Synchronous failure → failed_state + failure hooks
+### 4. Synchronous failure → failed_state + failure hooks + re-raise
 
 Inject a failure into one *named* side-effect — every other side-effect runs
-for real, so the genuine failure path executes.
+for real, so the genuine failure path executes. A synchronous `SideEffects`
+failure runs `fail_transition` (writes `failed_state`, runs the failure hooks)
+and then **re-raises to the caller** — pin that with `expect_raises`.
 
 ```python
 def test_validation_failure_voids_the_order(self):
     order = self.create_instance(status='draft')
     self.transition(order, 'approve',
                     fail_side_effect='validate_order',
-                    fail_with=ValueError('bad address'))
-    self.assert_state(order, 'draft')        # or the failed_state if declared
+                    fail_with=ValueError('bad address'),
+                    expect_raises=ValueError)          # <- the caller sees it
+    self.assert_state(order, 'draft')                  # or failed_state if declared
+    # If approve declared failure hooks, assert they ran:
+    # self.assert_failure_side_effects_ran(['void_reservation'])
+    # self.assert_failure_callbacks_ran(['notify_ops'])
 ```
+
+`expect_raises` is what makes this a journey test rather than a mirror:
+without it the harness absorbs the injected exception, so the test would pass
+whether the engine re-raised or silently swallowed. See
+[scenario 16](#16-the-caller-boundary-re-raise-vs-swallow) for the full
+re-raise/swallow contract.
 
 ### 5. Action — side-effects without a state change
 
@@ -344,6 +427,139 @@ def test_reproduce_stuck_order_12345(self):
     self.assert_state(order, 'fulfilled')
 ```
 
+### 14. Conditions in the *blocking* direction
+
+Most condition tests only prove a transition fires when the condition passes.
+A condition that silently always-returned-`True` would pass every one of those.
+Pin the negative too — the transition must be **refused** when the condition
+does not hold, with the object unchanged:
+
+```python
+def test_partial_fulfilment_cannot_be_marked_fulfilled(self):
+    order = self.create_instance(status='fulfilling')
+    order.lines.create(status='fulfilled')
+    order.lines.create(status='pending')          # not all lines done
+
+    # Unavailable...
+    self.assert_not_available(order, ['mark_fulfilled'])
+    # ...and refused if forced, with no state change.
+    self.transition(order, 'mark_fulfilled',
+                    expect_raises=TransitionNotAllowed)
+    self.assert_state(order, 'fulfilling')
+```
+
+### 15. Asserting the domain outcome (not just that a hook ran)
+
+`assert_side_effects_ran` proves the *wiring*; to pin the *outcome* — what the
+object became — capture a baseline and assert the delta. This is the assertion
+that fails if a side-effect is called but does the wrong thing.
+
+```python
+def test_approve_normalises_and_stamps_the_order(self):
+    order = self.create_instance(status='draft')
+    before = self.capture(order, ['status', 'total', 'approved_at'])
+
+    self.transition(order, 'approve', user=self.staff)
+
+    self.assert_side_effects_ran(['validate_order'])       # wiring
+    self.assert_changed(order, before, {                   # outcome
+        'status': ('draft', 'approved'),
+        'approved_at': (None, order.approved_at),           # now set
+    })
+    self.assert_unchanged(order, before, ['total'])         # must NOT move
+```
+
+For a hook whose whole job is a *related-row* effect (a `delete_*` callback, a
+side-effect that generates N records), assert the row delta directly:
+
+```python
+def test_cancel_deletes_reservations(self):
+    order = self.create_instance(status='approved')
+    order.reservations.create(); order.reservations.create()
+
+    self.transition(order, 'cancel')
+
+    self.assert_callbacks_ran(['release_reservations'])     # wiring
+    self.assert_related_count(order.reservations.all(), 0)  # outcome
+```
+
+### 16. The caller boundary: re-raise vs swallow
+
+The engine treats the four hook families asymmetrically at the *caller
+boundary*, and that asymmetry is exactly what the `0.1.6 → 0.2.0` regression
+flipped. Pin which one each transition relies on:
+
+| Hook | On failure | Assert with |
+|---|---|---|
+| `side_effects` | runs `fail_transition`, then **re-raises** | `expect_raises=Err` / `assert_raised(Err)` |
+| `callbacks` | **swallowed** (best-effort) | `expect_raises=False` / `assert_not_raised()` |
+| `next_transition` follow-up | follow-up failure **swallowed** | `expect_raises=False` |
+| `failure_side_effects` | **swallowed**, does not mask the original | `expect_raises=OriginalErr` |
+
+```python
+def test_side_effect_failure_reaches_the_caller(self):
+    order = self.create_instance(status='approved')
+    self.background_transition(order, 'fulfil',
+                               fail_side_effect='call_courier',
+                               fail_with=ConnectionError('down'),
+                               expect_raises=ConnectionError)
+    self.assert_raised(ConnectionError, match='down')
+
+def test_callback_failure_is_swallowed_and_target_kept(self):
+    order = self.create_instance(status='approved')
+    self.transition(order, 'confirm',
+                    fail_side_effect='send_receipt_email',   # a callback hook
+                    fail_with=SMTPError(),
+                    expect_raises=False)                     # must NOT propagate
+    self.assert_not_raised()
+    self.assert_state(order, 'confirmed')                    # target survives
+```
+
+`expect_raises` accepts an exception type (or tuple) to assert it propagated,
+or `False` to assert nothing did. Leave it out (the legacy default) only when
+you are asserting on the *recorded* error of a background failure rather than
+the caller boundary.
+
+### 17. Pinning the whole journey in one assertion
+
+`assert_state_trace` pins the ordered states the object passed through;
+`assert_journey` pins each drive's full observable transformation — action,
+before → after, side-effects, callbacks, and whether it reached the caller.
+
+```python
+from django_logic.testing import JourneyStep
+
+def test_fulfilment_journey(self):
+    order = self.create_instance(status='approved')
+    self.background_transition(order, 'fulfil')
+
+    # Every state the object moved through (in-progress -> target, chains, …):
+    self.assert_state_trace(['fulfilling', 'fulfilled'])
+
+    # The whole end-to-end story as one assertion:
+    self.assert_journey([
+        JourneyStep(action='fulfil', before='approved', after='fulfilled',
+                    side_effects=['reserve_stock', 'call_courier'],
+                    callbacks=['send_confirmation_email'],
+                    failed=False),
+    ])
+```
+
+`JourneyStep.failed` means *an exception propagated to the caller* — so a
+failure-path `assert_journey(..., failed=True)` alone detects a
+swallow-vs-reraise flip.
+
+### 18. The cross-machine cascade (anti-pattern contract)
+
+If a side-effect drives a transition on *another* instance and lets its
+exception propagate (the "fundamental problem" anti-pattern — see
+[docs/recipes/nested-processes.md](recipes/nested-processes.md) for the correct
+fan-out alternative), that behaviour is worth pinning as one journey so a
+refactor can't silently change it: the inner machine lands in its
+`failed_state` with its failure hooks run, the outer's later side-effects are
+skipped, and the exception reaches the caller. See
+`tests/test_cross_machine_cascade.py` for a worked contract test.
+
 ---
 
 ## ProcessScenario API reference
@@ -363,24 +579,59 @@ snapshot).
 | `retry_transition(obj)` | Re-run the instance's uncompleted `TransitionMessage` — simulates the periodic starter. |
 | `snapshot(obj)` / `from_snapshot(data_or_path)` | Capture / rebuild instance + `TransitionMessage` state. |
 
-`transition`, `background_transition` and `retry_transition` all accept
-`fail_side_effect='name'` + `fail_with=SomeError(...)`: only the named
-side-effect is wrapped to raise; everything else runs for real, and the
-injected exception is absorbed so you can assert on the recorded outcome.
-Any *other* (unexpected) exception fails the test loudly.
+`transition`, `background_transition` and `retry_transition` all accept:
+
+- `fail_side_effect='name'` + `fail_with=SomeError(...)` — only the named
+  side-effect is wrapped to raise; everything else runs for real. Any *other*
+  (unexpected) exception fails the test loudly.
+- `expect_raises=` — pin the caller boundary. An **exception type** (or tuple)
+  asserts it propagated to the caller (the `SideEffects` re-raise contract);
+  **`False`** asserts nothing propagated (the swallow contract). Omitted (the
+  legacy default), an injected failure is absorbed so you can assert on the
+  *recorded* error instead. See [scenario 16](#16-the-caller-boundary-re-raise-vs-swallow).
 
 **Assertions**
+
+*State & availability*
 
 | Assertion | Checks |
 |---|---|
 | `assert_state(obj, expected)` | The persisted state field. |
-| `assert_available(obj, actions, user=None)` | Actions currently offered by `get_available_actions`. |
-| `assert_not_available(obj, actions, user=None)` | Actions not offered. |
+| `assert_state_trace(states)` | The ordered states the object passed through in the last drive (in-progress → target, `next_transition` follow-ups, `failed_state`). |
+| `assert_available(obj, actions, user=None)` / `assert_not_available(...)` | Actions offered / not offered by `get_available_actions` — test availability *behaviour*, not the definition. |
+
+*Domain outcome (assert what the object became)*
+
+| Assertion | Checks |
+|---|---|
+| `capture(obj, fields)` | Snapshot named fields as a baseline (DB-fresh; does not mutate `obj`). Returns a dict for the asserts below. |
+| `assert_changed(obj, before, {field: (old, new)})` | Each field held `old` before and holds `new` now — fails if a hook ran but produced the wrong change. |
+| `assert_unchanged(obj, before, fields)` | The named fields still hold their `before` values. |
+| `assert_related_count(queryset, n)` | A queryset / related manager currently has `n` rows (for `delete_*` / generate-style hooks). |
+
+*Wiring (a hook ran — pair with an outcome assertion above)*
+
+| Assertion | Checks |
+|---|---|
 | `assert_side_effects_ran(names)` / `assert_side_effects_not_ran(names)` | Which side-effects executed in the last tracked drive (by function `__name__` — tracked, not mocked: the real code ran). Tracking covers the whole process tree, including `next_transition` follow-ups. |
 | `assert_callbacks_ran(names)` | Which callbacks executed. |
 | `assert_failure_side_effects_ran(names)` / `assert_failure_callbacks_ran(names)` | Which failure hooks executed (for failure-path scenarios). |
+
+*Caller boundary & durable row*
+
+| Assertion | Checks |
+|---|---|
+| `assert_raised(exc_type=None, match=None)` | The last drive propagated an exception to the caller (optionally of a type / containing a substring). |
+| `assert_not_raised()` | The last drive propagated nothing (the swallow contract). |
 | `assert_error_recorded(obj, contains)` | Substring of `last_error_message` on the latest `TransitionMessage`. |
 | `assert_error_count(obj, expected)` | `errors_count` on the latest `TransitionMessage`. |
+| `assert_transition_owner(obj, cls, transition_name=None)` | The `owning_process_class` recorded on a `TransitionMessage` (for chained / condition-disambiguated background transitions). |
+
+*The whole journey*
+
+| Assertion | Checks |
+|---|---|
+| `assert_journey([JourneyStep(...)])` | Each drive's full observable transformation — action, before → after, side-effects, callbacks, and `failed` (an exception reached the caller). Import `JourneyStep` from `django_logic.testing`. |
 
 On failure, every assertion raises with a numbered timeline of each step the
 test took, the relevant `TransitionMessage`, and (opt-in) a snapshot — built
@@ -440,14 +691,19 @@ You don't have to take the durability contract on faith — this is the test
 pyramid backing it:
 
 1. **Unit + regression suite** (`python tests/manage.py test`, SQLite,
-   ~310 tests): every reproduced defect from the 0.3 stability review has a
+   ~340 tests): every reproduced defect from the 0.3 stability review has a
    permanent regression test — savepoint isolation of side-effects
    (`tests/background/test_savepoint_isolation.py`), the phase-2 state guard
    (`test_phase2_state_guard.py`), the per-process in-flight constraint
    (`test_constraint_per_process.py`), restore verification
    (`test_restore_verification.py`), sync/background mutual exclusion
    (`test_sync_background_mutex.py`), and lock revalidation
-   (`tests/test_lock_revalidate.py`).
+   (`tests/test_lock_revalidate.py`). The engine's *behavioural contracts* are
+   pinned as journey tests too: the re-raise/swallow asymmetry
+   (`tests/test_exception_semantics.py`), the cross-machine failure cascade
+   (`tests/test_cross_machine_cascade.py`), and process-level
+   conditions/permissions (`tests/test_process_guards.py`) — each verified by
+   mutation to fail on the exact regression it names.
 2. **PostgreSQL + Redis stability suite** (`make stability-up &&
    make stability-test`, also a GitHub Actions workflow on every PR and
    nightly): real row locking, real concurrent transactions, deadlock and

--- a/tests/background/apps.py
+++ b/tests/background/apps.py
@@ -17,16 +17,26 @@ class BackgroundTestsConfig(AppConfig):
             AmbiguousConversationProcess,
             ArchivableProcess,
             ArchivableWidget,
+            CascadeInnerProcess,
+            CascadeOuterProcess,
+            ChainConversationProcess,
             Conversation,
             ConversationProcess,
             MixedSyncBgProcess,
             ScenarioGuardProcess,
             SharedActionConversationProcess,
             Widget,
+            WidgetAmbiguousConditionProcess,
+            WidgetAmbiguousNextProcess,
             WidgetAuditProcess,
+            WidgetBgChainProcess,
             WidgetChainProcess,
+            WidgetContextProcess,
+            WidgetNestedSyncProcess,
             WidgetParentProcess,
             WidgetProcess,
+            WidgetProcGuardProcess,
+            WidgetSyncProcess,
         )
 
         ProcessManager.bind_model_process(Widget, WidgetProcess, state_field='status')
@@ -40,3 +50,17 @@ class BackgroundTestsConfig(AppConfig):
         # Test-local processes attached to Widget (see models.py).
         ProcessManager.bind_model_process(Widget, ScenarioGuardProcess, state_field='status')
         ProcessManager.bind_model_process(Widget, WidgetChainProcess, state_field='status')
+        # Behavior-focused scenario fixtures (sync matrix + bg->bg chain +
+        # context chain + nested sync delegation).
+        ProcessManager.bind_model_process(Widget, WidgetSyncProcess, state_field='status')
+        ProcessManager.bind_model_process(Widget, WidgetBgChainProcess, state_field='status')
+        ProcessManager.bind_model_process(Widget, WidgetContextProcess, state_field='status')
+        ProcessManager.bind_model_process(Widget, WidgetNestedSyncProcess, state_field='status')
+        ProcessManager.bind_model_process(Widget, WidgetAmbiguousNextProcess, state_field='status')
+        ProcessManager.bind_model_process(Conversation, ChainConversationProcess, state_field='status')
+        # Contract fixtures: resolve-time ambiguity, process-level guards, and
+        # the cross-machine failure cascade (fundamental problem.md §3).
+        ProcessManager.bind_model_process(Widget, WidgetAmbiguousConditionProcess, state_field='status')
+        ProcessManager.bind_model_process(Widget, WidgetProcGuardProcess, state_field='status')
+        ProcessManager.bind_model_process(Widget, CascadeOuterProcess, state_field='status')
+        ProcessManager.bind_model_process(Widget, CascadeInnerProcess, state_field='status')

--- a/tests/background/models.py
+++ b/tests/background/models.py
@@ -8,7 +8,7 @@ loaded, so it is the single supported binding site.
 """
 from django.db import models
 
-from django_logic import Process, Transition
+from django_logic import Action, Process, Transition
 from django_logic.background import BackgroundAction, BackgroundTransition
 
 
@@ -590,4 +590,512 @@ class WidgetChainProcess(Process):
             target='notified',
             side_effects=[chain_followup],
         ),
+    ]
+
+
+# --- Scenario behavior fixtures (behavior-focused process tests) ----------
+# Processes that exercise the sync Transition/Action matrix and the
+# background->background next_transition chain, driven through the real
+# Process entrypoint by ProcessScenario tests. Observables are se_log/cb_log
+# (appended markers) so tests assert on how the OBJECT changes, not on
+# framework return values. Bound in tests/background/apps.py (the single
+# binding site) under distinct process_names on Widget/Conversation.
+
+
+def _se(marker):
+    """Side-effect factory: append ``marker`` to se_log. __name__ is stable
+    so track()/assert_side_effects_ran can name it."""
+    def fn(instance, **kwargs):
+        instance.se_log = (instance.se_log or '') + marker + ','
+        instance.save(update_fields=['se_log'])
+    fn.__name__ = f'se_{marker}'
+    return fn
+
+
+def _cb(marker):
+    """Callback factory: append ``marker`` to cb_log."""
+    def fn(instance, **kwargs):
+        instance.cb_log = (instance.cb_log or '') + marker + ','
+        instance.save(update_fields=['cb_log'])
+    fn.__name__ = f'cb_{marker}'
+    return fn
+
+
+# Module-global observables for behaviors that se_log/cb_log can't express:
+# failure-hook ordering across the fse/fcb boundary, and kwargs capture.
+SYNC_ORDER: list = []
+SYNC_LAST_KWARGS: dict = {}
+
+
+def _fse(marker):
+    """Failure-side-effect: append ``fse_<marker>`` to se_log AND record the
+    cross-hook ordering in SYNC_ORDER (so a test can assert fse runs before
+    fcb)."""
+    def fn(instance, **kwargs):
+        instance.se_log = (instance.se_log or '') + 'fse_' + marker + ','
+        instance.save(update_fields=['se_log'])
+        SYNC_ORDER.append(f'fse:{marker}')
+    fn.__name__ = f'fse_{marker}'
+    return fn
+
+
+def _fcb(marker):
+    """Failure-callback: append ``fcb_<marker>`` to cb_log AND record the
+    cross-hook ordering in SYNC_ORDER."""
+    def fn(instance, **kwargs):
+        instance.cb_log = (instance.cb_log or '') + 'fcb_' + marker + ','
+        instance.save(update_fields=['cb_log'])
+        SYNC_ORDER.append(f'fcb:{marker}')
+    fn.__name__ = f'fcb_{marker}'
+    return fn
+
+
+def sync_boom(instance, **kwargs):
+    """Side-effect that always raises — the injection target for failure
+    tests (fail_side_effect='sync_boom')."""
+    raise ValueError('sync boom')
+
+
+def sync_cb_boom(instance, **kwargs):
+    """Callback that always raises — proves a callback exception is
+    swallowed (best-effort) and the target state is kept."""
+    raise ValueError('callback boom')
+
+
+def sync_capture(instance, **kwargs):
+    """Side-effect that records the kwargs it received into SYNC_LAST_KWARGS
+    so a test can assert on kwargs forwarding / transition-context chaining."""
+    instance.se_log = (instance.se_log or '') + 'captured,'
+    instance.save(update_fields=['se_log'])
+    SYNC_LAST_KWARGS.clear()
+    SYNC_LAST_KWARGS.update(kwargs)
+
+
+def sync_capture_fail(instance, exception, **kwargs):
+    """Failure-callback that records kwargs + the exception, so a test can
+    assert failure hooks receive the ``exception`` kwarg and forwarded args."""
+    SYNC_LAST_KWARGS.clear()
+    SYNC_LAST_KWARGS.update(kwargs)
+    SYNC_LAST_KWARGS['exception'] = exception
+
+
+# Separate sink for the failure-SIDE-EFFECT exception/kwarg contract, so it is
+# asserted independently of the failure-CALLBACK sink above.
+SYNC_FSE_KWARGS: dict = {}
+
+
+def sync_capture_fse(instance, exception=None, **kwargs):
+    """Failure-side-effect that records the ``exception`` kwarg + forwarded
+    caller kwargs. Pins that failure_side_effects (not just failure_callbacks)
+    receive the original exception and the caller's kwargs."""
+    SYNC_FSE_KWARGS.clear()
+    SYNC_FSE_KWARGS.update(kwargs)
+    SYNC_FSE_KWARGS['exception'] = exception
+
+
+def sync_fse_boom(instance, exception=None, **kwargs):
+    """Failure-side-effect that itself raises. Pins that a raising
+    failure_side_effect is swallowed (does not mask the ORIGINAL exception,
+    which still re-raises to the caller)."""
+    raise RuntimeError('sync cleanup exploded')
+
+
+# Callback that records the persisted state visible AT CALLBACK TIME, proving
+# the target is written before callbacks run. Reads a fresh row from the DB so
+# it observes the persisted write, not an in-memory attribute.
+CALLBACK_SEEN_STATE: list = []
+
+
+def cb_record_seen_state(instance, **kwargs):
+    from_db = type(instance).objects.get(pk=instance.pk)
+    CALLBACK_SEEN_STATE.append(from_db.status)
+    instance.cb_log = (instance.cb_log or '') + 'seen_state,'
+    instance.save(update_fields=['cb_log'])
+
+
+def _always(instance, **kwargs):
+    return True
+
+
+def _flagged(instance, **kwargs):
+    return 'flag' in (instance.kwargs_seen or [])
+
+
+def _not_flagged(instance, **kwargs):
+    return 'flag' not in (instance.kwargs_seen or [])
+
+
+def _is_staff_user(instance, user=None, **kwargs):
+    return bool(user and getattr(user, 'is_staff', False))
+
+
+class WidgetSyncProcess(Process):
+    """Sync Transition/Action matrix on Widget.status, bound as ``sync_proc``.
+
+    Covers: ordered side-effects + next_transition chaining, the failure
+    path (failed_state + failure_side_effects + failure_callbacks), a sync
+    Action (no state change on success; failed_state only when unlocked),
+    a swallowed callback exception, same-action-name disambiguation by
+    condition, a permission gate, and kwargs forwarding / failure-hook
+    exception contract.
+    """
+
+    process_name = 'sync_proc'
+    transitions = [
+        Transition('approve', sources=['draft'], target='approved',
+                   side_effects=[_se('a'), _se('b')],
+                   callbacks=[_cb('after_approve')],
+                   next_transition='notify'),
+        Transition('notify', sources=['approved'], target='notified',
+                   side_effects=[_se('c')]),
+        Transition('reject', sources=['draft'], target='rejected',
+                   failed_state='rejection_failed',
+                   side_effects=[_se('reject_attempt')],
+                   failure_side_effects=[_fse('cleanup')],
+                   failure_callbacks=[_fcb('on_fail')]),
+        # Target is written before callbacks run, so a raising callback is
+        # swallowed and the target state survives.
+        Transition('boom_callback', sources=['draft'], target='boom_done',
+                   callbacks=[sync_cb_boom]),
+        Action('poke', sources=['draft'],
+               side_effects=[_se('poke')],
+               callbacks=[_cb('after_poke')]),
+        Action('poke_fail', sources=['draft'], failed_state='poked_failed',
+               side_effects=[_se('poke_attempt')],
+               failure_callbacks=[_fcb('on_poke_fail')]),
+        Transition('cancel', sources=['draft'], target='cancelled',
+                   conditions=[_not_flagged],
+                   side_effects=[_se('cancel_plain')]),
+        Transition('cancel', sources=['draft'], target='archived',
+                   conditions=[_flagged],
+                   side_effects=[_se('cancel_flagged')]),
+        Transition('staff_only', sources=['draft'], target='staffed',
+                   permissions=[_is_staff_user],
+                   side_effects=[_se('staff')]),
+        # kwargs forwarding + failure-hook exception contract.
+        Transition('capture', sources=['draft'], target='captured',
+                   side_effects=[sync_capture]),
+        Transition('capture_fail', sources=['draft'], target='captured',
+                   failed_state='capture_failed',
+                   side_effects=[sync_boom],
+                   failure_side_effects=[sync_capture_fse],
+                   failure_callbacks=[sync_capture_fail]),
+        # Callback ordering: the target is persisted BEFORE callbacks run.
+        Transition('finalize', sources=['draft'], target='finalized',
+                   side_effects=[_se('finalize')],
+                   callbacks=[cb_record_seen_state]),
+        # A raising failure_side_effect must be swallowed and must NOT mask the
+        # ORIGINAL side-effect exception, which still re-raises to the caller.
+        Transition('reject_bad_cleanup', sources=['draft'], target='rbc_done',
+                   failed_state='rbc_failed',
+                   side_effects=[sync_boom],
+                   failure_side_effects=[sync_fse_boom],
+                   failure_callbacks=[_fcb('rbc')]),
+    ]
+
+
+class WidgetContextProcess(Process):
+    """Two-step sync chain on Widget.status, bound as ``ctx_proc``, for
+    asserting next_transition mints a fresh tr_id and chains root_id /
+    parent_id across the follow-up. The follow-up captures its kwargs into
+    SYNC_LAST_KWARGS via sync_capture."""
+
+    process_name = 'ctx_proc'
+    transitions = [
+        Transition('parent_act', sources=['draft'], target='parent_done',
+                   side_effects=[_se('parent')], next_transition='child_act'),
+        Transition('child_act', sources=['parent_done'], target='child_done',
+                   side_effects=[sync_capture]),
+    ]
+
+
+class InnerSyncProcess(Process):
+    """Nested sub-process owning a sync transition, reached only via its
+    parent's ``nested_processes`` — proves the parent entrypoint drives a
+    nested transition behaviorally."""
+
+    process_name = 'inner_sync'
+    transitions = [
+        Transition('inner_act', sources=['draft'], target='inner_done',
+                   side_effects=[_se('inner')]),
+    ]
+
+
+class WidgetNestedSyncProcess(Process):
+    """Parent (``nested_sync``) delegating to :class:`InnerSyncProcess`."""
+
+    process_name = 'nested_sync'
+    nested_processes = [InnerSyncProcess]
+
+
+class WidgetAmbiguousNextProcess(Process):
+    """``start`` chains into ``follow``, but TWO ``follow`` transitions are
+    available from ``started`` with no disambiguating condition. The
+    follow-up must be REFUSED (neither runs) rather than picking one
+    arbitrarily — the behavior the old mock-based next_transition test
+    pinned, now expressed through the entrypoint on a real object."""
+
+    process_name = 'ambig_next'
+    transitions = [
+        Transition('start', sources=['draft'], target='started',
+                   side_effects=[_se('start')], next_transition='follow'),
+        Transition('follow', sources=['started'], target='a_done',
+                   side_effects=[_se('follow_a')]),
+        Transition('follow', sources=['started'], target='b_done',
+                   side_effects=[_se('follow_b')]),
+    ]
+
+
+class WidgetBgChainProcess(Process):
+    """Background -> background next_transition chain on Widget.status,
+    bound as ``bg_chain``.
+
+    ``bg_fulfil`` completes into ``bg_export`` via next_transition. This is
+    the regression fixture for the untested owner-overwrite path: the
+    follow-up TransitionMessage must record its OWN owner, not the
+    predecessor's, and the object must pass through every intermediate
+    state (chain_fulfilling -> fulfilled -> chain_exporting -> exported).
+    """
+
+    process_name = 'bg_chain'
+    transitions = [
+        BackgroundTransition('bg_fulfil', sources=['draft'], target='fulfilled',
+                             in_progress_state='chain_fulfilling',
+                             failed_state='chain_fulfil_failed',
+                             queue='django_logic.critical',
+                             side_effects=[_se('bg_fulfil_se')],
+                             next_transition='bg_export'),
+        BackgroundTransition('bg_export', sources=['fulfilled'], target='exported',
+                             in_progress_state='chain_exporting',
+                             failed_state='chain_export_failed',
+                             queue='django_logic.slow',
+                             side_effects=[_se('bg_export_se')],
+                             callbacks=[_cb('bg_export_cb')]),
+    ]
+
+
+# Nested condition-disambiguated background chain on Conversation. Each
+# integration owns a bg ``send`` (open -> open) that chains into a bg
+# ``report`` (open -> reported) via next_transition. The follow-up must
+# record the NESTED owning class (Gmail/Dummy), not the bound parent and
+# not the predecessor — the riskiest owner-overwrite case for issue #98.
+
+
+def chain_is_gmail(instance, **kwargs):
+    return instance.source_integration == 'gmail'
+
+
+def chain_is_dummy(instance, **kwargs):
+    return instance.source_integration == 'dummy'
+
+
+def chain_gmail_send(instance, **kwargs):
+    instance.se_log = (instance.se_log or '') + 'gmail_send,'
+    instance.save(update_fields=['se_log'])
+
+
+def chain_gmail_report(instance, **kwargs):
+    instance.se_log = (instance.se_log or '') + 'gmail_report,'
+    instance.save(update_fields=['se_log'])
+
+
+def chain_dummy_send(instance, **kwargs):
+    instance.se_log = (instance.se_log or '') + 'dummy_send,'
+    instance.save(update_fields=['se_log'])
+
+
+def chain_dummy_report(instance, **kwargs):
+    instance.se_log = (instance.se_log or '') + 'dummy_report,'
+    instance.save(update_fields=['se_log'])
+
+
+class GmailChainProcess(Process):
+    process_name = 'gmail_chain'
+    transitions = [
+        BackgroundTransition('send', sources=['open'], target='open',
+                             in_progress_state='gmail_chain_sending',
+                             failed_state='gmail_chain_send_failed',
+                             conditions=[chain_is_gmail],
+                             queue='django_logic.critical',
+                             side_effects=[chain_gmail_send],
+                             next_transition='report'),
+        BackgroundTransition('report', sources=['open'], target='reported',
+                             in_progress_state='gmail_chain_reporting',
+                             failed_state='gmail_chain_report_failed',
+                             conditions=[chain_is_gmail],
+                             queue='django_logic.slow',
+                             side_effects=[chain_gmail_report]),
+    ]
+
+
+class DummyChainProcess(Process):
+    process_name = 'dummy_chain'
+    transitions = [
+        BackgroundTransition('send', sources=['open'], target='open',
+                             in_progress_state='dummy_chain_sending',
+                             failed_state='dummy_chain_send_failed',
+                             conditions=[chain_is_dummy],
+                             queue='django_logic.critical',
+                             side_effects=[chain_dummy_send],
+                             next_transition='report'),
+        BackgroundTransition('report', sources=['open'], target='reported',
+                             in_progress_state='dummy_chain_reporting',
+                             failed_state='dummy_chain_report_failed',
+                             conditions=[chain_is_dummy],
+                             queue='django_logic.slow',
+                             side_effects=[chain_dummy_report]),
+    ]
+
+
+class ChainConversationProcess(Process):
+    """Bound parent (``chain_conv``) delegating to per-integration nested
+    bg chain processes. Generic callers invoke ``conversation.chain_conv.send()``
+    and conditions route to the right integration's chain."""
+
+    process_name = 'chain_conv'
+    nested_processes = [GmailChainProcess, DummyChainProcess]
+
+
+# --- Ambiguous same-action-name transitions with OVERLAPPING conditions -----
+# Two synchronous 'clash' transitions whose conditions BOTH pass. The resolve
+# step must refuse (raise TransitionNotAllowed) rather than pick one — with no
+# state write and no side-effect. Pins the resolve-time ambiguity contract that
+# the previous test only claimed to (it never actually created ambiguity).
+
+
+class WidgetAmbiguousConditionProcess(Process):
+    process_name = 'ambig_cond'
+    transitions = [
+        Transition('clash', sources=['draft'], target='clash_a',
+                   conditions=[_always], side_effects=[_se('clash_a')]),
+        Transition('clash', sources=['draft'], target='clash_b',
+                   conditions=[_always], side_effects=[_se('clash_b')]),
+    ]
+
+
+# --- Process-level conditions & permissions (Process.is_valid) ---------------
+# A process-level condition/permission gates the WHOLE process — its own
+# transitions AND every nested process's transitions — because
+# _iter_available_with_owner short-circuits the entire subtree when
+# is_valid(user) is False. These fixtures restore the class-level guard
+# coverage (and the nested-inheritance case) that the migration dropped.
+
+
+def process_gate_open(instance, **kwargs):
+    """Process-level condition: the process is inert unless the instance is
+    flagged 'gate_open'. Gates the class's own transitions and its nested
+    process's transitions alike."""
+    return 'gate_open' in (instance.kwargs_seen or [])
+
+
+def process_requires_staff(instance, user=None, **kwargs):
+    """Process-level permission: no transition is available/allowed without a
+    staff user. (Per the engine contract, a permission is only enforced when a
+    user is supplied; user=None means 'no user context'.)"""
+    return bool(user and getattr(user, 'is_staff', False))
+
+
+class GuardedInnerProcess(Process):
+    """Nested process with NO guards of its own — reached only through the
+    guarded parent, so the parent's process-level guard is what gates it."""
+
+    process_name = 'guarded_inner'
+    transitions = [
+        Transition('inner_go', sources=['draft'], target='inner_gone',
+                   side_effects=[_se('inner_go')]),
+    ]
+
+
+class WidgetProcGuardProcess(Process):
+    """Bound as ``proc_guard``. Class-level ``conditions`` + ``permissions``
+    gate BOTH ``go`` and the nested ``inner_go``."""
+
+    process_name = 'proc_guard'
+    conditions = [process_gate_open]
+    permissions = [process_requires_staff]
+    transitions = [
+        Transition('go', sources=['draft'], target='gone',
+                   side_effects=[_se('go')]),
+    ]
+    nested_processes = [GuardedInnerProcess]
+
+
+# --- Cross-machine failure cascade (fundamental problem.md §3) ---------------
+# THE ANTI-PATTERN, pinned so an engine change can't silently alter it: an
+# outer transition's side-effect drives a transition on a DIFFERENT instance
+# (a second state machine) and lets that inner failure propagate. The cascade
+# then is: inner lands in its failed_state with inner failure hooks run -> the
+# exception propagates -> outer's fail_transition runs (outer -> its
+# failed_state, outer failure hooks run) -> outer's side-effects declared AFTER
+# the nested call are SKIPPED -> outer's success callbacks are SKIPPED -> the
+# exception reaches the caller of the outer transition. This is exactly the
+# 0.1.6->0.2.0 cascade; one journey test locks every leg of it.
+
+CASCADE_ORDER: list = []
+
+
+def cascade_inner_boom(instance, **kwargs):
+    CASCADE_ORDER.append('inner:side_effect')
+    raise ValueError('inner machine failed')
+
+
+def cascade_inner_fcb(instance, exception=None, **kwargs):
+    CASCADE_ORDER.append('inner:failure_callback')
+    instance.cb_log = (instance.cb_log or '') + 'inner_fcb,'
+    instance.save(update_fields=['cb_log'])
+
+
+class CascadeInnerProcess(Process):
+    process_name = 'cascade_inner'
+    transitions = [
+        Transition('inner_fulfil', sources=['draft'], target='inner_done',
+                   failed_state='inner_failed',
+                   side_effects=[cascade_inner_boom],
+                   failure_callbacks=[cascade_inner_fcb]),
+    ]
+
+
+def cascade_outer_before(instance, **kwargs):
+    CASCADE_ORDER.append('outer:before')
+    instance.se_log = (instance.se_log or '') + 'outer_before,'
+    instance.save(update_fields=['se_log'])
+
+
+def cascade_call_inner(instance, inner_pk=None, **kwargs):
+    """The anti-pattern: a side-effect drives another machine's transition and
+    lets its exception propagate (never re-raise a child error into a parent —
+    see CLAUDE.md rule 3). The inner pk is forwarded as a caller kwarg."""
+    CASCADE_ORDER.append('outer:call_inner')
+    Widget.objects.get(pk=inner_pk).cascade_inner.inner_fulfil()
+
+
+def cascade_outer_after(instance, **kwargs):
+    # Declared AFTER the nested call; must be SKIPPED once it raises.
+    CASCADE_ORDER.append('outer:after')
+    instance.se_log = (instance.se_log or '') + 'outer_after,'
+    instance.save(update_fields=['se_log'])
+
+
+def cascade_outer_cb(instance, **kwargs):
+    # Success callback; must NOT run when the transition fails.
+    CASCADE_ORDER.append('outer:success_callback')
+    instance.cb_log = (instance.cb_log or '') + 'outer_cb,'
+    instance.save(update_fields=['cb_log'])
+
+
+def cascade_outer_fcb(instance, exception=None, **kwargs):
+    CASCADE_ORDER.append('outer:failure_callback')
+    instance.cb_log = (instance.cb_log or '') + 'outer_fcb,'
+    instance.save(update_fields=['cb_log'])
+
+
+class CascadeOuterProcess(Process):
+    process_name = 'cascade_outer'
+    transitions = [
+        Transition('outer_fulfil', sources=['draft'], target='outer_done',
+                   failed_state='outer_failed',
+                   side_effects=[cascade_outer_before, cascade_call_inner,
+                                 cascade_outer_after],
+                   callbacks=[cascade_outer_cb],
+                   failure_callbacks=[cascade_outer_fcb]),
     ]

--- a/tests/background/test_bg_chain.py
+++ b/tests/background/test_bg_chain.py
@@ -1,0 +1,206 @@
+"""Issue #98 follow-up: background -> background ``next_transition`` chaining.
+
+The ``owning_process_class`` overwrite in ``Process._get_transition_method``
+(process.py) exists specifically for the chained-``next_transition`` case:
+a follow-up transition forwards the predecessor's kwargs, and the owner
+must be re-resolved to the follow-up's own declaring process — not
+inherited. Until now this path had **no test**: the only ``next_transition``
+fixture was sync -> sync (``WidgetChainProcess``).
+
+These scenarios drive the real object through the whole chain via the
+``Process`` entrypoint (no mocks, no ``change_state`` patching) and assert
+on the observable transformation — the full state trace, the side-effects
+that ran, and the per-transition ``owning_process_class`` recorded on each
+``TransitionMessage``.
+
+Two cases:
+
+1. A flat ``WidgetBgChainProcess``: ``bg_fulfil`` -> ``bg_export``. The
+   follow-up TM must record ``WidgetBgChainProcess`` (not the
+   predecessor's), and the object must pass through every intermediate
+   state.
+
+2. A nested condition-disambiguated ``ChainConversationProcess``: a
+   per-integration nested bg ``send`` chains into a nested bg ``report``.
+   The follow-up ``report`` TM must record the NESTED owning class
+   (``GmailChainProcess`` / ``DummyChainProcess``), not the bound parent
+   and not the predecessor — the riskiest owner-overwrite case.
+"""
+from django.test import override_settings
+
+from django_logic.background.models import TransitionMessage
+from django_logic.testing import JourneyStep, ProcessScenario
+from tests.background.models import (
+    ChainConversationProcess,
+    Conversation,
+    Widget,
+    WidgetBgChainProcess,
+)
+
+
+_SYNC_SETTINGS = {
+    'LOCK_TIMEOUT': 7200,
+    'BACKGROUND_EXECUTION': 'sync',
+    'STARTER_QUEUE': 'django_logic.starter',
+    'TRANSITION_MESSAGE_MAX_ERRORS': 3,
+    'TRANSITION_MESSAGE_RETRY_MINUTES': 2,
+    'TRANSITION_MESSAGE_CLEANUP_DAYS': 7,
+}
+
+_BG_CHAIN = 'tests.background.models.WidgetBgChainProcess'
+_GMAIL_CHAIN = 'tests.background.models.GmailChainProcess'
+_DUMMY_CHAIN = 'tests.background.models.DummyChainProcess'
+
+
+@override_settings(DJANGO_LOGIC=_SYNC_SETTINGS)
+class BgToBgChainScenario(ProcessScenario):
+    """A background transition whose ``next_transition`` is another
+    background transition, driven end-to-end through the entrypoint."""
+
+    process_class = WidgetBgChainProcess
+    model = Widget
+    state_field = 'status'
+    process_name = 'bg_chain'
+
+    def test_chains_and_records_each_owner(self):
+        widget = self.create_instance(status='draft')
+        self.assert_available(widget, ['bg_fulfil'])
+
+        self.background_transition(widget, 'bg_fulfil')
+
+        # The object passed through EVERY intermediate state — the in_progress
+        # and target of each leg of the chain. This is the observable journey,
+        # not just the final state.
+        self.assert_state_trace(
+            ['chain_fulfilling', 'fulfilled', 'chain_exporting', 'exported']
+        )
+        self.assert_state(widget, 'exported')
+
+        # Both legs' side-effects ran, in order, inside the one drive.
+        self.assert_side_effects_ran(['se_bg_fulfil_se', 'se_bg_export_se'])
+        self.assert_callbacks_ran(['cb_bg_export_cb'])
+
+        # Two separate durable rows were created, one per background
+        # transition — and each records its OWN owner, not the predecessor's.
+        tms = list(TransitionMessage.objects.order_by('id'))
+        self.assertEqual([t.transition_name for t in tms], ['bg_fulfil', 'bg_export'])
+        self.assertTrue(all(t.is_completed for t in tms))
+        self.assert_transition_owner(
+            widget, _BG_CHAIN, transition_name='bg_fulfil'
+        )
+        self.assert_transition_owner(
+            widget, _BG_CHAIN, transition_name='bg_export'
+        )
+
+    def test_journey_pins_the_whole_transformation(self):
+        # The journey assertion locks the end-to-end observable behaviour
+        # in one statement: one drive, draft -> exported, both side-effects,
+        # the export callback, no failure.
+        widget = self.create_instance(status='draft')
+        self.background_transition(widget, 'bg_fulfil')
+        self.assert_journey([
+            JourneyStep(
+                action='bg_fulfil',
+                before='draft',
+                after='exported',
+                side_effects=['se_bg_fulfil_se', 'se_bg_export_se'],
+                callbacks=['cb_bg_export_cb'],
+                failed=False,
+            ),
+        ])
+
+    def test_failure_of_first_leg_does_not_chain(self):
+        # A failure of the first leg stops the chain: the follow-up never
+        # runs and no follow-up TransitionMessage is created. The instance
+        # stays in the first leg's in_progress state, pending retry.
+        widget = self.create_instance(status='draft')
+        self.background_transition(
+            widget, 'bg_fulfil', fail_side_effect='se_bg_fulfil_se',
+            fail_with=ValueError('fulfil broke'),
+        )
+        self.assert_state(widget, 'chain_fulfilling')
+        # Only the first leg's side-effect was attempted (and injected to
+        # fail); the export side-effect never ran.
+        self.assert_side_effects_not_ran(['se_bg_export_se'])
+        # Only one TM exists — the failed first leg, uncompleted for retry.
+        self.assertEqual(TransitionMessage.objects.count(), 1)
+        self.assertFalse(TransitionMessage.objects.get().is_completed)
+        self.assert_transition_owner(widget, _BG_CHAIN, transition_name='bg_fulfil')
+
+    def test_terminal_failure_of_first_leg_does_not_chain(self):
+        # When the first leg exhausts MAX_ERRORS it terminalizes into its
+        # failed_state; the follow-up still never runs.
+        widget = self.create_instance(status='draft')
+        self.background_transition(
+            widget, 'bg_fulfil', fail_side_effect='se_bg_fulfil_se',
+            fail_with=ValueError('persistent'),
+        )
+        # Drive retries until terminal (MAX_ERRORS total attempts).
+        for _ in range(2):  # MAX_ERRORS=3 -> initial + 2 retries
+            self.retry_transition(
+                widget, fail_side_effect='se_bg_fulfil_se',
+                fail_with=ValueError('persistent'),
+            )
+        self.assert_state(widget, 'chain_fulfil_failed')
+        self.assert_side_effects_not_ran(['se_bg_export_se'])
+        self.assertEqual(TransitionMessage.objects.count(), 1)
+        self.assertTrue(TransitionMessage.objects.get().is_completed)
+
+
+@override_settings(DJANGO_LOGIC=_SYNC_SETTINGS)
+class NestedDisambiguatedBgChainScenario(ProcessScenario):
+    """A nested, condition-disambiguated background chain. The follow-up
+    ``report`` must record the NESTED owning class, not the bound parent
+    and not the predecessor — the riskiest owner-overwrite case for #98."""
+
+    process_class = ChainConversationProcess
+    model = Conversation
+    state_field = 'status'
+    process_name = 'chain_conv'
+
+    def test_gmail_chain_records_nested_owner_on_each_leg(self):
+        conv = self.create_instance(status='open', source_integration='gmail')
+        self.background_transition(conv, 'send')
+
+        # open -> gmail_chain_sending -> open -> gmail_chain_reporting -> reported
+        self.assert_state_trace(
+            ['gmail_chain_sending', 'open', 'gmail_chain_reporting', 'reported']
+        )
+        self.assert_state(conv, 'reported')
+        self.assert_side_effects_ran(['chain_gmail_send', 'chain_gmail_report'])
+        self.assertNotIn('dummy_', conv.se_log)
+
+        # Each leg's TM records the NESTED Gmail class as owner — not the
+        # bound parent ChainConversationProcess, and the follow-up does NOT
+        # inherit the predecessor's owner.
+        self.assert_transition_owner(conv, _GMAIL_CHAIN, transition_name='send')
+        self.assert_transition_owner(conv, _GMAIL_CHAIN, transition_name='report')
+
+    def test_dummy_chain_records_nested_owner_on_each_leg(self):
+        conv = self.create_instance(status='open', source_integration='dummy')
+        self.background_transition(conv, 'send')
+
+        self.assert_state_trace(
+            ['dummy_chain_sending', 'open', 'dummy_chain_reporting', 'reported']
+        )
+        self.assert_state(conv, 'reported')
+        self.assert_side_effects_ran(['chain_dummy_send', 'chain_dummy_report'])
+        self.assertNotIn('gmail_', conv.se_log)
+
+        self.assert_transition_owner(conv, _DUMMY_CHAIN, transition_name='send')
+        self.assert_transition_owner(conv, _DUMMY_CHAIN, transition_name='report')
+
+    def test_two_conversations_chain_independently(self):
+        gmail = self.create_instance(status='open', source_integration='gmail')
+        dummy = self.create_instance(status='open', source_integration='dummy')
+        self.background_transition(gmail, 'send')
+        self.background_transition(dummy, 'send')
+
+        gmail.refresh_from_db()
+        dummy.refresh_from_db()
+        self.assertEqual(gmail.status, 'reported')
+        self.assertEqual(dummy.status, 'reported')
+        self.assertIn('gmail_report,', gmail.se_log)
+        self.assertNotIn('dummy_', gmail.se_log)
+        self.assertIn('dummy_report,', dummy.se_log)
+        self.assertNotIn('gmail_', dummy.se_log)

--- a/tests/background/test_bg_chain.py
+++ b/tests/background/test_bg_chain.py
@@ -82,6 +82,7 @@ class BgToBgChainScenario(ProcessScenario):
 
         # Two separate durable rows were created, one per background
         # transition — and each records its OWN owner, not the predecessor's.
+        self.assert_related_count(TransitionMessage.objects.all(), 2)
         tms = list(TransitionMessage.objects.order_by('id'))
         self.assertEqual([t.transition_name for t in tms], ['bg_fulfil', 'bg_export'])
         self.assertTrue(all(t.is_completed for t in tms))

--- a/tests/test_cross_machine_cascade.py
+++ b/tests/test_cross_machine_cascade.py
@@ -1,0 +1,101 @@
+"""Named engine contract: the cross-machine failure cascade.
+
+``fundamental problem.md`` §3 documents the anti-pattern that silently changed
+behaviour between 0.1.6 and 0.2.0: an outer transition's *side-effect* drives a
+transition on a **different** state machine (another instance) and lets that
+inner failure propagate. This test pins every leg of the resulting cascade as
+ONE journey, so an engine change of that magnitude fails here first:
+
+  1. the inner machine lands in its ``failed_state`` with its failure hooks run;
+  2. the exception propagates out of the inner transition;
+  3. the outer transition's ``fail_transition`` runs — outer lands in its own
+     ``failed_state`` with its failure hooks run;
+  4. the outer side-effects declared AFTER the nested call are SKIPPED;
+  5. the outer success callbacks are SKIPPED;
+  6. the exception reaches the CALLER of the outer transition.
+
+(The fan-out pattern in ``docs/recipes/nested-processes.md`` is the correct way
+to model parent→children work; this test does not endorse the anti-pattern, it
+locks its real behaviour so a regression can't move it unnoticed.)
+"""
+from django_logic.testing import JourneyStep, ProcessScenario
+from tests.background import models
+from tests.background.models import (
+    CascadeOuterProcess,
+    Widget,
+)
+
+
+class CrossMachineCascadeContract(ProcessScenario):
+    process_class = CascadeOuterProcess
+    model = Widget
+    state_field = 'status'
+    process_name = 'cascade_outer'
+
+    def setUp(self):
+        super().setUp()
+        models.CASCADE_ORDER.clear()
+
+    def test_inner_failure_cascades_and_reaches_the_caller(self):
+        outer = self.create_instance(status='draft')
+        inner = self.create_instance(status='draft')
+
+        # Drive the outer machine; its second side-effect drives the inner
+        # machine, which fails. The exception must reach us (expect_raises).
+        self.transition(
+            outer, 'outer_fulfil', inner_pk=inner.pk, expect_raises=ValueError,
+        )
+        self.assert_raised(ValueError, match='inner machine failed')
+
+        # (1)+(2) inner machine is contained in ITS failed_state, ITS failure
+        # callback ran.
+        inner.refresh_from_db()
+        self.assertEqual(inner.status, 'inner_failed')
+        self.assertIn('inner_fcb,', inner.cb_log)
+
+        # (3) outer machine landed in ITS failed_state; outer failure callback
+        # ran (tracked, since it lives on the driven process).
+        self.assert_state(outer, 'outer_failed')
+        self.assert_failure_callbacks_ran(['cascade_outer_fcb'])
+
+        # (4) the side-effect BEFORE the nested call ran; the one AFTER it was
+        # skipped when the nested call raised.
+        outer.refresh_from_db()
+        self.assertIn('outer_before,', outer.se_log)
+        self.assertNotIn('outer_after,', outer.se_log)
+        self.assert_side_effects_ran(['cascade_outer_before'])
+        self.assert_side_effects_not_ran(['cascade_outer_after'])
+
+        # (5) the outer SUCCESS callback never ran.
+        self.assertNotIn('outer_cb,', outer.cb_log)
+
+        # The full ordered cascade, across both machines. The inner machine
+        # fails and cleans up entirely before control returns to the outer
+        # machine's failure path.
+        self.assertEqual(models.CASCADE_ORDER, [
+            'outer:before',
+            'outer:call_inner',
+            'inner:side_effect',
+            'inner:failure_callback',
+            'outer:failure_callback',
+        ])
+
+    def test_journey_pins_the_whole_cascade(self):
+        outer = self.create_instance(status='draft')
+        inner = self.create_instance(status='draft')
+        self.transition(
+            outer, 'outer_fulfil', inner_pk=inner.pk, expect_raises=ValueError,
+        )
+        # One assertion locks the outer machine's observable transformation:
+        # draft -> outer_failed, only the pre-nested side-effect ran, no
+        # success callback, and the failure DID reach the caller (failed=True).
+        self.assert_journey([
+            JourneyStep(
+                action='outer_fulfil',
+                before='draft',
+                after='outer_failed',
+                side_effects=['cascade_outer_before'],
+                callbacks=[],
+                failed=True,
+            ),
+        ])

--- a/tests/test_exception_semantics.py
+++ b/tests/test_exception_semantics.py
@@ -122,9 +122,13 @@ class SwallowContract(ProcessScenario):
             expect_raises=False,
         )
         self.assert_not_raised()
-        self.assert_state(widget, 'approved')          # parent target kept
+        # The parent kept its target — the load-bearing proof the follow-up's
+        # failure was swallowed (a re-raise would have failed the whole drive).
+        self.assert_state(widget, 'approved')
         self.assert_side_effects_ran(['se_a', 'se_b'])  # approve's own ran
-        self.assert_side_effects_not_ran(['se_c'])      # notify's failed, never ran
+        # (se_c is the injected target, so it never records as "ran"
+        # regardless of engine behaviour — not asserted; the kept 'approved'
+        # state above is what proves notify failed and was swallowed.)
 
     def test_failure_hooks_run_in_order_across_the_boundary(self):
         # Independent of the caller boundary: failure_side_effects run before

--- a/tests/test_exception_semantics.py
+++ b/tests/test_exception_semantics.py
@@ -1,0 +1,139 @@
+"""Named engine contract: the re-raise / swallow exception asymmetry.
+
+This is the contract the ``0.1.6 -> 0.2.0`` upgrade silently flipped (see
+``fundamental problem.md`` §3 and the process-testing report §4.1). The engine
+deliberately treats the four hook families asymmetrically at the *caller
+boundary*:
+
+* ``SideEffects`` — on failure, run ``fail_transition``, then **RE-RAISE** so
+  the caller observes the failure (``commands.py`` ``SideEffects.execute``).
+* ``Callbacks`` — best-effort; exceptions are **swallowed**.
+* ``NextTransition`` — a follow-up's failure is **swallowed** (it must not
+  bubble into the transition that triggered it).
+* ``FailureSideEffects`` — a raising cleanup hook is **swallowed** and must not
+  mask the original exception (which still re-raises).
+
+Every test drives a real object through the real entrypoint and pins what
+reaches the caller via ``expect_raises`` / ``assert_raised`` /
+``assert_not_raised``. These are the tests that fail loudly if a future engine
+change reverts ``SideEffects.execute`` to swallow — before it reaches
+production, not during it.
+"""
+from django_logic.testing import JourneyStep, ProcessScenario
+from tests.background.models import (
+    SYNC_ORDER,
+    Widget,
+    WidgetSyncProcess,
+)
+
+
+class SideEffectReRaiseContract(ProcessScenario):
+    """SideEffects re-raise: a failing side-effect surfaces to the caller."""
+
+    process_class = WidgetSyncProcess
+    model = Widget
+    state_field = 'status'
+    process_name = 'sync_proc'
+
+    def test_side_effect_failure_reraises_to_caller(self):
+        # Inject a failure into reject's side-effect. The engine must write
+        # failed_state, run the failure hooks, AND re-raise the exception to
+        # the caller of the entrypoint.
+        widget = self.create_instance(status='draft')
+        self.transition(
+            widget, 'reject',
+            fail_side_effect='se_reject_attempt', fail_with=ValueError('reject boom'),
+            expect_raises=ValueError,
+        )
+        # The caller saw the exception (expect_raises above) AND the object
+        # landed in its failed_state with both failure hook families run.
+        self.assert_raised(ValueError, match='reject boom')
+        self.assert_state(widget, 'rejection_failed')
+        self.assert_failure_side_effects_ran(['fse_cleanup'])
+        self.assert_failure_callbacks_ran(['fcb_on_fail'])
+
+    def test_genuine_side_effect_exception_reaches_caller_without_injection(self):
+        # capture_fail's side-effect (sync_boom) always raises — no injection.
+        # The genuinely-raising hook must still reach the caller.
+        widget = self.create_instance(status='draft')
+        self.transition(widget, 'capture_fail', expect_raises=ValueError)
+        self.assert_raised(ValueError, match='sync boom')
+        self.assert_state(widget, 'capture_failed')
+
+    def test_journey_marks_the_failure_as_reaching_the_caller(self):
+        # The journey step's ``failed`` flag records that an exception reached
+        # the caller. This one assertion detects a swallow-vs-reraise flip:
+        # under a swallow regression, failed would be False and this fails.
+        widget = self.create_instance(status='draft')
+        self.transition(
+            widget, 'reject',
+            fail_side_effect='se_reject_attempt', fail_with=ValueError('boom'),
+            expect_raises=ValueError,
+        )
+        self.assert_journey([
+            JourneyStep(
+                action='reject',
+                before='draft',
+                after='rejection_failed',
+                side_effects=[],          # the attempt raised, so it never "ran"
+                callbacks=[],
+                failed=True,              # <- the re-raise pin
+            ),
+        ])
+
+    def test_failure_side_effect_that_raises_does_not_mask_the_original(self):
+        # reject_bad_cleanup: side-effect raises ValueError, then its
+        # failure_side_effect (sync_fse_boom) ALSO raises RuntimeError. The
+        # cleanup failure must be swallowed and must NOT replace the original
+        # ValueError, which still re-raises. The failure callback still runs.
+        widget = self.create_instance(status='draft')
+        self.transition(widget, 'reject_bad_cleanup', expect_raises=ValueError)
+        self.assert_raised(ValueError, match='sync boom')  # original, not RuntimeError
+        self.assert_state(widget, 'rbc_failed')
+        self.assert_failure_callbacks_ran(['fcb_rbc'])
+
+
+class SwallowContract(ProcessScenario):
+    """Callbacks / NextTransition swallow: a best-effort failure must NOT
+    reach the caller, and the object keeps the state it legitimately reached."""
+
+    process_class = WidgetSyncProcess
+    model = Widget
+    state_field = 'status'
+    process_name = 'sync_proc'
+
+    def test_callback_failure_is_swallowed_and_target_kept(self):
+        # boom_callback's callback raises. The target is already written, so
+        # the exception is swallowed and the object keeps its target state.
+        widget = self.create_instance(status='draft')
+        self.transition(widget, 'boom_callback', expect_raises=False)
+        self.assert_not_raised()
+        self.assert_state(widget, 'boom_done')
+
+    def test_next_transition_failure_is_swallowed_and_parent_kept(self):
+        # approve completes (target 'approved') then chains into notify. Inject
+        # a failure into notify's side-effect (se_c): the follow-up fails, but
+        # NextTransition swallows it — the parent keeps 'approved' and the
+        # caller sees no exception.
+        widget = self.create_instance(status='draft')
+        self.transition(
+            widget, 'approve',
+            fail_side_effect='se_c', fail_with=ValueError('notify boom'),
+            expect_raises=False,
+        )
+        self.assert_not_raised()
+        self.assert_state(widget, 'approved')          # parent target kept
+        self.assert_side_effects_ran(['se_a', 'se_b'])  # approve's own ran
+        self.assert_side_effects_not_ran(['se_c'])      # notify's failed, never ran
+
+    def test_failure_hooks_run_in_order_across_the_boundary(self):
+        # Independent of the caller boundary: failure_side_effects run before
+        # failure_callbacks. Pinned via the cross-hook SYNC_ORDER sink.
+        SYNC_ORDER.clear()
+        widget = self.create_instance(status='draft')
+        self.transition(
+            widget, 'reject',
+            fail_side_effect='se_reject_attempt', fail_with=ValueError('boom'),
+            expect_raises=ValueError,
+        )
+        self.assertEqual(SYNC_ORDER, ['fse:cleanup', 'fcb:on_fail'])

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1,783 +1,265 @@
-from django.test import TestCase
+"""Behavior-focused Process tests.
 
-from tests.models import Invoice
+Every test here drives a real object through the real ``instance.process.<action>()``
+entrypoint and asserts on the OBSERVABLE transformation — what state the
+object landed in, which side-effects/callbacks mutated it, what became
+available next, and how the object moved through the workflow. No test
+defines a process inline and asserts on framework return values, and
+nothing mocks ``change_state``: those tests just re-state the
+implementation and prevent nothing (a rewrite regenerates them to match
+whatever code exists).
 
-from django_logic import Process, Transition
+The fixtures live in tests/background/models.py and are bound in
+tests/background/apps.py (the single binding site, per issue #100).
+"""
+from django.contrib.auth import get_user_model
+
 from django_logic.exceptions import TransitionNotAllowed
-from unittest.mock import patch
-
-
-class User:
-    def __init__(self, is_allowed=True, is_staff=False):
-        self.is_allowed = is_allowed
-        self.is_staff = is_staff
-
-
-def allowed(instance, user):
-    return user.is_allowed and not user.is_staff
-
-
-def is_staff(instance, user):
-    return user.is_staff
-
-
-def disallow(instance, user):
-    return False
-
-
-def is_editable(instance):
-    return not instance.customer_received
-
-
-def is_available(instance):
-    return instance.is_available
-
-
-def not_available(instance):
-    return False
-
-
-def disable_invoice(invoice: Invoice, *args, **kwargs):
-    invoice.is_available = False
-    invoice.customer_received = False
-    invoice.save()
-
-
-def update_invoice(invoice, is_available, customer_received, *args, **kwargs):
-    invoice.is_available = is_available
-    invoice.customer_received = customer_received
-    invoice.save()
-
-
-def enable_invoice(invoice: Invoice, *args, **kwargs):
-    invoice.is_available = True
-    invoice.save()
-
-
-def fail_invoice(invoice: Invoice, *args, **kwargs):
-    raise Exception
-
-
-class ValidateProcessTestCase(TestCase):
-    def setUp(self) -> None:
-        self.user = User()
-
-    def test_pure_process(self):
-        class MyProcess(Process):
-            pass
-
-        process = MyProcess(field_name='status', instance=Invoice(status='draft'))
-        self.assertTrue(process.is_valid())
-        self.assertTrue(process.is_valid(self.user))
-
-    def test_empty_permissions(self):
-        class MyProcess(Process):
-            permissions = []
-
-        self.assertTrue(MyProcess('state', instance=Invoice(status='draft')).is_valid())
-        self.assertTrue(MyProcess('state', instance=Invoice(status='draft')).is_valid(self.user))
-
-    def test_permissions_successfully(self):
-        class MyProcess(Process):
-            permissions = [allowed]
-
-        self.assertTrue(MyProcess('state', instance=Invoice(status='draft')).is_valid())
-        self.assertTrue(MyProcess('state', instance=Invoice(status='draft')).is_valid(self.user))
-
-    def test_permission_fail(self):
-        self.user.is_allowed = False
-
-        class MyProcess(Process):
-            permissions = [allowed]
-
-        process = MyProcess(field_name='status', instance=Invoice(status='draft'))
-        self.assertTrue(process.is_valid())
-        self.assertFalse(process.is_valid(self.user))
-
-        class AnotherProcess(Process):
-            permissions = [allowed, disallow]
-
-        process = AnotherProcess(field_name='status', instance=Invoice(status='draft'))
-        self.assertTrue(process.is_valid())
-        self.assertFalse(process.is_valid(self.user))
-
-    def test_empty_conditions(self):
-        class MyProcess(Process):
-            conditions = []
-
-        process = MyProcess(field_name='status', instance=Invoice(status='draft'))
-        self.assertTrue(process.is_valid(self.user))
-
-    def test_conditions_successfully(self):
-        class MyProcess(Process):
-            conditions = [is_editable]
-
-        process = MyProcess(field_name='status', instance=Invoice(status='draft'))
-        self.assertTrue(process.is_valid())
-        self.assertTrue(process.is_valid(self.user))
-
-    def test_conditions_fail(self):
-        class MyProcess(Process):
-            conditions = [not_available]
-
-        process = MyProcess(field_name='status', instance=Invoice(status='draft'))
-
-        self.assertFalse(process.is_valid())
-        self.assertFalse(process.is_valid(self.user))
-
-        class AnotherProcess(Process):
-            conditions = [is_editable]
-
-        instance = Invoice(status='draft')
-        instance.customer_received = True
-        process = AnotherProcess(field_name='status', instance=instance)
-        self.assertFalse(process.is_valid())
-        self.assertFalse(process.is_valid(self.user))
-
-    def test_permissions_and_conditions_successfully(self):
-        class MyProcess(Process):
-            permissions = [allowed]
-            conditions = [is_editable]
-
-        process = MyProcess(field_name='status', instance=Invoice(status='draft'))
-        self.assertTrue(process.is_valid())
-        self.assertTrue(process.is_valid(self.user))
-
-    def test_permissions_and_conditions_fail(self):
-        class MyProcess(Process):
-            permissions = [allowed, disallow]
-            conditions = [is_editable]
-
-        process = MyProcess(field_name='status', instance=Invoice(status='draft'))
-        self.assertTrue(process.is_valid())
-        self.assertFalse(process.is_valid(self.user))
-
-        class AnotherProcess(Process):
-            permissions = [allowed]
-            conditions = [is_editable, not_available]
-
-        process = AnotherProcess(field_name='status', instance=Invoice(status='draft'))
-        self.assertFalse(process.is_valid())
-        self.assertFalse(process.is_valid(self.user))
-
-        class FinalProcess(Process):
-            permissions = [allowed, disallow]
-            conditions = [is_editable, not_available]
-
-        process = FinalProcess(field_name='status', instance=Invoice(status='draft'))
-        self.assertFalse(process.is_valid())
-        self.assertFalse(process.is_valid(self.user))
-
-    def test_getattr_is_valid_name_and_transition(self):
-        class MyProcess(Process):
-            transitions = [Transition('is_valid', sources=['draft'], target='valid')]
-
-        invoice = Invoice.objects.create(status='draft')
-        process = MyProcess(instance=invoice, field_name='status')
-        # transition shouldn't be executed
-        self.assertTrue(process.is_valid())
-        invoice.refresh_from_db()
-        self.assertEqual(invoice.status, 'draft')
-
-
-class GetAvailableActionsTestCase(TestCase):
-    def setUp(self) -> None:
-        self.user = User()
-
-    def test_get_actions_with_the_same_name(self):
-        transition1 = Transition('action', sources=['draft'], target='done')
-        transition2 = Transition('action', sources=['draft'], target='closed')
-
-        class ChildProcess(Process):
-            transitions = [transition1, transition2]
-
-        process = ChildProcess(instance=Invoice.objects.create(status='draft'), field_name='status')
-        self.assertEqual(process.get_available_actions(), ['action'])
-
-    def test_get_sorted_list(self):
-        transition1 = Transition('cancel', sources=['draft'], target='done')
-        transition2 = Transition('action', sources=['draft'], target='closed')
-        transition3 = Transition('bulk_action', sources=['draft'], target='closed')
-
-        class ChildProcess(Process):
-            transitions = [transition1, transition2, transition3]
-
-        process = ChildProcess(instance=Invoice.objects.create(status='draft'), field_name='status')
-        self.assertEqual(process.get_available_actions(), ['action', 'bulk_action', 'cancel'])
-
-
-class GetAvailableTransitionsTestCase(TestCase):
-    def setUp(self) -> None:
-        self.user = User()
-
-    def test_pure_process(self):
-        class ChildProcess(Process):
-            pass
-
-        process = ChildProcess(instance=Invoice.objects.create(status='draft'), field_name='status')
-        self.assertEqual(list(process.get_available_transitions()), [])
-
-    def test_process(self):
-        transition1 = Transition('action', sources=['draft'], target='done')
-        transition2 = Transition('action', sources=['done'], target='closed')
-
-        class ChildProcess(Process):
-            transitions = [transition1, transition2]
-
-        process = ChildProcess(instance=Invoice.objects.create(status='draft'), field_name='status')
-        self.assertEqual(list(process.get_available_transitions()), [transition1])
-
-        process = ChildProcess(instance=Invoice.objects.create(status='done'), field_name='status')
-        self.assertEqual(list(process.get_available_transitions()), [transition2])
-
-        process = ChildProcess(instance=Invoice.objects.create(status='closed'), field_name='status')
-        self.assertEqual(list(process.get_available_transitions()), [])
-
-    def test_process_fail(self):
-        transition1 = Transition('action', sources=['draft'], target='done')
-        transition2 = Transition('action', sources=['done'], target='closed')
-
-        class ChildProcess(Process):
-            conditions = [not_available]
-            transitions = [transition1, transition2]
-
-        process = ChildProcess(instance=Invoice.objects.create(status='draft'), field_name='status')
-        self.assertEqual(list(process.get_available_transitions()), [])
-
-        process = ChildProcess(instance=Invoice.objects.create(status='done'), field_name='status')
-        self.assertEqual(list(process.get_available_transitions()), [])
-
-        process = ChildProcess(instance=Invoice.objects.create(status='closed'), field_name='status')
-        self.assertEqual(list(process.get_available_transitions()), [])
-
-    def test_conditions_and_permissions_successfully(self):
-        transition1 = Transition('action', sources=['draft'], target='done')
-        transition2 = Transition('action', sources=['done'], target='closed')
-
-        class ChildProcess(Process):
-            conditions = [is_editable]
-            permissions = [allowed]
-            transitions = [transition1, transition2]
-
-        process = ChildProcess(instance=Invoice.objects.create(status='draft'), field_name='status')
-        self.assertEqual(list(process.get_available_transitions(self.user)), [transition1])
-
-        process = ChildProcess(instance=Invoice.objects.create(status='done'), field_name='status')
-        self.assertEqual(list(process.get_available_transitions(self.user)), [transition2])
-
-        process = ChildProcess(instance=Invoice.objects.create(status='closed'), field_name='status')
-        self.assertEqual(list(process.get_available_transitions(self.user)), [])
-
-    def test_conditions_and_permissions_fail(self):
-        transition1 = Transition('action', sources=['draft'], target='done')
-        transition2 = Transition('action', sources=['done'], target='closed')
-
-        class ChildProcess(Process):
-            conditions = [is_editable]
-            permissions = [disallow]
-            transitions = [transition1, transition2]
-
-        process = ChildProcess(instance=Invoice.objects.create(status='draft'), field_name='status')
-        self.assertEqual(list(process.get_available_transitions(self.user)), [])
-
-        process = ChildProcess(instance=Invoice.objects.create(status='done'), field_name='status')
-        self.assertEqual(list(process.get_available_transitions(self.user)), [])
-
-        process = ChildProcess(instance=Invoice.objects.create(status='closed'), field_name='status')
-        self.assertEqual(list(process.get_available_transitions(self.user)), [])
-
-    def test_nested_process_permissions_successfully(self):
-        transition1 = Transition('action', sources=['draft'], target='done')
-        transition2 = Transition('action', sources=['done'], target='closed')
-
-        class ChildProcess(Process):
-            permissions = [allowed]
-            transitions = [transition1, transition2]
-
-        process = ChildProcess(instance=Invoice.objects.create(status='draft'), field_name='status')
-        self.assertEqual(list(process.get_available_transitions(self.user)), [transition1])
-
-        class ParentProcess(Process):
-            permissions = [allowed]
-            nested_processes = (ChildProcess,)
-
-        process = ParentProcess(instance=Invoice.objects.create(status='draft'), field_name='status')
-        self.assertEqual(list(process.get_available_transitions(self.user)), [transition1])
-
-        class GrandParentProcess(Process):
-            permissions = [allowed]
-            nested_processes = (ParentProcess,)
-
-        process = GrandParentProcess(instance=Invoice.objects.create(status='draft'), field_name='status')
-        self.assertEqual(list(process.get_available_transitions(self.user)), [transition1])
-
-    def test_nested_process_permissions_fail(self):
-        transition1 = Transition('action', sources=['draft'], target='done')
-        transition2 = Transition('action', sources=['done'], target='closed')
-
-        class ChildProcess(Process):
-            permissions = [disallow]
-            transitions = [transition1, transition2]
-
-        process = ChildProcess(instance=Invoice.objects.create(status='draft'), field_name='status')
-        self.assertEqual(list(process.get_available_transitions(self.user)), [])
-
-        class ParentProcess(Process):
-            permissions = [allowed]
-            nested_processes = (ChildProcess,)
-
-        process = ParentProcess(instance=Invoice.objects.create(status='draft'), field_name='status')
-        self.assertEqual(list(process.get_available_transitions(self.user)), [])
-
-        class GrandParentProcess(Process):
-            permissions = [allowed]
-            nested_processes = (ParentProcess,)
-
-        process = GrandParentProcess(instance=Invoice.objects.create(status='draft'), field_name='status')
-        self.assertEqual(list(process.get_available_transitions(self.user)), [])
-
-    def test_nested_process_conditions_successfully(self):
-        transition1 = Transition('action', sources=['draft'], target='done')
-        transition2 = Transition('action', sources=['done'], target='closed')
-
-        class ChildProcess(Process):
-            conditions = [is_editable]
-            transitions = [transition1, transition2]
-
-        process = ChildProcess(instance=Invoice.objects.create(status='draft'), field_name='status')
-        self.assertEqual(list(process.get_available_transitions(self.user)), [transition1])
-
-        class ParentProcess(Process):
-            conditions = [is_editable]
-            nested_processes = (ChildProcess,)
-
-        process = ParentProcess(instance=Invoice.objects.create(status='draft'), field_name='status')
-        self.assertEqual(list(process.get_available_transitions(self.user)), [transition1])
-
-        class GrandParentProcess(Process):
-            conditions = [is_editable]
-            nested_processes = (ParentProcess,)
-
-        process = GrandParentProcess(instance=Invoice.objects.create(status='draft'), field_name='status')
-        self.assertEqual(list(process.get_available_transitions(self.user)), [transition1])
-
-    def test_nested_process_conditions_fail(self):
-        transition1 = Transition('action', sources=['draft'], target='done')
-        transition2 = Transition('action', sources=['done'], target='closed')
-
-        class ChildProcess(Process):
-            conditions = [is_editable]
-            transitions = [transition1, transition2]
-
-        process = ChildProcess(instance=Invoice.objects.create(status='draft'), field_name='status')
-        self.assertEqual(list(process.get_available_transitions(self.user)), [transition1])
-
-        class ParentProcess(Process):
-            conditions = [not_available]
-            nested_processes = (ChildProcess,)
-
-        process = ParentProcess(instance=Invoice.objects.create(status='draft'), field_name='status')
-        self.assertEqual(list(process.get_available_transitions(self.user)), [])
-
-        class GrandParentProcess(Process):
-            conditions = [is_editable]
-            nested_processes = (ParentProcess,)
-
-        process = GrandParentProcess(instance=Invoice.objects.create(status='draft'), field_name='status')
-        self.assertEqual(list(process.get_available_transitions(self.user)), [])
-
-    def test_nested_process_successfully(self):
-        transition1 = Transition('action', sources=['draft'], target='done')
-        transition2 = Transition('action', sources=['done'], target='closed')
-
-        class ChildProcess(Process):
-            permissions = [allowed]
-            conditions = [is_editable]
-            transitions = [transition1, transition2]
-
-        process = ChildProcess(instance=Invoice.objects.create(status='draft'), field_name='status')
-        self.assertEqual(list(process.get_available_transitions(self.user)), [transition1])
-
-        class ParentProcess(Process):
-            permissions = [allowed]
-            conditions = [is_editable]
-            nested_processes = (ChildProcess,)
-
-        process = ParentProcess(instance=Invoice.objects.create(status='draft'), field_name='status')
-        self.assertEqual(list(process.get_available_transitions(self.user)), [transition1])
-
-        class GrandParentProcess(Process):
-            permissions = [allowed]
-            conditions = [is_editable]
-            nested_processes = (ParentProcess,)
-
-        process = GrandParentProcess(instance=Invoice.objects.create(status='draft'), field_name='status')
-        self.assertEqual(list(process.get_available_transitions(self.user)), [transition1])
-
-    def test_nested_process_fail(self):
-        transition1 = Transition('action', sources=['draft'], target='done')
-        transition2 = Transition('action', sources=['done'], target='closed')
-
-        class ChildProcess(Process):
-            permissions = [allowed]
-            conditions = [is_editable]
-            transitions = [transition1, transition2]
-
-        process = ChildProcess(instance=Invoice.objects.create(status='draft'), field_name='status')
-        self.assertEqual(list(process.get_available_transitions(self.user)), [transition1])
-
-        class ParentProcess(Process):
-            permissions = [allowed]
-            conditions = [is_editable]
-            nested_processes = (ChildProcess,)
-
-        process = ParentProcess(instance=Invoice.objects.create(status='draft'), field_name='status')
-        self.assertEqual(list(process.get_available_transitions(self.user)), [transition1])
-
-        class GrandParentProcess(Process):
-            permissions = [allowed]
-            conditions = [not_available]
-            nested_processes = (ParentProcess,)
-
-        process = GrandParentProcess(instance=Invoice.objects.create(status='draft'), field_name='status')
-        self.assertEqual(list(process.get_available_transitions(self.user)), [])
-
-    def test_nested_process_with_nested_transitions_successfully(self):
-        transition1 = Transition('action', sources=['draft'], target='done')
-        transition2 = Transition('action', sources=['done'], target='closed')
-        transition3 = Transition('action', sources=['draft'], target='approved')
-        transition4 = Transition('action', sources=['done'], target='closed')
-        transition5 = Transition('action', sources=['draft'], target='declined')
-
-        class ChildProcess(Process):
-            permissions = [allowed]
-            conditions = [is_editable]
-            transitions = [transition1, transition2]
-
-        class ParentProcess(Process):
-            permissions = [allowed]
-            conditions = [is_editable]
-            nested_processes = (ChildProcess,)
-            transitions = [transition3, transition4]
-
-        class GrandParentProcess(Process):
-            permissions = [allowed]
-            conditions = [is_editable]
-            nested_processes = (ParentProcess,)
-
-            transitions = [transition5]
-
-        process = GrandParentProcess(instance=Invoice.objects.create(status='draft'), field_name='status')
-
-        for transition in process.get_available_transitions(self.user):
-            self.assertIn(transition, [transition1, transition3, transition5])
-
-        process = GrandParentProcess(instance=Invoice.objects.create(status='done'), field_name='status')
-        for transition in process.get_available_transitions(self.user):
-            self.assertIn(transition, [transition2, transition4])
-
-    def test_nested_process_with_nested_transitions_fail(self):
-        transition1 = Transition('action', sources=['draft'], target='done')
-        transition2 = Transition('action', sources=['done'], target='closed')
-        transition3 = Transition('action', sources=['draft'], target='approved')
-        transition4 = Transition('action', sources=['done'], target='closed')
-        transition5 = Transition('action', sources=['draft'], target='declined')
-
-        class ChildProcess(Process):
-            permissions = [disallow]
-            conditions = [is_editable]
-            transitions = [transition1, transition2]
-
-        class ParentProcess(Process):
-            permissions = [allowed]
-            conditions = [is_editable]
-            nested_processes = (ChildProcess,)
-            transitions = [transition3, transition4]
-
-        class GrandParentProcess(Process):
-            permissions = [allowed]
-            conditions = [is_editable]
-            nested_processes = (ParentProcess,)
-
-            transitions = [transition5]
-
-        process = GrandParentProcess(instance=Invoice.objects.create(status='draft'), field_name='status')
-        for transition in process.get_available_transitions(self.user):
-            self.assertIn(transition, [transition3, transition5])
-
-        process = GrandParentProcess(instance=Invoice.objects.create(status='done'), field_name='status')
-        for transition in process.get_available_transitions(self.user):
-            self.assertIn(transition, [transition4])
-
-    def test_nested_process_with_nested_transitions_conditions_and_permissions_successfully(self):
-        transition1 = Transition('action', permissions=[allowed], conditions=[is_editable],
-                                 sources=['draft'],
-                                 target='done')
-        transition2 = Transition('action', permissions=[allowed], conditions=[is_editable],
-                                 sources=['done'],
-                                 target='closed')
-        transition3 = Transition('action',
-                                 permissions=[allowed],
-                                 conditions=[is_editable],
-                                 sources=['draft'],
-                                 target='approved')
-        transition4 = Transition('action',
-                                 permissions=[allowed],
-                                 conditions=[is_editable],
-                                 sources=['done'],
-                                 target='closed')
-        transition5 = Transition('action',
-                                 permissions=[allowed],
-                                 conditions=[is_editable],
-                                 sources=['draft'],
-                                 target='declined')
-
-        class ChildProcess(Process):
-            transitions = [transition1, transition2]
-
-        class ParentProcess(Process):
-            nested_processes = (ChildProcess,)
-            transitions = [transition3, transition4]
-
-        class GrandParentProcess(Process):
-            nested_processes = (ParentProcess,)
-
-            transitions = [transition5]
-
-        process = GrandParentProcess(instance=Invoice.objects.create(status='draft'), field_name='status')
-        for transition in process.get_available_transitions(self.user):
-            self.assertIn(transition, [transition1, transition3, transition5])
-
-        process = GrandParentProcess(instance=Invoice.objects.create(status='done'), field_name='status')
-        for transition in process.get_available_transitions(self.user):
-            self.assertIn(transition, [transition2, transition4])
-
-    def test_nested_process_with_nested_transitions_conditions_and_permissions_fail(self):
-        transition1 = Transition('action',
-                                 permissions=[allowed],
-                                 conditions=[is_editable],
-                                 sources=['draft'],
-                                 target='done')
-        transition2 = Transition('action',
-                                 permissions=[disallow],
-                                 conditions=[is_editable],
-                                 sources=['done'],
-                                 target='closed')
-        transition3 = Transition('action',
-                                 permissions=[allowed],
-                                 conditions=[not_available],
-                                 sources=['draft'],
-                                 target='approved')
-        transition4 = Transition('action',
-                                 permissions=[allowed],
-                                 conditions=[is_editable],
-                                 sources=['done'],
-                                 target='closed')
-        transition5 = Transition('action',
-                                 permissions=[disallow],
-                                 conditions=[not_available],
-                                 sources=['draft'],
-                                 target='declined')
-
-        class ChildProcess(Process):
-            transitions = [transition1, transition2]
-
-        class ParentProcess(Process):
-            nested_processes = (ChildProcess,)
-            transitions = [transition3, transition4]
-
-        class GrandParentProcess(Process):
-            nested_processes = (ParentProcess,)
-
-            transitions = [transition5]
-
-        process = GrandParentProcess(instance=Invoice.objects.create(status='draft'), field_name='status')
-        for transition in process.get_available_transitions(self.user):
-            self.assertIn(transition, [transition1])
-
-        process = GrandParentProcess(instance=Invoice.objects.create(status='done'), field_name='status')
-        for transition in process.get_available_transitions(self.user):
-            self.assertIn(transition, [transition4])
-
-    def test_getattr_get_available_transition_name_and_transition(self):
-        class MyProcess(Process):
-            transitions = [Transition('get_available_transition', sources=['draft'], target='valid')]
-
-        invoice = Invoice.objects.create(status='draft')
-        process = MyProcess(instance=invoice, field_name='status')
-        # transition shouldn't be executed
-        self.assertEqual(list(process.get_available_transitions()), MyProcess.transitions)
-        invoice.refresh_from_db()
-        self.assertEqual(invoice.status, 'draft')
-
-    def test_get_non_existing_transition(self):
-        class MyProcess(Process):
-            transitions = [Transition('validate', sources=['draft'], target='valid')]
-
-        invoice = Invoice.objects.create(status='draft')
-        process = MyProcess(instance=invoice, field_name='status')
+from django_logic.testing import JourneyStep, ProcessScenario
+from tests.background.models import (
+    Widget,
+    WidgetAmbiguousConditionProcess,
+    WidgetNestedSyncProcess,
+    WidgetSyncProcess,
+)
+
+
+class SyncProcessAvailabilityScenario(ProcessScenario):
+    """What an instance MAY do from a given state — asserted as availability,
+    not as the framework's internal transition list."""
+
+    process_class = WidgetSyncProcess
+    model = Widget
+    state_field = 'status'
+    process_name = 'sync_proc'
+
+    def test_actions_available_from_draft(self):
+        widget = self.create_instance(status='draft')
+        # All draft-sourced actions are available from 'draft'.
+        self.assert_available(
+            widget,
+            ['approve', 'reject', 'poke', 'poke_fail',
+             'cancel', 'staff_only', 'capture', 'capture_fail', 'boom_callback'],
+        )
+
+    def test_actions_not_available_from_wrong_state(self):
+        widget = self.create_instance(status='approved')
+        # From 'approved' only the follow-up 'notify' is available — the
+        # draft-only actions are gated by source state.
+        self.assert_available(widget, ['notify'])
+        self.assert_not_available(
+            widget,
+            ['approve', 'reject', 'poke', 'cancel', 'staff_only'],
+        )
+
+    def test_nothing_available_from_terminal_state(self):
+        widget = self.create_instance(status='notified')
+        self.assertEqual(self._available(widget), [])
+
+    def test_condition_routes_same_action_name(self):
+        # Two 'cancel' transitions share an action_name, disambiguated by a
+        # condition on kwargs_seen. The object's DESTINATION depends on the
+        # condition — that is the observable behavior to pin.
+        widget = self.create_instance(status='draft')
+        self.transition(widget, 'cancel')
+        self.assert_state(widget, 'cancelled')
+        self.assertIn('cancel_plain,', widget.se_log)
+        self.assertNotIn('cancel_flagged,', widget.se_log)
+
+        flagged = self.create_instance(status='draft', kwargs_seen=['flag'])
+        self.transition(flagged, 'cancel')
+        self.assert_state(flagged, 'archived')
+        self.assertIn('cancel_flagged,', flagged.se_log)
+
+    def test_permission_gate_blocks_non_staff(self):
+        User = get_user_model()
+        staff = User.objects.create(username='proc_staff', is_staff=True)
+        customer = User.objects.create(username='proc_customer', is_staff=False)
+
+        widget = self.create_instance(status='draft')
+        self.assert_available(widget, ['staff_only'], user=staff)
+        self.assert_not_available(widget, ['staff_only'], user=customer)
+
+        self.transition(widget, 'staff_only', user=staff)
+        self.assert_state(widget, 'staffed')
+        self.assertIn('staff,', widget.se_log)
+
+    def test_permission_denial_keeps_object_unchanged(self):
+        User = get_user_model()
+        customer = User.objects.create(username='proc_customer2', is_staff=False)
+        widget = self.create_instance(status='draft')
+        # Drive through the real entrypoint; permission denial raises at
+        # resolve time, before any state write or side-effect.
         with self.assertRaises(TransitionNotAllowed):
-            process.test()
-
-    def test_get_transition_by_action_name_from_in_progress_state(self):
-        """``in_progress_state`` is appended to ``sources`` in Transition
-        init, so a transition is findable while its instance is mid-flight.
-        """
-        class MyProcess(Process):
-            transitions = [
-                Transition('process', sources=['draft'], target='done',
-                           in_progress_state='processing'),
-            ]
-
-        invoice = Invoice.objects.create(status='processing')
-        process = MyProcess(instance=invoice, field_name='status')
-
-        transition = process.get_transition_by_action_name('process')
-        self.assertEqual(transition.action_name, 'process')
-        self.assertEqual(transition.target, 'done')
+            self._process(widget).staff_only(user=customer)
+        # Object untouched: state unchanged, side-effect never ran.
+        widget.refresh_from_db()
+        self.assertEqual(widget.status, 'draft')
+        self.assertNotIn('staff,', widget.se_log)
 
 
-class ApplyTransitionTestCase(TestCase):
-    def setUp(self) -> None:
-        self.user = User()
-        self.invoice = Invoice.objects.create(status='draft')
+class SyncProcessDrivingScenario(ProcessScenario):
+    """How the object changes as it is driven through actions."""
 
-    def test_simple_transition(self):
-        class TestProcess(Process):
-            transitions = [
-                Transition('cancel', sources=['draft', ], target='cancelled')
-            ]
+    process_class = WidgetSyncProcess
+    model = Widget
+    state_field = 'status'
+    process_name = 'sync_proc'
 
-        process = TestProcess(instance=self.invoice, field_name='status')
-        process.cancel()
-        self.assertEqual(self.invoice.status, 'cancelled')
+    def test_approve_chains_into_notify_via_next_transition(self):
+        widget = self.create_instance(status='draft')
+        self.transition(widget, 'approve')
+        # The object passed through both states; the follow-up's side-effect
+        # ran in the same drive.
+        self.assert_state_trace(['approved', 'notified'])
+        self.assert_state(widget, 'notified')
+        self.assert_side_effects_ran(['se_a', 'se_b', 'se_c'])
+        self.assert_callbacks_ran(['cb_after_approve'])
 
-    def test_several_transitions(self):
-        class TestProcess(Process):
-            transitions = [
-                Transition('cancel', sources=['draft', ], target='cancelled'),
-                Transition('undo', sources=['cancelled'], target='draft')
-            ]
+    def test_side_effects_run_in_declaration_order(self):
+        # se_a is declared before se_b; the recorded order reflects the
+        # declaration order, which is the contract callers rely on.
+        widget = self.create_instance(status='draft')
+        self.transition(widget, 'approve')
+        ran = self._tracker().side_effects_ran
+        self.assertEqual(ran.index('se_a') < ran.index('se_b'), True)
+        # And the object's se_log reflects that order.
+        widget.refresh_from_db()
+        self.assertEqual(widget.se_log, 'a,b,c,')
 
-        TestProcess(instance=self.invoice, field_name='status').cancel()
-        self.invoice.refresh_from_db()
-        self.assertEqual(self.invoice.status, 'cancelled')
-        TestProcess(instance=self.invoice, field_name='status').undo()
-        self.invoice.refresh_from_db()
-        self.assertEqual(self.invoice.status, 'draft')
+    def test_reject_failure_path(self):
+        widget = self.create_instance(status='draft')
+        self.transition(
+            widget, 'reject',
+            fail_side_effect='se_reject_attempt', fail_with=ValueError('reject broke'),
+        )
+        # Failure writes failed_state; the failure hooks ran; the success
+        # side-effect did NOT complete.
+        self.assert_state(widget, 'rejection_failed')
+        self.assert_state_trace(['rejection_failed'])
+        self.assert_failure_side_effects_ran(['fse_cleanup'])
+        self.assert_failure_callbacks_ran(['fcb_on_fail'])
+        self.assert_side_effects_not_ran(['se_reject_attempt'])
 
-    def test_transition_with_side_effect(self):
-        class TestProcess(Process):
-            transitions = [
-                Transition('cancel', sources=['draft', ], target='cancelled', side_effects=[disable_invoice]),
-                Transition('undo', sources=['cancelled'], target='draft', side_effects=[update_invoice])
-            ]
-        self.assertTrue(self.invoice.is_available)
-        TestProcess(instance=self.invoice, field_name='status').cancel()
-        self.invoice.refresh_from_db()
-        self.assertEqual(self.invoice.status, 'cancelled')
-        self.assertFalse(self.invoice.is_available)
-        self.assertFalse(self.invoice.customer_received)
-        TestProcess(instance=self.invoice, field_name='status').undo(is_available=True, customer_received=True)
-        self.invoice.refresh_from_db()
-        self.assertEqual(self.invoice.status, 'draft')
-        self.assertTrue(self.invoice.is_available)
-        self.assertTrue(self.invoice.customer_received)
+    def test_failure_side_effects_run_before_failure_callbacks(self):
+        # The cross-hook ordering is observable via SYNC_ORDER.
+        from tests.background.models import SYNC_ORDER
+        SYNC_ORDER.clear()
+        widget = self.create_instance(status='draft')
+        self.transition(
+            widget, 'reject',
+            fail_side_effect='se_reject_attempt', fail_with=ValueError('boom'),
+        )
+        self.assertEqual(SYNC_ORDER, ['fse:cleanup', 'fcb:on_fail'])
 
-    def test_transition_with_callbacks(self):
-        class TestProcess(Process):
-            transitions = [
-                Transition('cancel', sources=['draft', ], target='cancelled', callbacks=[disable_invoice]),
-                Transition('undo', sources=['cancelled'], target='draft', callbacks=[update_invoice])
-            ]
-        self.assertTrue(self.invoice.is_available)
-        TestProcess(instance=self.invoice, field_name='status').cancel()
-        self.invoice.refresh_from_db()
-        self.assertEqual(self.invoice.status, 'cancelled')
-        self.assertFalse(self.invoice.is_available)
-        self.assertFalse(self.invoice.customer_received)
-        TestProcess(instance=self.invoice, field_name='status').undo(is_available=True, customer_received=True)
-        self.invoice.refresh_from_db()
-        self.assertEqual(self.invoice.status, 'draft')
-        self.assertTrue(self.invoice.is_available)
-        self.assertTrue(self.invoice.customer_received)
+    def test_action_does_not_change_state_on_success(self):
+        widget = self.create_instance(status='draft')
+        self.transition(widget, 'poke')
+        self.assert_state(widget, 'draft')
+        self.assert_state_trace([])  # no state write at all
+        self.assert_side_effects_ran(['se_poke'])
+        self.assert_callbacks_ran(['cb_after_poke'])
 
-    def test_transition_with_failure_callbacks(self):
-        class TestProcess(Process):
-            transitions = [
-                Transition('cancel', sources=['draft', ], target='cancelled', callbacks=[disable_invoice]),
-                Transition('undo', sources=['draft'], target='draft', side_effects=[fail_invoice], failed_state='failed', failure_callbacks=[update_invoice])
-            ]
-        update_invoice(self.invoice, is_available=False, customer_received=False)
-        self.assertFalse(self.invoice.is_available)
-        self.assertFalse(self.invoice.customer_received)
-        self.assertEqual(self.invoice.status, 'draft')
-        process = TestProcess(instance=self.invoice, field_name='status')
-        with self.assertRaises(Exception):
-            process.undo(is_available=True, customer_received=True)
-        self.invoice.refresh_from_db()
-        self.assertEqual(self.invoice.status, 'failed')
-        self.assertTrue(self.invoice.is_available)
-        self.assertTrue(self.invoice.customer_received)
+    def test_action_failed_state_only_written_when_unlocked(self):
+        widget = self.create_instance(status='draft')
+        self.transition(
+            widget, 'poke_fail',
+            fail_side_effect='se_poke_attempt', fail_with=ValueError('poke broke'),
+        )
+        self.assert_state(widget, 'poked_failed')
+        self.assert_failure_callbacks_ran(['fcb_on_poke_fail'])
 
-    def test_same_action_name_with_several_conditions(self):
-        class TestProcess(Process):
-            transitions = [
-                Transition('cancel', sources=['draft', ], target='cancelled', conditions=[is_editable]),
-                Transition('cancel', sources=['draft', ], target='cancelled', conditions=[is_available])
-            ]
-        invoice = Invoice.objects.create(status='draft')
-        update_invoice(invoice, customer_received=True, is_available=False)
+    def test_failing_action_does_not_release_a_concurrent_lock(self):
+        # An Action never acquires the state lock; a failing Action must not
+        # release one a concurrent Transition legitimately holds. Drive
+        # through the entrypoint with a pre-held lock and assert it survives.
+        widget = self.create_instance(status='draft')
+        state = self._process(widget).state
+        self.assertTrue(state.lock(), 'pre-condition: acquire the lock')
+        try:
+            self.transition(
+                widget, 'poke_fail',
+                fail_side_effect='se_poke_attempt', fail_with=ValueError('poke broke'),
+            )
+            self.assertTrue(
+                state.is_locked(),
+                'failing Action released a lock it never acquired',
+            )
+            # failed_state is skipped while locked — the object stays put.
+            self.assert_state(widget, 'draft')
+        finally:
+            state.unlock()
 
-        with self.assertRaises(TransitionNotAllowed):
-            # not editable and not available
-            TestProcess('status', invoice).cancel()
-        self.assertEqual(invoice.status, 'draft')
+    def test_kwargs_are_forwarded_to_side_effects(self):
+        from tests.background.models import SYNC_LAST_KWARGS
+        widget = self.create_instance(status='draft')
+        self.transition(widget, 'capture', foo='bar')
+        # The kwarg reached the side-effect...
+        self.assertEqual(SYNC_LAST_KWARGS.get('foo'), 'bar')
+        # ...and the drive actually transformed the persisted object (guardrail
+        # c: a kwargs check alone would pass even if the engine never ran).
+        self.assert_state(widget, 'captured')
+        self.assertIn('captured,', widget.se_log)
 
-        # is editable, but not available
-        update_invoice(invoice, customer_received=False, is_available=False)
-        TestProcess('status', invoice).cancel()
-        self.assertEqual(invoice.status, 'cancelled')
+    def test_positional_arguments_are_rejected(self):
+        # A positional user used to be silently dropped, bypassing permission
+        # checks. The entrypoint must refuse it loudly.
+        widget = self.create_instance(status='draft')
+        with self.assertRaises(TypeError):
+            # Pass a positional argument to the action method.
+            self._process(widget).approve('not-a-kwarg')
 
-        invoice = Invoice.objects.create(status='draft')
-        # is available, but not editable
-        update_invoice(invoice, customer_received=True, is_available=True)
-        TestProcess('status', invoice).cancel()
-        self.assertEqual(invoice.status, 'cancelled')
+    def test_journey_pins_the_whole_approve_workflow(self):
+        widget = self.create_instance(status='draft')
+        self.transition(widget, 'approve')
+        self.assert_journey([
+            JourneyStep(
+                action='approve',
+                before='draft',
+                after='notified',
+                side_effects=['se_a', 'se_b', 'se_c'],
+                callbacks=['cb_after_approve'],
+                failed=False,
+            ),
+        ])
 
-    def test_same_action_name_with_several_permissions(self):
-        class TestProcess(Process):
-            transitions = [
-                Transition('cancel', sources=['draft', ], target='cancelled', permissions=[is_staff]),
-                Transition('cancel', sources=['draft', ], target='cancelled', permissions=[allowed])
-            ]
 
-        user = User(is_allowed=True)
-        staff = User(is_staff=True)
+class NestedSyncDelegationScenario(ProcessScenario):
+    """A parent process drives a transition declared on a nested process,
+    through the parent entrypoint — the observable behavior the old
+    ``test_nested_process_*`` tests expressed as transition-object identity."""
 
-        invoice = Invoice.objects.create(status='draft')
-        with self.assertRaises(TransitionNotAllowed):
-            # either user or staff
-            TestProcess('status', invoice).cancel()
+    process_class = WidgetNestedSyncProcess
+    model = Widget
+    state_field = 'status'
+    process_name = 'nested_sync'
 
-        self.assertEqual(invoice.status, 'draft')
-        TestProcess('status', invoice).cancel(user=user)
-        self.assertEqual(invoice.status, 'cancelled')
+    def test_parent_entrypoint_drives_nested_transition(self):
+        widget = self.create_instance(status='draft')
+        # 'inner_act' is declared on InnerSyncProcess, not on the bound parent.
+        # The parent entrypoint must still find and run it.
+        self.assert_available(widget, ['inner_act'])
+        self.transition(widget, 'inner_act')
+        self.assert_state(widget, 'inner_done')
+        self.assert_side_effects_ran(['se_inner'])
 
-        invoice = Invoice.objects.create(status='draft')
-        TestProcess('status', invoice).cancel(user=staff)
-        self.assertEqual(invoice.status, 'cancelled')
 
-    @patch('django_logic.transition.Transition.change_state')
-    def test_kwargs_passed(self, change_state):
-        class TestProcess(Process):
-            transitions = [
-                Transition('cancel', sources=['draft', ], target='cancelled')
-            ]
+class AmbiguousConditionScenario(ProcessScenario):
+    """Two transitions share the action_name 'clash' and BOTH conditions pass.
+    Resolution must refuse (raise TransitionNotAllowed) with no state write and
+    no side-effect — it must not silently pick whichever comes first."""
 
-        process = TestProcess(instance=self.invoice, field_name='status')
-        process.cancel(foo='bar', user='user')
-        self.assertTrue(change_state.called)
-        call_kwargs = change_state.call_args[1]
-        self.assertEqual(call_kwargs['foo'], 'bar')
-        self.assertEqual(call_kwargs['user'], 'user')
+    process_class = WidgetAmbiguousConditionProcess
+    model = Widget
+    state_field = 'status'
+    process_name = 'ambig_cond'
+
+    def test_genuinely_ambiguous_call_is_refused_with_no_state_change(self):
+        widget = self.create_instance(status='draft')
+        self.transition(widget, 'clash', expect_raises=TransitionNotAllowed)
+        # Neither destination was taken, neither side-effect ran.
+        self.assert_state(widget, 'draft')
+        self.assert_state_trace([])
+        self.assert_side_effects_not_ran(['se_clash_a', 'se_clash_b'])
+        widget.refresh_from_db()
+        self.assertEqual(widget.se_log, '')

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -263,3 +263,47 @@ class AmbiguousConditionScenario(ProcessScenario):
         self.assert_side_effects_not_ran(['se_clash_a', 'se_clash_b'])
         widget.refresh_from_db()
         self.assertEqual(widget.se_log, '')
+
+
+class DomainOutcomeScenario(ProcessScenario):
+    """Assert what the object BECAME, not just that a hook ran (issue #103).
+    ``assert_side_effects_ran`` is a wiring check; ``capture`` +
+    ``assert_changed`` / ``assert_unchanged`` pin the before/after delta."""
+
+    process_class = WidgetSyncProcess
+    model = Widget
+    state_field = 'status'
+    process_name = 'sync_proc'
+
+    def test_capture_and_assert_the_domain_delta(self):
+        widget = self.create_instance(status='draft')
+        before = self.capture(widget, ['status', 'se_log', 'audit_status'])
+
+        self.transition(widget, 'approve')
+
+        # The side-effect ran (wiring) AND produced the exact domain change:
+        # status moved and se_log gained the ordered markers.
+        self.assert_side_effects_ran(['se_a', 'se_b', 'se_c'])
+        self.assert_changed(widget, before, {
+            'status': ('draft', 'notified'),
+            'se_log': ('', 'a,b,c,'),
+        })
+        # approve drives the 'sync_proc' machine; it must NOT touch the
+        # sibling audit machine's field. assert_unchanged catches a hook that
+        # wrote where it shouldn't.
+        self.assert_unchanged(widget, before, ['audit_status'])
+
+    def test_refused_transition_leaves_business_fields_unchanged(self):
+        User = get_user_model()
+        customer = User.objects.create(username='do_customer', is_staff=False)
+        widget = self.create_instance(status='draft')
+        before = self.capture(widget, ['status', 'se_log'])
+
+        # A permission-denied transition is refused at resolve time. The
+        # business field must be untouched — this would FAIL if the engine ran
+        # the side-effect (se_staff) before denying, which is the real regression
+        # assert_unchanged guards against here.
+        self.transition(widget, 'staff_only', user=customer,
+                        expect_raises=TransitionNotAllowed)
+        self.assert_unchanged(widget, before, ['status', 'se_log'])
+        self.assert_side_effects_not_ran(['se_staff'])

--- a/tests/test_process_guards.py
+++ b/tests/test_process_guards.py
@@ -1,0 +1,92 @@
+"""Process-LEVEL conditions & permissions (``Process.is_valid``).
+
+Distinct from *transition-level* guards: a class-level ``conditions`` /
+``permissions`` list gates the WHOLE process at once — its own transitions and
+every nested process's transitions — because ``_iter_available_with_owner``
+short-circuits the entire subtree when ``is_valid(user)`` is False
+(``process.py``). The migration to journey tests dropped this coverage
+entirely; disabling ``is_valid`` used to pass the whole suite. These tests
+restore it in both directions (allowed / blocked) and include the
+nested-inheritance case, on a real persisted instance.
+
+``WidgetProcGuardProcess`` (bound as ``proc_guard``) has:
+  conditions=[process_gate_open]      # instance flagged 'gate_open'
+  permissions=[process_requires_staff] # a staff user
+  transitions=[go]                     # its own
+  nested_processes=[GuardedInnerProcess]  # inner_go (no guards of its own)
+"""
+from django.contrib.auth import get_user_model
+
+from django_logic.exceptions import TransitionNotAllowed
+from django_logic.testing import ProcessScenario
+from tests.background.models import Widget, WidgetProcGuardProcess
+
+
+class ProcessLevelGuardScenario(ProcessScenario):
+    process_class = WidgetProcGuardProcess
+    model = Widget
+    state_field = 'status'
+    process_name = 'proc_guard'
+
+    def setUp(self):
+        super().setUp()
+        User = get_user_model()
+        self.staff = User.objects.create(username='pg_staff', is_staff=True)
+        self.customer = User.objects.create(username='pg_customer', is_staff=False)
+
+    # --- allowed direction ------------------------------------------------
+
+    def test_open_gate_and_staff_allows_own_transition(self):
+        widget = self.create_instance(status='draft', kwargs_seen=['gate_open'])
+        self.assert_available(widget, ['go', 'inner_go'], user=self.staff)
+        self.transition(widget, 'go', user=self.staff)
+        self.assert_state(widget, 'gone')
+        self.assertIn('go,', widget.se_log)
+
+    def test_open_gate_and_staff_allows_nested_transition(self):
+        # inner_go is declared on the nested GuardedInnerProcess; it is only
+        # reachable because the PARENT's process-level guard passed.
+        widget = self.create_instance(status='draft', kwargs_seen=['gate_open'])
+        self.transition(widget, 'inner_go', user=self.staff)
+        self.assert_state(widget, 'inner_gone')
+        self.assertIn('inner_go,', widget.se_log)
+
+    # --- blocked by process-level CONDITION -------------------------------
+
+    def test_closed_gate_hides_own_and_nested_transitions(self):
+        widget = self.create_instance(status='draft', kwargs_seen=[])  # gate closed
+        # The process-level condition fails, so NOTHING is available — not the
+        # class's own transition, not the nested one.
+        self.assert_not_available(widget, ['go', 'inner_go'], user=self.staff)
+
+    def test_closed_gate_blocks_drive_with_object_unchanged(self):
+        widget = self.create_instance(status='draft', kwargs_seen=[])
+        self.transition(widget, 'go', user=self.staff,
+                        expect_raises=TransitionNotAllowed)
+        # No state write, no side-effect: the process-level condition rejected
+        # the call at resolve time.
+        self.assert_state(widget, 'draft')
+        self.assertNotIn('go,', widget.se_log)
+        self.assert_state_trace([])
+
+    def test_closed_gate_blocks_nested_drive_with_object_unchanged(self):
+        widget = self.create_instance(status='draft', kwargs_seen=[])
+        self.transition(widget, 'inner_go', user=self.staff,
+                        expect_raises=TransitionNotAllowed)
+        self.assert_state(widget, 'draft')
+        self.assertNotIn('inner_go,', widget.se_log)
+
+    # --- blocked by process-level PERMISSION ------------------------------
+
+    def test_non_staff_is_blocked_even_with_open_gate(self):
+        widget = self.create_instance(status='draft', kwargs_seen=['gate_open'])
+        # Condition passes, but the process-level permission fails for a
+        # non-staff user — again gating both the own and the nested transition.
+        self.assert_not_available(widget, ['go', 'inner_go'], user=self.customer)
+
+    def test_non_staff_drive_blocked_with_object_unchanged(self):
+        widget = self.create_instance(status='draft', kwargs_seen=['gate_open'])
+        self.transition(widget, 'go', user=self.customer,
+                        expect_raises=TransitionNotAllowed)
+        self.assert_state(widget, 'draft')
+        self.assertNotIn('go,', widget.se_log)

--- a/tests/test_process_guards.py
+++ b/tests/test_process_guards.py
@@ -41,7 +41,8 @@ class ProcessLevelGuardScenario(ProcessScenario):
         self.assert_available(widget, ['go', 'inner_go'], user=self.staff)
         self.transition(widget, 'go', user=self.staff)
         self.assert_state(widget, 'gone')
-        self.assertIn('go,', widget.se_log)
+        # Exact match: 'go,' is a substring of 'inner_go,', so pin the whole log.
+        self.assertEqual(widget.se_log, 'go,')
 
     def test_open_gate_and_staff_allows_nested_transition(self):
         # inner_go is declared on the nested GuardedInnerProcess; it is only
@@ -49,7 +50,7 @@ class ProcessLevelGuardScenario(ProcessScenario):
         widget = self.create_instance(status='draft', kwargs_seen=['gate_open'])
         self.transition(widget, 'inner_go', user=self.staff)
         self.assert_state(widget, 'inner_gone')
-        self.assertIn('inner_go,', widget.se_log)
+        self.assertEqual(widget.se_log, 'inner_go,')
 
     # --- blocked by process-level CONDITION -------------------------------
 

--- a/tests/test_transition.py
+++ b/tests/test_transition.py
@@ -1,665 +1,306 @@
-from unittest.mock import Mock, patch
+"""Behavior-focused Transition / Action tests.
 
-from django.test import TestCase
+These tests replaced an older suite that drove ``transition.change_state(state)``
+directly (bypassing the ``instance.process.<action>()`` entrypoint users
+actually call), mocked ``change_state`` to assert it was called, and
+asserted on private helpers like ``_init_transition_context``. Those tests
+re-stated the implementation and prevented nothing.
 
-from django_logic.state import State
-from django_logic import Transition, Action, Process
-from tests.models import Invoice
+The replacements drive a real object through the real entrypoint and
+assert on the observable transformation: the state the object landed in,
+the ordered side-effects/callbacks that mutated it, the failure path's
+``failed_state`` + cleanup, the lock discipline, and the ``next_transition``
+context contract. Fixtures live in tests/background/models.py; binding in
+tests/background/apps.py.
+"""
+from django.test import override_settings
 
-
-def disable_invoice(invoice: Invoice, *args, **kwargs):
-    invoice.is_available = False
-    invoice.save()
-
-
-def update_invoice(invoice, is_available, customer_received, *args, **kwargs):
-    invoice.is_available = is_available
-    invoice.customer_received = customer_received
-    invoice.save()
-
-
-def enable_invoice(invoice: Invoice, *args, **kwargs):
-    invoice.is_available = True
-    invoice.save()
-
-
-def fail_invoice(invoice: Invoice, *args, **kwargs):
-    raise Exception
-
-
-def receive_invoice(invoice: Invoice, *args, **kwargs):
-    invoice.customer_received = True
-    invoice.save()
+from django_logic.testing import JourneyStep, ProcessScenario
+from tests.background.models import (
+    CALLBACK_SEEN_STATE,
+    SYNC_FSE_KWARGS,
+    SYNC_LAST_KWARGS,
+    SYNC_ORDER,
+    Widget,
+    WidgetAmbiguousNextProcess,
+    WidgetContextProcess,
+    WidgetSyncProcess,
+)
 
 
-def debug_action(*args, **kwargs):
-    pass
+# ProcessScenario runs in sync mode by default (BACKGROUND_EXECUTION='sync'
+# is set per-class via override_settings where background work is involved;
+# the sync Transition/Action tests below don't touch the background engine,
+# so the default sync setting is fine).
+_SYNC_SETTINGS = {
+    'LOCK_TIMEOUT': 7200,
+    'BACKGROUND_EXECUTION': 'sync',
+    'STARTER_QUEUE': 'django_logic.starter',
+    'TRANSITION_MESSAGE_MAX_ERRORS': 3,
+    'TRANSITION_MESSAGE_RETRY_MINUTES': 2,
+    'TRANSITION_MESSAGE_CLEANUP_DAYS': 7,
+}
 
 
-class TransitionSideEffectsTestCase(TestCase):
-    def setUp(self) -> None:
-        self.invoice = Invoice.objects.create(status='draft')
+@override_settings(DJANGO_LOGIC=_SYNC_SETTINGS)
+class TransitionSideEffectsScenario(ProcessScenario):
+    process_class = WidgetSyncProcess
+    model = Widget
+    state_field = 'status'
+    process_name = 'sync_proc'
 
-    def test_one_side_effect(self):
-        transition = Transition('test', sources=['draft'], target='cancelled', side_effects=[disable_invoice])
-        self.assertTrue(self.invoice.is_available)
-        state = State(self.invoice, 'status')
-        transition.change_state(state)
-        self.assertEqual(self.invoice.status, transition.target)
-        self.assertFalse(self.invoice.is_available)
-        self.assertFalse(state.is_locked())
+    def test_side_effects_run_in_order_and_write_target(self):
+        widget = self.create_instance(status='draft')
+        self.transition(widget, 'approve')
+        self.assert_state(widget, 'notified')  # approve -> notify (next_transition)
+        self.assert_side_effects_ran(['se_a', 'se_b', 'se_c'])
+        widget.refresh_from_db()
+        # se_log records the declaration order verbatim.
+        self.assertEqual(widget.se_log, 'a,b,c,')
 
-    def test_many_side_effects(self):
-        transition = Transition('test', sources=['draft'], target='cancelled',
-                                side_effects=[disable_invoice, enable_invoice])
-        self.assertTrue(self.invoice.is_available)
-        state = State(self.invoice, 'status')
-        transition.change_state(state)
-        self.assertEqual(self.invoice.status, transition.target)
-        self.assertTrue(self.invoice.is_available)
-        self.assertFalse(state.is_locked())
+    def test_callback_runs_after_target_is_written(self):
+        # Ordering is made OBSERVABLE: 'finalize' has a callback that reads the
+        # persisted state at call time. If the target is written before
+        # callbacks run (the contract), the callback sees 'finalized'. A
+        # regression that runs callbacks before the state write would record
+        # 'draft' here and fail — the previous version of this test could not
+        # tell the difference.
+        CALLBACK_SEEN_STATE.clear()
+        widget = self.create_instance(status='draft')
+        self.transition(widget, 'finalize')
+        self.assert_state(widget, 'finalized')
+        self.assert_callbacks_ran(['cb_record_seen_state'])
+        self.assertEqual(CALLBACK_SEEN_STATE, ['finalized'])
+        widget.refresh_from_db()
+        self.assertIn('seen_state,', widget.cb_log)
 
-    def test_failure_during_side_effect(self):
-        transition = Transition('test', sources=['draft'], target='cancelled',
-                                side_effects=[disable_invoice, fail_invoice, enable_invoice])
-        self.assertTrue(self.invoice.is_available)
-        state = State(self.invoice, 'status')
-        with self.assertRaises(Exception):
-            transition.change_state(state)
-        self.assertEqual(self.invoice.status, 'draft')
-        self.assertFalse(self.invoice.is_available)
-        self.assertFalse(state.is_locked())
+    def test_callback_exception_is_swallowed_and_target_kept(self):
+        # A raising callback is best-effort: the target state survives and
+        # the exception does not propagate out of the entrypoint.
+        widget = self.create_instance(status='draft')
+        # 'boom_callback' has a callback that raises; the drive must not
+        # surface it (Callbacks.execute swallows).
+        self.transition(widget, 'boom_callback')
+        self.assert_state(widget, 'boom_done')
+        self.assert_state_trace(['boom_done'])
 
-    def test_failure_during_side_effect_with_failed_state(self):
-        transition = Transition('test', sources=['draft'], target='cancelled', failed_state='failed',
-                                side_effects=[disable_invoice, fail_invoice, enable_invoice])
-        self.assertTrue(self.invoice.is_available)
-        state = State(self.invoice, 'status')
-        with self.assertRaises(Exception):
-            transition.change_state(state)
-        self.assertEqual(self.invoice.status, 'failed')
-        self.assertFalse(self.invoice.is_available)
-        self.assertFalse(state.is_locked())
-
-    def test_side_effect_with_parameters(self):
-        update_invoice(self.invoice, is_available=True, customer_received=True)
-        transition = Transition('test', sources=['draft'], target='cancelled', failed_state='failed',
-                                side_effects=[update_invoice])
-        self.invoice.refresh_from_db()
-        self.assertTrue(self.invoice.is_available)
-        self.assertTrue(self.invoice.customer_received)
-        state = State(self.invoice, 'status')
-        transition.change_state(state, is_available=False, customer_received=False)
-        self.invoice.refresh_from_db()
-        self.assertFalse(self.invoice.is_available)
-        self.assertFalse(self.invoice.customer_received)
-        self.assertFalse(state.is_locked())
-
-
-class TransitionCallbacksTestCase(TestCase):
-    def setUp(self) -> None:
-        self.invoice = Invoice.objects.create(status='draft')
-
-    def test_one_callback(self):
-        transition = Transition('test', sources=['draft'], target='cancelled', callbacks=[disable_invoice])
-        self.assertTrue(self.invoice.is_available)
-        state = State(self.invoice, 'status')
-        transition.change_state(state)
-        self.assertEqual(self.invoice.status, transition.target)
-        self.assertFalse(self.invoice.is_available)
-        self.assertFalse(state.is_locked())
-
-    def test_many_callbacks(self):
-        transition = Transition('test', sources=['draft'], target='cancelled',
-                                callbacks=[disable_invoice, enable_invoice])
-        self.assertTrue(self.invoice.is_available)
-        state = State(self.invoice, 'status')
-        transition.change_state(state)
-        self.assertEqual(self.invoice.status, transition.target)
-        self.assertTrue(self.invoice.is_available)
-        self.assertFalse(state.is_locked())
-
-    def test_failure_during_callbacks(self):
-        transition = Transition('test', sources=['draft'], target='cancelled',
-                                callbacks=[disable_invoice, fail_invoice, enable_invoice])
-        self.assertTrue(self.invoice.is_available)
-        state = State(self.invoice, 'status')
-        transition.change_state(state)
-        self.assertEqual(self.invoice.status, 'cancelled')
-        self.assertFalse(self.invoice.is_available)
-        self.assertFalse(state.is_locked())
-
-    def test_failure_during_callbacks_with_failed_state(self):
-        transition = Transition('test', sources=['draft'], target='cancelled', failed_state='failed',
-                                side_effects=[disable_invoice, fail_invoice, enable_invoice])
-        self.assertTrue(self.invoice.is_available)
-        state = State(self.invoice, 'status')
-        with self.assertRaises(Exception):
-            transition.change_state(state)
-        self.assertEqual(self.invoice.status, 'failed')
-        self.assertFalse(self.invoice.is_available)
-        self.assertFalse(state.is_locked())
-
-    def test_callbacks_with_parameters(self):
-        update_invoice(self.invoice, is_available=True, customer_received=True)
-        transition = Transition('test', sources=['draft'], target='cancelled', failed_state='failed',
-                                callbacks=[update_invoice])
-        self.invoice.refresh_from_db()
-        self.assertTrue(self.invoice.is_available)
-        self.assertTrue(self.invoice.customer_received)
-        state = State(self.invoice, 'status')
-        transition.change_state(state, is_available=False, customer_received=False)
-        self.invoice.refresh_from_db()
-        self.assertFalse(self.invoice.is_available)
-        self.assertFalse(self.invoice.customer_received)
-        self.assertFalse(state.is_locked())
-
-
-class TransitionFailureCallbacksTestCase(TestCase):
-    def setUp(self) -> None:
-        self.invoice = Invoice.objects.create(status='draft')
-
-    def test_one_callback(self):
-        transition = Transition('test', sources=['draft'], target='success', side_effects=[fail_invoice],
-                                failure_callbacks=[disable_invoice], failed_state='failed')
-        self.assertTrue(self.invoice.is_available)
-        state = State(self.invoice, 'status')
-        with self.assertRaises(Exception):
-            transition.change_state(state)
-        self.assertEqual(self.invoice.status, 'failed')
-        self.assertFalse(self.invoice.is_available)
-        self.assertFalse(state.is_locked())
-
-    def test_many_callback(self):
-        transition = Transition('test', sources=['draft'], target='success', side_effects=[fail_invoice],
-                                failure_callbacks=[disable_invoice, receive_invoice], failed_state='failed')
-        self.assertTrue(self.invoice.is_available)
-        self.assertFalse(self.invoice.customer_received)
-        state = State(self.invoice, 'status')
-        with self.assertRaises(Exception):
-            transition.change_state(state)
-        self.assertEqual(self.invoice.status, 'failed')
-        self.assertFalse(self.invoice.is_available)
-        self.assertTrue(self.invoice.customer_received)
-        self.assertFalse(state.is_locked())
-
-    def test_callbacks_with_parameters(self):
-        update_invoice(self.invoice, is_available=True, customer_received=True)
-        transition = Transition('test', sources=['draft'], target='success', failed_state='failed',
-                                side_effects=[fail_invoice], failure_callbacks=[update_invoice])
-        self.invoice.refresh_from_db()
-        self.assertTrue(self.invoice.is_available)
-        self.assertTrue(self.invoice.customer_received)
-        state = State(self.invoice, 'status')
-        with self.assertRaises(Exception):
-            transition.change_state(state, is_available=False, customer_received=False)
-        self.invoice.refresh_from_db()
-        self.assertEqual(self.invoice.status, 'failed')
-        self.assertFalse(self.invoice.is_available)
-        self.assertFalse(self.invoice.customer_received)
-        self.assertFalse(state.is_locked())
-
-    def test_failure_callback_exception_passed(self):
-        failure_callback_mock = Mock(__name__='test_failure_callback')
-        transition = Transition('test', sources=['draft'], target='success', failed_state='failed',
-                                side_effects=[fail_invoice], failure_callbacks=[failure_callback_mock])
-        self.invoice.refresh_from_db()
-        state = State(self.invoice, 'status')
-        with self.assertRaises(Exception):
-            transition.change_state(state, foo="bar")
-        failure_callback_mock.assert_called_once()
-        call_args = failure_callback_mock.call_args[0]
-        call_kwargs = failure_callback_mock.call_args[1]
-        self.assertEqual(call_args, (self.invoice,))
-        self.assertIn('exception', call_kwargs)
-        self.assertTrue(isinstance(call_kwargs['exception'], Exception))
-        self.assertEqual(call_kwargs['foo'], 'bar')
-
-
-class TransitionFailureSideEffectsTestCase(TestCase):
-    def setUp(self) -> None:
-        self.invoice = Invoice.objects.create(status='draft')
-
-    def test_one_failure_side_effect(self):
-        transition = Transition('test', sources=['draft'], target='success', side_effects=[fail_invoice],
-                                failure_side_effects=[disable_invoice], failed_state='failed')
-        self.assertTrue(self.invoice.is_available)
-        state = State(self.invoice, 'status')
-        with self.assertRaises(Exception):
-            transition.change_state(state)
-        self.assertEqual(self.invoice.status, 'failed')
-        self.assertFalse(self.invoice.is_available)
-        self.assertFalse(state.is_locked())
-
-    def test_many_failure_side_effects(self):
-        transition = Transition('test', sources=['draft'], target='success', side_effects=[fail_invoice],
-                                failure_side_effects=[disable_invoice, receive_invoice], failed_state='failed')
-        self.assertTrue(self.invoice.is_available)
-        self.assertFalse(self.invoice.customer_received)
-        state = State(self.invoice, 'status')
-        with self.assertRaises(Exception):
-            transition.change_state(state)
-        self.assertEqual(self.invoice.status, 'failed')
-        self.assertFalse(self.invoice.is_available)
-        self.assertTrue(self.invoice.customer_received)
-        self.assertFalse(state.is_locked())
-
-    def test_failure_side_effect_with_parameters(self):
-        update_invoice(self.invoice, is_available=True, customer_received=True)
-        transition = Transition('test', sources=['draft'], target='success', failed_state='failed',
-                                side_effects=[fail_invoice], failure_side_effects=[update_invoice])
-        self.invoice.refresh_from_db()
-        self.assertTrue(self.invoice.is_available)
-        self.assertTrue(self.invoice.customer_received)
-        state = State(self.invoice, 'status')
-        with self.assertRaises(Exception):
-            transition.change_state(state, is_available=False, customer_received=False)
-        self.invoice.refresh_from_db()
-        self.assertEqual(self.invoice.status, 'failed')
-        self.assertFalse(self.invoice.is_available)
-        self.assertFalse(self.invoice.customer_received)
-        self.assertFalse(state.is_locked())
-
-    def test_failure_side_effect_exception_passed(self):
-        failure_side_effect_mock = Mock(__name__='test_failure_side_effect')
-        transition = Transition('test', sources=['draft'], target='success', failed_state='failed',
-                                side_effects=[fail_invoice], failure_side_effects=[failure_side_effect_mock])
-        state = State(self.invoice, 'status')
-        with self.assertRaises(Exception):
-            transition.change_state(state, foo="bar")
-        failure_side_effect_mock.assert_called_once()
-        call_args = failure_side_effect_mock.call_args[0]
-        call_kwargs = failure_side_effect_mock.call_args[1]
-        self.assertEqual(call_args, (self.invoice,))
-        self.assertIn('exception', call_kwargs)
-        self.assertTrue(isinstance(call_kwargs['exception'], Exception))
-        self.assertEqual(call_kwargs['foo'], 'bar')
+    def test_failure_during_side_effect_writes_failed_state(self):
+        widget = self.create_instance(status='draft')
+        self.transition(
+            widget, 'reject',
+            fail_side_effect='se_reject_attempt', fail_with=ValueError('reject broke'),
+        )
+        self.assert_state(widget, 'rejection_failed')
+        self.assert_state_trace(['rejection_failed'])
+        # The success side-effect did not complete; the failure hooks ran.
+        self.assert_side_effects_not_ran(['se_reject_attempt'])
+        self.assert_failure_side_effects_ran(['fse_cleanup'])
+        self.assert_failure_callbacks_ran(['fcb_on_fail'])
 
     def test_failure_side_effects_run_before_failure_callbacks(self):
-        order = []
-
-        def failure_side_effect(invoice, *args, **kwargs):
-            order.append('failure_side_effect')
-
-        def failure_callback(invoice, *args, **kwargs):
-            order.append('failure_callback')
-
-        transition = Transition('test', sources=['draft'], target='success', failed_state='failed',
-                                side_effects=[fail_invoice],
-                                failure_side_effects=[failure_side_effect],
-                                failure_callbacks=[failure_callback])
-        state = State(self.invoice, 'status')
-        with self.assertRaises(Exception):
-            transition.change_state(state)
-        self.assertEqual(order, ['failure_side_effect', 'failure_callback'])
-
-
-class ActionSideEffectsTestCase(TestCase):
-    def setUp(self) -> None:
-        self.invoice = Invoice.objects.create(status='draft')
-
-    def test_one_side_effect(self):
-        action = Action('test', sources=['draft'], side_effects=[disable_invoice])
-        self.assertTrue(self.invoice.is_available)
-        state = State(self.invoice, 'status')
-        action.change_state(state)
-        self.assertEqual(self.invoice.status, 'draft')  # not changed
-        self.assertFalse(self.invoice.is_available)
-        self.assertFalse(state.is_locked())
-
-    def test_many_side_effects(self):
-        action = Action('test', sources=['draft'], side_effects=[disable_invoice, enable_invoice])
-        self.assertTrue(self.invoice.is_available)
-        state = State(self.invoice, 'status')
-        action.change_state(state)
-        self.assertEqual(self.invoice.status, 'draft')
-        self.assertTrue(self.invoice.is_available)
-        self.assertFalse(state.is_locked())
-
-    def test_failure_during_side_effect(self):
-        action = Action('test', sources=['draft'], side_effects=[disable_invoice, fail_invoice, enable_invoice])
-        self.assertTrue(self.invoice.is_available)
-        state = State(self.invoice, 'status')
-        with self.assertRaises(Exception):
-            action.change_state(state)
-        self.assertEqual(self.invoice.status, 'draft')
-        self.assertFalse(self.invoice.is_available)
-        self.assertFalse(state.is_locked())
-
-    def test_failure_during_side_effect_with_failed_state(self):
-        action = Action('test', sources=['draft'], failed_state='failed', side_effects=[disable_invoice, fail_invoice, enable_invoice])
-        self.assertTrue(self.invoice.is_available)
-        state = State(self.invoice, 'status')
-        with self.assertRaises(Exception):
-            action.change_state(state)
-        self.assertEqual(self.invoice.status, 'failed')
-        self.assertFalse(self.invoice.is_available)
-        self.assertFalse(state.is_locked())
-
-    def test_side_effect_with_parameters(self):
-        update_invoice(self.invoice, is_available=True, customer_received=True)
-        action = Action('test', sources=['draft'], failed_state='failed', side_effects=[update_invoice])
-        self.invoice.refresh_from_db()
-        self.assertTrue(self.invoice.is_available)
-        self.assertTrue(self.invoice.customer_received)
-        state = State(self.invoice, 'status')
-        action.change_state(state, is_available=False, customer_received=False)
-        self.invoice.refresh_from_db()
-        self.assertFalse(self.invoice.is_available)
-        self.assertFalse(self.invoice.customer_received)
-        self.assertFalse(state.is_locked())
-
-    def test_failed_action_does_not_release_a_concurrent_lock(self):
-        # An Action never acquires the state lock (change_state skips
-        # state.lock()), so a *failing* Action must not release one either.
-        # Otherwise it would delete the lock a concurrent Transition on the
-        # same instance/field legitimately holds. Regression for Action
-        # inheriting Transition.fail_transition's unconditional unlock().
-        state = State(self.invoice, 'status')
-        self.assertTrue(state.lock())  # a concurrent transition holds it
-        action = Action('test', sources=['draft'], side_effects=[fail_invoice])
-        with self.assertRaises(Exception):
-            action.change_state(state)
-        self.assertTrue(
-            state.is_locked(),
-            'failing Action released a lock it never acquired',
+        SYNC_ORDER.clear()
+        widget = self.create_instance(status='draft')
+        self.transition(
+            widget, 'reject',
+            fail_side_effect='se_reject_attempt', fail_with=ValueError('boom'),
         )
-        state.unlock()  # cleanup
+        self.assertEqual(SYNC_ORDER, ['fse:cleanup', 'fcb:on_fail'])
 
+    def test_lock_is_released_after_success(self):
+        widget = self.create_instance(status='draft')
+        self.transition(widget, 'approve')
+        self.assertFalse(self._process(widget).state.is_locked())
 
-class ActionCallbacksTestCase(TestCase):
-    def setUp(self) -> None:
-        self.invoice = Invoice.objects.create(status='draft')
-
-    def test_one_callback(self):
-        action = Action('test', sources=['draft'], callbacks=[disable_invoice])
-        self.assertTrue(self.invoice.is_available)
-        state = State(self.invoice, 'status')
-        action.change_state(state)
-        self.assertEqual(self.invoice.status, 'draft')
-        self.assertFalse(self.invoice.is_available)
-        self.assertFalse(state.is_locked())
-
-    def test_many_callbacks(self):
-        action = Action('test', sources=['draft'], callbacks=[disable_invoice, enable_invoice])
-        self.assertTrue(self.invoice.is_available)
-        state = State(self.invoice, 'status')
-        action.change_state(state)
-        self.assertEqual(self.invoice.status, 'draft')
-        self.assertTrue(self.invoice.is_available)
-        self.assertFalse(state.is_locked())
-
-    def test_failure_during_callbacks(self):
-        action = Action('test', sources=['draft'], callbacks=[disable_invoice, fail_invoice, enable_invoice])
-        self.assertTrue(self.invoice.is_available)
-        state = State(self.invoice, 'status')
-        action.change_state(state)
-        self.assertEqual(self.invoice.status, 'draft')
-        self.assertFalse(self.invoice.is_available)
-        self.assertFalse(state.is_locked())
-
-    def test_failure_during_callbacks_with_failed_state(self):
-        action = Action('test', failed_state='failed', sources=['draft'], side_effects=[disable_invoice, fail_invoice, enable_invoice])
-        self.assertTrue(self.invoice.is_available)
-        state = State(self.invoice, 'status')
-        with self.assertRaises(Exception):
-            action.change_state(state)
-        self.assertEqual(self.invoice.status, 'failed')
-        self.assertFalse(self.invoice.is_available)
-        self.assertFalse(state.is_locked())
-
-    def test_callbacks_with_parameters(self):
-        update_invoice(self.invoice, is_available=True, customer_received=True)
-        action = Action('test', failed_state='failed', sources=['draft'], callbacks=[update_invoice])
-        self.invoice.refresh_from_db()
-        self.assertTrue(self.invoice.is_available)
-        self.assertTrue(self.invoice.customer_received)
-        state = State(self.invoice, 'status')
-        action.change_state(state, is_available=False, customer_received=False)
-        self.invoice.refresh_from_db()
-        self.assertFalse(self.invoice.is_available)
-        self.assertFalse(self.invoice.customer_received)
-        self.assertFalse(state.is_locked())
-
-
-class ActionFailureCallbacksTestCase(TestCase):
-    def setUp(self) -> None:
-        self.invoice = Invoice.objects.create(status='draft')
-
-    def test_one_callback(self):
-        action = Action('test', side_effects=[fail_invoice], sources=['draft'],
-                        failure_callbacks=[disable_invoice], failed_state='failed')
-        self.assertTrue(self.invoice.is_available)
-        state = State(self.invoice, 'status')
-        with self.assertRaises(Exception):
-            action.change_state(state)
-        self.assertEqual(self.invoice.status, 'failed')
-        self.assertFalse(self.invoice.is_available)
-        self.assertFalse(state.is_locked())
-
-    def test_many_callback(self):
-        action = Action('test', side_effects=[fail_invoice], sources=['draft'],
-                        failure_callbacks=[disable_invoice, receive_invoice], failed_state='failed')
-        self.assertTrue(self.invoice.is_available)
-        self.assertFalse(self.invoice.customer_received)
-        state = State(self.invoice, 'status')
-        with self.assertRaises(Exception):
-            action.change_state(state)
-        self.assertEqual(self.invoice.status, 'failed')
-        self.assertFalse(self.invoice.is_available)
-        self.assertTrue(self.invoice.customer_received)
-        self.assertFalse(state.is_locked())
-
-    def test_callbacks_with_parameters(self):
-        update_invoice(self.invoice, is_available=True, customer_received=True)
-        action = Action('test', failed_state='failed',
-                        side_effects=[fail_invoice], sources=['draft'], failure_callbacks=[update_invoice])
-        self.invoice.refresh_from_db()
-        self.assertTrue(self.invoice.is_available)
-        self.assertTrue(self.invoice.customer_received)
-        state = State(self.invoice, 'status')
-        with self.assertRaises(Exception):
-            action.change_state(state, is_available=False, customer_received=False)
-        self.invoice.refresh_from_db()
-        self.assertEqual(self.invoice.status, 'failed')
-        self.assertFalse(self.invoice.is_available)
-        self.assertFalse(self.invoice.customer_received)
-        self.assertFalse(state.is_locked())
-
-    def test_failure_callback_exception_passed(self):
-        failure_callback_mock = Mock(__name__='test_failure_callback')
-        action = Action('test', failed_state='failed',
-                        side_effects=[fail_invoice], sources=['draft'], failure_callbacks=[failure_callback_mock])
-        self.invoice.refresh_from_db()
-        state = State(self.invoice, 'status')
-        with self.assertRaises(Exception):
-            action.change_state(state, foo="bar")
-        failure_callback_mock.assert_called_once()
-        call_args = failure_callback_mock.call_args[0]
-        call_kwargs = failure_callback_mock.call_args[1]
-        self.assertEqual(call_args, (self.invoice,))
-        self.assertIn('exception', call_kwargs)
-        self.assertTrue(isinstance(call_kwargs['exception'], Exception))
-        self.assertEqual(call_kwargs['foo'], 'bar')
-
-
-class ActionFailureSideEffectsTestCase(TestCase):
-    def setUp(self) -> None:
-        self.invoice = Invoice.objects.create(status='draft')
-
-    def test_one_failure_side_effect(self):
-        action = Action('test', sources=['draft'], side_effects=[fail_invoice],
-                        failure_side_effects=[disable_invoice], failed_state='failed')
-        self.assertTrue(self.invoice.is_available)
-        state = State(self.invoice, 'status')
-        with self.assertRaises(Exception):
-            action.change_state(state)
-        self.assertEqual(self.invoice.status, 'failed')
-        self.assertFalse(self.invoice.is_available)
-        self.assertFalse(state.is_locked())
-
-    def test_many_failure_side_effects(self):
-        action = Action('test', sources=['draft'], side_effects=[fail_invoice],
-                        failure_side_effects=[disable_invoice, receive_invoice], failed_state='failed')
-        self.assertTrue(self.invoice.is_available)
-        self.assertFalse(self.invoice.customer_received)
-        state = State(self.invoice, 'status')
-        with self.assertRaises(Exception):
-            action.change_state(state)
-        self.assertEqual(self.invoice.status, 'failed')
-        self.assertFalse(self.invoice.is_available)
-        self.assertTrue(self.invoice.customer_received)
-        self.assertFalse(state.is_locked())
-
-    def test_failure_side_effect_exception_passed(self):
-        failure_side_effect_mock = Mock(__name__='test_failure_side_effect')
-        action = Action('test', failed_state='failed', sources=['draft'],
-                        side_effects=[fail_invoice], failure_side_effects=[failure_side_effect_mock])
-        state = State(self.invoice, 'status')
-        with self.assertRaises(Exception):
-            action.change_state(state, foo="bar")
-        failure_side_effect_mock.assert_called_once()
-        call_args = failure_side_effect_mock.call_args[0]
-        call_kwargs = failure_side_effect_mock.call_args[1]
-        self.assertEqual(call_args, (self.invoice,))
-        self.assertIn('exception', call_kwargs)
-        self.assertTrue(isinstance(call_kwargs['exception'], Exception))
-        self.assertEqual(call_kwargs['foo'], 'bar')
-
-
-class TransitionNextTransitionTestCase(TestCase):
-    TRANSITION_NAME = 'transition_test'
-    NEXT_TRANSITION_NAME = 'next_transition_test'
-
-    def setUp(self) -> None:
-        self.invoice = Invoice.objects.create(status=Invoice.STATUS_DRAFT)
-        self.state = State(self.invoice, 'status', 'process')
-
-        # next transition
-        self.next_transition = Transition(self.NEXT_TRANSITION_NAME,
-                                          sources=[Invoice.STATUS_SUCCESS],
-                                          target=Invoice.STATUS_CANCELLED)
-
-        class TestProcess(Process):
-            transitions = [
-                self.next_transition,
-            ]
-
-        self.process = TestProcess(instance=self.invoice, state=self.state)
-        self.invoice.process = self.process
-
-    def test_successful_next_transition(self):
-        transition1 = Transition(self.TRANSITION_NAME,
-                                 sources=[Invoice.STATUS_DRAFT],
-                                 target=Invoice.STATUS_SUCCESS,
-                                 next_transition=self.NEXT_TRANSITION_NAME)
-        self.process.transitions.append(transition1)
-
-        with patch.object(self.next_transition, 'change_state') as next_transition_mock:
-            transition1.change_state(self.state)
-
-        next_transition_mock.assert_called_once()
-
-    def test_failed_next_transition(self):
-        transition1 = Transition(self.TRANSITION_NAME,
-                                 sources=[Invoice.STATUS_DRAFT],
-                                 target=Invoice.STATUS_SUCCESS,
-                                 failed_state=Invoice.STATUS_FAILED,
-                                 side_effects=[fail_invoice],
-                                 next_transition=self.NEXT_TRANSITION_NAME)
-        self.process.transitions.append(transition1)
-
-        with patch.object(self.next_transition, 'change_state') as next_transition_mock:
-            with self.assertRaises(Exception):
-                transition1.change_state(self.state)
-
-        next_transition_mock.assert_not_called()
-
-    def test_next_transition_runs_end_to_end_with_fresh_context(self):
-        # Unmocked: prove the follow-up actually runs through the Process
-        # entrypoint and gets its OWN tr_id while chaining root_id and
-        # linking parent_id to the parent's tr_id.
-        captured = {}
-
-        def capture(invoice, **kwargs):
-            captured.update(kwargs)
-
-        child = Transition(
-            self.NEXT_TRANSITION_NAME,
-            sources=[Invoice.STATUS_SUCCESS],
-            target=Invoice.STATUS_CANCELLED,
-            side_effects=[capture],
+    def test_lock_is_released_after_failure(self):
+        widget = self.create_instance(status='draft')
+        self.transition(
+            widget, 'reject',
+            fail_side_effect='se_reject_attempt', fail_with=ValueError('boom'),
         )
-        parent = Transition(
-            self.TRANSITION_NAME,
-            sources=[Invoice.STATUS_DRAFT],
-            target=Invoice.STATUS_SUCCESS,
-            next_transition=self.NEXT_TRANSITION_NAME,
+        self.assertFalse(self._process(widget).state.is_locked())
+
+
+@override_settings(DJANGO_LOGIC=_SYNC_SETTINGS)
+class ActionScenario(ProcessScenario):
+    process_class = WidgetSyncProcess
+    model = Widget
+    state_field = 'status'
+    process_name = 'sync_proc'
+
+    def test_action_runs_side_effects_without_changing_state(self):
+        widget = self.create_instance(status='draft')
+        self.transition(widget, 'poke')
+        self.assert_state(widget, 'draft')
+        self.assert_state_trace([])  # an Action never writes state on success
+        self.assert_side_effects_ran(['se_poke'])
+        self.assert_callbacks_ran(['cb_after_poke'])
+
+    def test_action_failure_writes_failed_state_when_unlocked(self):
+        widget = self.create_instance(status='draft')
+        self.transition(
+            widget, 'poke_fail',
+            fail_side_effect='se_poke_attempt', fail_with=ValueError('poke broke'),
         )
+        self.assert_state(widget, 'poked_failed')
+        self.assert_state_trace(['poked_failed'])
+        self.assert_failure_callbacks_ran(['fcb_on_poke_fail'])
 
-        class _P(Process):
-            transitions = [child, parent]
+    def test_failing_action_does_not_release_a_concurrent_lock(self):
+        # An Action never acquires the state lock, so a failing Action must
+        # not release one a concurrent Transition holds. This is the
+        # regression behind Action.fail_transition not calling unlock().
+        widget = self.create_instance(status='draft')
+        state = self._process(widget).state
+        self.assertTrue(state.lock(), 'pre-condition: acquire the lock')
+        try:
+            self.transition(
+                widget, 'poke_fail',
+                fail_side_effect='se_poke_attempt', fail_with=ValueError('poke broke'),
+            )
+            self.assertTrue(
+                state.is_locked(),
+                'failing Action released a lock it never acquired',
+            )
+            # failed_state is skipped while locked — object stays put.
+            self.assert_state(widget, 'draft')
+        finally:
+            state.unlock()
 
-        process = _P(instance=self.invoice, state=self.state)
-        self.invoice.process = process
 
-        parent.change_state(self.state, root_id='ROOT', tr_id='PARENT_TR')
+@override_settings(DJANGO_LOGIC=_SYNC_SETTINGS)
+class KwargsAndFailureContractScenario(ProcessScenario):
+    """The kwargs + ``exception`` contract side-effects/callbacks receive."""
 
-        self.invoice.refresh_from_db()
-        # The whole chain ran unmocked: parent -> success -> follow-up -> cancelled.
-        self.assertEqual(self.invoice.status, Invoice.STATUS_CANCELLED)
-        # Follow-up got a fresh tr_id, parent_id = parent's tr_id, root_id chained.
+    process_class = WidgetSyncProcess
+    model = Widget
+    state_field = 'status'
+    process_name = 'sync_proc'
+
+    def test_kwargs_forwarded_to_side_effects(self):
+        widget = self.create_instance(status='draft')
+        self.transition(widget, 'capture', foo='bar', amount=42)
+        self.assertEqual(SYNC_LAST_KWARGS.get('foo'), 'bar')
+        self.assertEqual(SYNC_LAST_KWARGS.get('amount'), 42)
+
+    def test_failure_callback_receives_exception_and_forwarded_kwargs(self):
+        widget = self.create_instance(status='draft')
+        self.transition(
+            widget, 'capture_fail',
+            fail_side_effect='sync_boom', fail_with=ValueError('captured boom'),
+            foo='bar',
+        )
+        self.assert_state(widget, 'capture_failed')
+        # The failure callback got the original exception + the caller's kwarg.
+        self.assertIsInstance(SYNC_LAST_KWARGS.get('exception'), ValueError)
+        self.assertIn('captured boom', str(SYNC_LAST_KWARGS['exception']))
+        self.assertEqual(SYNC_LAST_KWARGS.get('foo'), 'bar')
+
+    def test_failure_side_effect_receives_exception_and_forwarded_kwargs(self):
+        # Same contract for failure_SIDE_EFFECTS (not just failure_callbacks):
+        # they are called with the original exception and the caller's kwargs.
+        SYNC_FSE_KWARGS.clear()
+        widget = self.create_instance(status='draft')
+        self.transition(
+            widget, 'capture_fail',
+            fail_side_effect='sync_boom', fail_with=ValueError('fse boom'),
+            ticket=7,
+        )
+        self.assert_state(widget, 'capture_failed')
+        self.assertIsInstance(SYNC_FSE_KWARGS.get('exception'), ValueError)
+        self.assertIn('fse boom', str(SYNC_FSE_KWARGS['exception']))
+        self.assertEqual(SYNC_FSE_KWARGS.get('ticket'), 7)
+
+
+@override_settings(DJANGO_LOGIC=_SYNC_SETTINGS)
+class NextTransitionScenario(ProcessScenario):
+    """``next_transition`` behavior — the follow-up runs through the entrypoint
+    with a fresh ``tr_id`` and chained ``root_id``/``parent_id``, only on
+    success, and is refused when ambiguous."""
+
+    process_class = WidgetContextProcess
+    model = Widget
+    state_field = 'status'
+    process_name = 'ctx_proc'
+
+    def test_follow_up_runs_with_fresh_tr_id_and_chained_context(self):
+        widget = self.create_instance(status='draft')
+        # Drive the parent through the entrypoint with a caller-supplied
+        # root_id. The follow-up (child_act) captures its kwargs.
+        self.transition(widget, 'parent_act', root_id='ROOT')
+        # The whole chain ran: parent_done -> child_done.
+        self.assert_state(widget, 'child_done')
+        self.assert_state_trace(['parent_done', 'child_done'])
+        self.assert_side_effects_ran(['se_parent', 'sync_capture'])
+
+        # The follow-up got its OWN tr_id (not the parent's), the root_id
+        # chained from the caller, and parent_id links to the parent's tr_id.
+        captured = SYNC_LAST_KWARGS
         self.assertEqual(captured.get('root_id'), 'ROOT')
-        self.assertEqual(captured.get('parent_id'), 'PARENT_TR')
-        self.assertNotEqual(captured.get('tr_id'), 'PARENT_TR')
         self.assertIsNotNone(captured.get('tr_id'))
+        self.assertIsNotNone(captured.get('parent_id'))
+        self.assertNotEqual(captured.get('tr_id'), captured.get('parent_id'))
+        # parent_id is the parent's tr_id, not the root.
+        self.assertNotEqual(captured.get('parent_id'), 'ROOT')
 
-    def test_ambiguous_next_transition_is_refused(self):
-        # Two follow-ups share the action_name and are both available; the
-        # follow-up must be refused (logged + skipped), not run arbitrarily.
-        ran = []
+    def test_journey_pins_the_chain(self):
+        widget = self.create_instance(status='draft')
+        self.transition(widget, 'parent_act', root_id='ROOT')
+        self.assert_journey([
+            JourneyStep(
+                action='parent_act',
+                before='draft',
+                after='child_done',
+                side_effects=['se_parent', 'sync_capture'],
+                callbacks=[],
+                failed=False,
+            ),
+        ])
 
-        def se(invoice, **kwargs):
-            ran.append(invoice.pk)
 
-        child_a = Transition(
-            self.NEXT_TRANSITION_NAME, sources=[Invoice.STATUS_SUCCESS],
-            target=Invoice.STATUS_CANCELLED, side_effects=[se],
+@override_settings(DJANGO_LOGIC=_SYNC_SETTINGS)
+class NextTransitionFailureScenario(ProcessScenario):
+    """``next_transition`` must NOT fire when the parent transition fails."""
+
+    process_class = WidgetSyncProcess
+    model = Widget
+    state_field = 'status'
+    process_name = 'sync_proc'
+
+    def test_follow_up_skipped_when_parent_fails(self):
+        # 'approve' chains into 'notify' on success. Inject a failure on
+        # approve's first side-effect: the parent fails and re-raises to the
+        # caller (approve is the driven transition), the follow-up never fires,
+        # and — approve has no failed_state — the object stays in 'draft'.
+        widget = self.create_instance(status='draft')
+        self.transition(
+            widget, 'approve',
+            fail_side_effect='se_a', fail_with=ValueError('approve boom'),
+            expect_raises=ValueError,
         )
-        child_b = Transition(
-            self.NEXT_TRANSITION_NAME, sources=[Invoice.STATUS_SUCCESS],
-            target=Invoice.STATUS_FAILED, side_effects=[se],
-        )
-        parent = Transition(
-            self.TRANSITION_NAME, sources=[Invoice.STATUS_DRAFT],
-            target=Invoice.STATUS_SUCCESS,
-            next_transition=self.NEXT_TRANSITION_NAME,
-        )
-
-        class _P(Process):
-            transitions = [child_a, child_b, parent]
-
-        process = _P(instance=self.invoice, state=self.state)
-        self.invoice.process = process
-
-        parent.change_state(self.state)
-
-        self.invoice.refresh_from_db()
-        # Parent completed; ambiguous follow-up was refused, so neither ran.
-        self.assertEqual(self.invoice.status, Invoice.STATUS_SUCCESS)
-        self.assertEqual(ran, [])
+        # Landed back in the source state (no failed_state, no state write).
+        self.assert_state(widget, 'draft')
+        self.assert_state_trace([])
+        # se_a raised, so it never "ran"; se_b (approve's own) and se_c
+        # (notify's) never ran either — the whole chain stopped.
+        self.assert_side_effects_not_ran(['se_a', 'se_b', 'se_c'])
 
 
-class InitTransitionContextTestCase(TestCase):
-    def test_init_transition_context_test(self):
-        initial_context = {'test_key': 1}
-        Transition._init_transition_context(initial_context)
-        self.assertEqual(initial_context['context'], {})
-        self.assertEqual(initial_context['test_key'], 1)
+@override_settings(DJANGO_LOGIC=_SYNC_SETTINGS)
+class AmbiguousNextTransitionScenario(ProcessScenario):
+    """An ambiguous ``next_transition`` (two same-name follow-ups both
+    available, no disambiguating condition) is refused — neither runs —
+    rather than picking arbitrarily. The parent still completes."""
 
-    def test_existing_transition_context_test(self):
-        initial_context = {
-            'context': {'a': 1},
-        }
-        Transition._init_transition_context(initial_context)
-        self.assertEqual(initial_context['context'], {'a': 1})
+    process_class = WidgetAmbiguousNextProcess
+    model = Widget
+    state_field = 'status'
+    process_name = 'ambig_next'
+
+    def test_ambiguous_follow_up_runs_neither(self):
+        widget = self.create_instance(status='draft')
+        self.transition(widget, 'start')
+        # 'start' completed; the ambiguous follow-up was refused.
+        self.assert_state(widget, 'started')
+        self.assert_side_effects_ran(['se_start'])
+        self.assert_side_effects_not_ran(['se_follow_a', 'se_follow_b'])
+        self.assert_state_trace(['started'])  # no follow-up state write

--- a/tests/test_transition.py
+++ b/tests/test_transition.py
@@ -280,16 +280,25 @@ class NextTransitionFailureScenario(ProcessScenario):
         # Landed back in the source state (no failed_state, no state write).
         self.assert_state(widget, 'draft')
         self.assert_state_trace([])
-        # se_a raised, so it never "ran"; se_b (approve's own) and se_c
-        # (notify's) never ran either — the whole chain stopped.
-        self.assert_side_effects_not_ran(['se_a', 'se_b', 'se_c'])
+        # se_b (approve's own, after the failed se_a) and se_c (notify's
+        # follow-up) never ran — the whole chain stopped at the failure. (se_a
+        # is the injected target and never records regardless, so it carries
+        # no signal here and is deliberately not asserted.)
+        self.assert_side_effects_not_ran(['se_b', 'se_c'])
 
 
 @override_settings(DJANGO_LOGIC=_SYNC_SETTINGS)
 class AmbiguousNextTransitionScenario(ProcessScenario):
     """An ambiguous ``next_transition`` (two same-name follow-ups both
     available, no disambiguating condition) is refused — neither runs —
-    rather than picking arbitrarily. The parent still completes."""
+    rather than picking arbitrarily. The parent still completes.
+
+    Note: this pins the observable BEHAVIOUR ('runs neither'), which is
+    enforced by two independent layers — ``NextTransition.execute``'s own
+    ambiguity guard and the entrypoint's ``_resolve_transition_with_owner``
+    refusal (whose exception NextTransition swallows). It therefore does not
+    isolate either guard on its own; removing just one still leaves the object
+    in ``started``. That defence-in-depth is intended."""
 
     process_class = WidgetAmbiguousNextProcess
     model = Widget


### PR DESCRIPTION
Lands the process journey/contract testing work on `master`.

Supersedes #104 (which merged into the `fix/issue-100` base before the docs commit) — this brings the **complete** set to master, including the documentation.

**Harness** (`django_logic/testing/`): `expect_raises=` on the drive methods (assert an exception propagated to the caller, or `False` to assert it was swallowed) + `assert_raised`/`assert_not_raised`; domain-outcome helpers `capture`/`assert_changed`/`assert_unchanged`/`assert_related_count` (closes #103); `assert_state_trace`/`assert_journey`/`assert_transition_owner`.

**Engine contract tests** (mutation-verified to fail on the regression they name): re-raise vs swallow asymmetry (`test_exception_semantics.py`), the cross-machine failure cascade (`test_cross_machine_cascade.py`), background→background chaining (`test_bg_chain.py`).

**Restored coverage**: process-level conditions/permissions incl. nested (`test_process_guards.py`), real resolve-time ambiguity, callback-after-target ordering, no-`failed_state` landing, failure-hook exception kwargs — replacing the mirror halves of `test_process.py`/`test_transition.py`.

**Docs**: `TESTING_GUIDE.md` "Journeys, not mirrors" + guardrails + 5 new catalog scenarios + expanded API reference; README testing section; INDEX pointer.

Full suite green (337 tests). Companion consumer failure-path tests were validated on the real Heroku matrix (all 25 rows green) and merged in django-logic-test#2.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Substantial new public testing API and a broad test-suite rewrite; production transition runtime is largely untouched, but incorrect harness semantics could mislead consumers pinning caller-boundary and background-chain contracts.
> 
> **Overview**
> Extends **`django_logic.testing`** so process tests assert **journeys and outcomes**, not just that hooks ran. Drive methods gain **`expect_raises`** (re-raise vs swallow at the caller boundary), plus **`capture` / `assert_changed` / `assert_unchanged` / `assert_related_count`**, **`assert_state_trace`**, **`assert_journey`** with **`JourneyStep`**, **`assert_transition_owner`**, and **`message_for`** for per-transition `TransitionMessage` rows. **`track()`** now records an ordered **`state_trace`** by wrapping **`State.set_state`**.
> 
> Replaces large **mirror-style** suites in **`test_process.py`** and **`test_transition.py`** with **`ProcessScenario`** tests that hit **`instance.process.<action>()`**, backed by new fixtures in **`tests/background/models.py`** (sync matrix, bg→bg chains, ambiguity, process-level guards, cross-machine cascade).
> 
> Adds **named engine contract tests**: re-raise/swallow (**`test_exception_semantics.py`**), cross-machine failure cascade (**`test_cross_machine_cascade.py`**), background **`next_transition`** chaining and **`owning_process_class`** (**`test_bg_chain.py`**), and process-level **`is_valid`** guards (**`test_process_guards.py`**).
> 
> Documentation: new/expanded **`docs/TESTING_GUIDE.md`** (“journeys, not mirrors”), README testing section, and **`docs/INDEX.md`** link.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7657c2483018bc8492b294a97aa02809101b3bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->