### PR TITLE
Type-faithful kwargs round-trip, loud request drop, bind-time hook validation (#107, #108, #113)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+### Added — bind-time hook-signature validation (#113)
+
+- `ProcessManager.bind_model_process` now validates every hook across the
+  process tree (side-effects, callbacks, failure hooks, conditions,
+  permissions): the engine calls hooks as `fn(instance, **kwargs)`, so a
+  hook whose first parameter is not a named positional (e.g. task-style
+  `def hook(*args, **kwargs)`) is flagged at bind time instead of failing
+  at runtime on a worker. Warns by default;
+  `DJANGO_LOGIC['STRICT_HOOK_SIGNATURES'] = True` raises
+  `ImproperlyConfigured`.
+
 ### Changed — kwargs serialization (#107, #108)
 
 - **Type-faithful kwargs round-trip** (#108). Background-transition kwargs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,28 @@
 
 ## [Unreleased]
 
-_Nothing yet — the next release accumulates here._
+### Changed — kwargs serialization (#107, #108)
+
+- **Type-faithful kwargs round-trip** (#108). Background-transition kwargs
+  are now persisted with a self-describing type tag (`__dl_type__`) and
+  restored to their original Python types in phase 2: `datetime`, `date`,
+  `time`, `Decimal`, `UUID`, `tuple`, `set`, `frozenset` — recursively
+  inside containers. A side-effect now receives the same types whether its
+  transition is synchronous or background. `Decimal` and `set`, previously
+  rejected at phase 1, are now supported. Rows written by older versions
+  (plain ISO strings) still decode; deploy web and workers together when
+  upgrading across this boundary (an old worker passes tagged dicts through
+  verbatim). Model instances remain rejected — pass a pk and re-fetch.
+- **`request` is dropped loudly** (#107). Phase-1 serialization logs a
+  warning (with the tr_id) when it drops `request` from a background
+  transition's kwargs, and the new
+  `DJANGO_LOGIC['STRICT_KWARGS_SERIALIZATION'] = True` raises `TypeError`
+  instead. Phase-2 hooks must never read `request` — the engine rehydrates
+  `user`; pass anything else as plain values.
+- New `deserialize_kwargs()` is the phase-2 inverse of
+  `serialize_kwargs()`; `restore_user()` remains available.
+  `make_json_safe()` is kept as a legacy helper but is no longer used by
+  the engine.
 
 ## [0.4.1] — 2026-07-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,15 @@
 ### Added — bind-time hook-signature validation (#113)
 
 - `ProcessManager.bind_model_process` now validates every hook across the
-  process tree (side-effects, callbacks, failure hooks, conditions,
-  permissions): the engine calls hooks as `fn(instance, **kwargs)`, so a
-  hook whose first parameter is not a named positional (e.g. task-style
-  `def hook(*args, **kwargs)`) is flagged at bind time instead of failing
-  at runtime on a worker. Warns by default;
+  process tree — transition-level side-effects, callbacks, failure hooks,
+  conditions and permissions, plus process-level `conditions`/`permissions`:
+  the engine calls hooks as `fn(instance, **kwargs)` (permissions as
+  `fn(instance, user, **kwargs)`), so a hook whose first parameter is not a
+  named positional (e.g. task-style `def hook(*args, **kwargs)`) is flagged
+  at bind time instead of failing at runtime on a worker. Warns by default;
   `DJANGO_LOGIC['STRICT_HOOK_SIGNATURES'] = True` raises
-  `ImproperlyConfigured`.
+  `ImproperlyConfigured`. Decorated hooks need `functools.wraps` so their
+  real signature is visible to the validator.
 
 ### Changed — kwargs serialization (#107, #108)
 
@@ -25,12 +27,16 @@
   (plain ISO strings) still decode; deploy web and workers together when
   upgrading across this boundary (an old worker passes tagged dicts through
   verbatim). Model instances remain rejected — pass a pk and re-fetch.
+  Non-string dict keys cannot round-trip (JSON objects have string keys):
+  phase 1 flags them with a warning, or a `TypeError` under
+  `STRICT_KWARGS_SERIALIZATION`.
 - **`request` is dropped loudly** (#107). Phase-1 serialization logs a
   warning (with the tr_id) when it drops `request` from a background
   transition's kwargs, and the new
   `DJANGO_LOGIC['STRICT_KWARGS_SERIALIZATION'] = True` raises `TypeError`
-  instead. Phase-2 hooks must never read `request` — the engine rehydrates
-  `user`; pass anything else as plain values.
+  (specifically `serializers.KwargsSerializationError`) instead. Phase-2
+  hooks must never read `request` — the engine rehydrates `user`; pass
+  anything else as plain values.
 - New `deserialize_kwargs()` is the phase-2 inverse of
   `serialize_kwargs()`; `restore_user()` remains available.
   `make_json_safe()` is kept as a legacy helper but is no longer used by

--- a/README.md
+++ b/README.md
@@ -678,6 +678,9 @@ DJANGO_LOGIC = {
     'TRANSITION_MESSAGE_MAX_ERRORS': 5,
     'TRANSITION_MESSAGE_RETRY_MINUTES': 2,
     'TRANSITION_MESSAGE_CLEANUP_DAYS': 7,
+    'SENTRY_TRANSACTION_NAMING': True,  # per-transition Sentry naming (no-op without sentry-sdk)
+    'STRICT_KWARGS_SERIALIZATION': False,  # True: raise (not warn) on dropped 'request' / non-string dict keys
+    'STRICT_HOOK_SIGNATURES': False,    # True: refuse to bind hooks without a named instance-first parameter
 }
 ```
 

--- a/django_logic/background/runner.py
+++ b/django_logic/background/runner.py
@@ -52,7 +52,7 @@ from django.db import OperationalError, transaction
 from django_logic.background import settings as bg_settings
 from django_logic.background.models import TransitionMessage
 from django_logic.background.observability import set_sentry_context
-from django_logic.background.serializers import restore_user
+from django_logic.background.serializers import deserialize_kwargs
 from django_logic.background.transitions import BackgroundAction, BackgroundTransition
 from django_logic.logger import TransitionEventType, transition_logger
 from django_logic.process import _transition_context
@@ -303,8 +303,7 @@ def _finalize_terminal_from_watchdog(
         tm.mark_as_completed(measure_duration=False)
         return None
 
-    kwargs = dict(tm.kwargs or {})
-    restore_user(kwargs)
+    kwargs = deserialize_kwargs(tm.kwargs)
     # Mirror the sync path: side-effects/callbacks may read ``context``.
     kwargs.setdefault('context', {})
     state = process.state
@@ -398,8 +397,7 @@ def _run_atomic(tm_id: int) -> _Outcome:
         # best-effort, no-op without sentry-sdk. See observability.py / issue #78.
         set_sentry_context(tm)
 
-        kwargs = dict(tm.kwargs or {})
-        restore_user(kwargs)
+        kwargs = deserialize_kwargs(tm.kwargs)
         # Mirror the synchronous path (Transition._init_transition_context):
         # side-effects/callbacks may read a framework-provided ``context``
         # dict. serialize_kwargs drops it at phase 1, so rebuild it here —

--- a/django_logic/background/serializers.py
+++ b/django_logic/background/serializers.py
@@ -22,6 +22,9 @@ Deliberate handling:
   ``json.dumps`` (``TypeError``). Pass a pk and re-fetch in the hook:
   phase 2 may run much later and must see fresh rows, not a stale
   snapshot.
+* Non-string dict keys — JSON objects only have string keys, so these are
+  stringified in storage and do **not** round-trip. Flagged loudly at
+  phase 1 (warning, or ``TypeError`` under the strict setting).
 
 .. note::
 
@@ -40,6 +43,17 @@ from uuid import UUID
 
 from django_logic.background import settings as bg_settings
 from django_logic.logger import transition_logger
+
+
+class KwargsSerializationError(TypeError):
+    """Strict-mode rejection of kwargs that phase 1 would otherwise mutate
+    silently (a dropped ``request``, stringified non-string dict keys).
+
+    A ``TypeError`` subclass, so the documented "raises ``TypeError``"
+    contract holds — but distinct, so the phase-1 dispatcher re-raises it
+    as-is instead of wrapping it in the generic "not JSON-serializable"
+    ``ImproperlyConfigured``.
+    """
 
 
 _CONTEXT_KEYS = ('tr_id', 'root_id', 'parent_id')
@@ -134,15 +148,36 @@ def decode_value(value):
     return value
 
 
+def _non_string_key_paths(value, path='kwargs'):
+    """Yield a path for every dict key that is not a ``str``.
+
+    JSON objects only have string keys, so ``{1: 'a'}`` is persisted as
+    ``{"1": "a"}`` — silently, since ``json.dumps`` stringifies int/float/
+    bool/None keys instead of raising. That breaks the type-faithful
+    round-trip (a phase-2 hook sees ``'1'`` where the synchronous path saw
+    ``1``), so phase 1 flags it loudly instead.
+    """
+    if isinstance(value, dict):
+        for k, v in value.items():
+            if not isinstance(k, str):
+                yield f'{path}[{k!r}]'
+            yield from _non_string_key_paths(v, f'{path}[{k!r}]')
+    elif isinstance(value, (list, tuple, set, frozenset)):
+        for item in value:
+            yield from _non_string_key_paths(item, f'{path}[]')
+
+
 def serialize_kwargs(kwargs: dict) -> dict:
     """Return a JSON-serializable copy of ``kwargs`` fit for storage.
 
     Drops ``request`` (warning, or ``TypeError`` under
     ``STRICT_KWARGS_SERIALIZATION``). Replaces ``user`` with ``user_id``.
     Tag-encodes non-JSON-native values so phase 2 restores real types.
-    Raises ``TypeError`` via ``json.dumps`` if something unexpected slips
-    through — the caller should let that propagate so the failure is
-    visible at phase 1 rather than at phase 2.
+    Non-string dict keys are stringified by JSON persistence and cannot
+    round-trip — flagged with a warning (or ``TypeError`` under the strict
+    setting). Raises ``TypeError`` via ``json.dumps`` if something
+    unexpected slips through — the caller should let that propagate so the
+    failure is visible at phase 1 rather than at phase 2.
     """
     out = dict(kwargs)
     if 'request' in out:
@@ -153,7 +188,7 @@ def serialize_kwargs(kwargs: dict) -> dict:
             f"'user'; pass anything else as plain values)"
         )
         if bg_settings.strict_kwargs_serialization():
-            raise TypeError(message)
+            raise KwargsSerializationError(message)
         transition_logger.warning(message)
     out.pop('context', None)  # rebuilt in phase 2
     # Persisted on its own TransitionMessage column, not in the kwargs JSON:
@@ -173,6 +208,19 @@ def serialize_kwargs(kwargs: dict) -> dict:
     for key in _CONTEXT_KEYS:
         if key in out and out[key] is not None:
             out[key] = str(out[key])
+
+    bad_keys = sorted(set(_non_string_key_paths(out)))
+    if bad_keys:
+        message = (
+            f"{out.get('tr_id')} non-string dict keys in background "
+            f"transition kwargs ({', '.join(bad_keys)}) are stringified by "
+            f"JSON persistence — a phase-2 hook sees '1' where the "
+            f"synchronous path saw 1, and colliding keys ({{1: …, '1': …}}) "
+            f"silently lose data. Use string keys, or a list of pairs."
+        )
+        if bg_settings.strict_kwargs_serialization():
+            raise KwargsSerializationError(message)
+        transition_logger.warning(message)
 
     out = encode_value(out)
 

--- a/django_logic/background/serializers.py
+++ b/django_logic/background/serializers.py
@@ -1,54 +1,69 @@
 """kwargs serialization for persisting transition arguments.
 
 ``TransitionMessage.kwargs`` is a JSONField, so everything we write must
-be JSON-serializable. This module handles the common non-serializable
-values that transitions receive.
+be JSON-serializable. Values that JSON cannot represent natively are
+stored with a self-describing type tag and restored to their original
+Python type in phase 2, so a side-effect receives the same types whether
+its transition is synchronous or background.
 
 Deliberate handling:
 
-* ``request`` — dropped. Extract ``user`` first if you need it.
+* ``request`` — dropped, loudly: a warning is logged, and
+  ``DJANGO_LOGIC['STRICT_KWARGS_SERIALIZATION'] = True`` raises instead.
+  A live request cannot cross the phase boundary; extract ``user`` (which
+  is rehydrated) or pass plain values.
 * ``user`` — replaced with ``user_id`` (restored on the phase-2 side).
-* ``UUID`` — stringified.
-* ``datetime`` / ``date`` — ISO-formatted.
+* ``datetime`` / ``date`` / ``time`` / ``Decimal`` / ``UUID`` / ``tuple``
+  / ``set`` / ``frozenset`` — tag-encoded, restored in phase 2 with the
+  original type (recursively, inside dicts/lists/tuples/sets).
 * ``_transition_context``-managed keys (``tr_id``, ``root_id``,
   ``parent_id``) — stringified when present.
+* Model instances and arbitrary objects — rejected at phase 1 via
+  ``json.dumps`` (``TypeError``). Pass a pk and re-fetch in the hook:
+  phase 2 may run much later and must see fresh rows, not a stale
+  snapshot.
 
-Any unrecognised type falls through to ``json.dumps`` which will raise
-``TypeError`` — we surface that as an ``ImproperlyConfigured``-style
-error at phase-1 time rather than letting it fail at phase-2 fetch time.
+.. note::
 
-.. warning::
-
-    **The round-trip is lossy and types are NOT preserved.** A background
-    transition's side-effects receive a *different Python type* for some
-    kwargs than the identical synchronous transition would:
-
-    * ``datetime`` / ``date`` → ``str`` (ISO 8601)
-    * ``UUID`` → ``str``
-    * ``tuple`` → ``list``
-
-    Only ``user`` is rehydrated in phase 2 (``user_id`` → live ``User``).
-    There is no inverse for the rest, because the JSON column does not
-    record the original type. So a side-effect that does ``when.date()`` or
-    ``some_id.hex`` works synchronously and raises ``AttributeError`` in the
-    background path. Write background side-effects to accept the serialized
-    forms (parse the ISO string / re-wrap the UUID yourself), or pass an
-    already-stringified value. ``set``, ``Decimal``, and model instances are
-    rejected outright at phase 1 (see :func:`serialize_kwargs`) — pass a
-    list / str / pk instead.
+    Rows written before the typed encoding (plain ISO strings) still
+    decode — absence of a tag means passthrough. The inverse is not true:
+    a worker running an older version passes the tagged dicts through
+    verbatim, so deploy web and workers together when upgrading across
+    this boundary.
 """
 from __future__ import annotations
 
 import json
-from datetime import date, datetime
+from datetime import date, datetime, time
+from decimal import Decimal
 from uuid import UUID
+
+from django_logic.background import settings as bg_settings
+from django_logic.logger import transition_logger
 
 
 _CONTEXT_KEYS = ('tr_id', 'root_id', 'parent_id')
 
+#: Marker key for tag-encoded values. A caller dict that happens to contain
+#: this key is escaped with the ``'dict'`` tag so it round-trips verbatim.
+TYPE_TAG = '__dl_type__'
+
+_SCALAR_DECODERS = {
+    'datetime': datetime.fromisoformat,
+    'date': date.fromisoformat,
+    'time': time.fromisoformat,
+    'decimal': Decimal,
+    'uuid': UUID,
+}
+
 
 def make_json_safe(value):
-    """Recursively convert a value into something JSON-serializable."""
+    """Recursively coerce a value into something JSON-serializable.
+
+    Legacy helper (lossy: UUID/datetime become strings, tuples become
+    lists). Kept for backward compatibility; :func:`serialize_kwargs` now
+    uses the type-preserving :func:`encode_value` instead.
+    """
     if isinstance(value, UUID):
         return str(value)
     if isinstance(value, (datetime, date)):
@@ -60,17 +75,86 @@ def make_json_safe(value):
     return value
 
 
+def encode_value(value):
+    """Recursively encode a value into tagged, JSON-serializable form."""
+    # datetime before date: datetime is a date subclass.
+    if isinstance(value, datetime):
+        return {TYPE_TAG: 'datetime', 'value': value.isoformat()}
+    if isinstance(value, date):
+        return {TYPE_TAG: 'date', 'value': value.isoformat()}
+    if isinstance(value, time):
+        return {TYPE_TAG: 'time', 'value': value.isoformat()}
+    if isinstance(value, Decimal):
+        return {TYPE_TAG: 'decimal', 'value': str(value)}
+    if isinstance(value, UUID):
+        return {TYPE_TAG: 'uuid', 'value': str(value)}
+    if isinstance(value, tuple):
+        return {TYPE_TAG: 'tuple', 'value': [encode_value(v) for v in value]}
+    if isinstance(value, frozenset):
+        return {TYPE_TAG: 'frozenset', 'value': [encode_value(v) for v in value]}
+    if isinstance(value, set):
+        return {TYPE_TAG: 'set', 'value': [encode_value(v) for v in value]}
+    if isinstance(value, dict):
+        encoded = {k: encode_value(v) for k, v in value.items()}
+        if TYPE_TAG in value:
+            return {TYPE_TAG: 'dict', 'value': encoded}
+        return encoded
+    if isinstance(value, list):
+        return [encode_value(v) for v in value]
+    return value
+
+
+def decode_value(value):
+    """Inverse of :func:`encode_value`; untagged values pass through."""
+    if isinstance(value, list):
+        return [decode_value(v) for v in value]
+    if isinstance(value, dict):
+        tag = value.get(TYPE_TAG)
+        if tag is None:
+            return {k: decode_value(v) for k, v in value.items()}
+        inner = value.get('value')
+        if tag == 'dict':
+            return {k: decode_value(v) for k, v in inner.items()}
+        if tag == 'tuple':
+            return tuple(decode_value(v) for v in inner)
+        if tag == 'set':
+            return {decode_value(v) for v in inner}
+        if tag == 'frozenset':
+            return frozenset(decode_value(v) for v in inner)
+        decoder = _SCALAR_DECODERS.get(tag)
+        if decoder is None:
+            # A row written by a newer version than this worker: pass the
+            # tagged form through rather than crash phase 2.
+            transition_logger.warning(
+                f"unknown kwargs type tag {tag!r} — passing value through "
+                f"undecoded (worker older than the row writer?)"
+            )
+            return value
+        return decoder(inner)
+    return value
+
+
 def serialize_kwargs(kwargs: dict) -> dict:
     """Return a JSON-serializable copy of ``kwargs`` fit for storage.
 
-    Drops ``request`` entirely. Replaces ``user`` with ``user_id``.
-    Stringifies UUIDs and datetimes. Raises ``TypeError`` via
-    ``json.dumps`` if something unexpected slips through — the caller
-    should let that propagate so the failure is visible at phase 1
-    rather than at phase 2.
+    Drops ``request`` (warning, or ``TypeError`` under
+    ``STRICT_KWARGS_SERIALIZATION``). Replaces ``user`` with ``user_id``.
+    Tag-encodes non-JSON-native values so phase 2 restores real types.
+    Raises ``TypeError`` via ``json.dumps`` if something unexpected slips
+    through — the caller should let that propagate so the failure is
+    visible at phase 1 rather than at phase 2.
     """
     out = dict(kwargs)
-    out.pop('request', None)
+    if 'request' in out:
+        out.pop('request')
+        message = (
+            f"{out.get('tr_id')} 'request' dropped at kwargs serialization "
+            f"— phase-2 hooks must not read it (the engine rehydrates "
+            f"'user'; pass anything else as plain values)"
+        )
+        if bg_settings.strict_kwargs_serialization():
+            raise TypeError(message)
+        transition_logger.warning(message)
     out.pop('context', None)  # rebuilt in phase 2
     # Persisted on its own TransitionMessage column, not in the kwargs JSON:
     # phase 2 reads it from the column, and it must not leak into the kwargs
@@ -90,7 +174,7 @@ def serialize_kwargs(kwargs: dict) -> dict:
         if key in out and out[key] is not None:
             out[key] = str(out[key])
 
-    out = make_json_safe(out)
+    out = encode_value(out)
 
     # Round-trip through json to surface any remaining non-serializable
     # types at phase 1. Cheap on small dicts and invaluable in tests.
@@ -98,10 +182,22 @@ def serialize_kwargs(kwargs: dict) -> dict:
     return out
 
 
+def deserialize_kwargs(raw: dict | None) -> dict:
+    """Phase-2 inverse of :func:`serialize_kwargs`.
+
+    Restores tag-encoded values to their original Python types and swaps
+    ``user_id`` back for a live ``user``.
+    """
+    kwargs = decode_value(dict(raw or {}))
+    restore_user(kwargs)
+    return kwargs
+
+
 def restore_user(kwargs: dict) -> None:
     """In-place: if ``user_id`` is set, swap it for a live ``user`` object.
 
-    Called at the top of phase 2. No-op if ``user_id`` is absent.
+    Called in phase 2 (via :func:`deserialize_kwargs`). No-op if
+    ``user_id`` is absent.
     """
     user_id = kwargs.pop('user_id', None)
     if user_id is None:

--- a/django_logic/background/settings.py
+++ b/django_logic/background/settings.py
@@ -224,3 +224,14 @@ def _check_lock_cache_in_celery_mode() -> None:
         logger.warning(message)
     else:
         raise ImproperlyConfigured(message)
+
+
+def strict_kwargs_serialization() -> bool:
+    """When True, phase-1 kwargs serialization raises on silently-droppable
+    caller kwargs (``request``) instead of logging a warning.
+
+    Default False: generic API layers commonly pass ``request`` to every
+    transition uniformly, so raising by default would break them. Enable
+    once call sites are clean to turn the drop into a hard contract.
+    """
+    return bool(_conf().get('STRICT_KWARGS_SERIALIZATION', False))

--- a/django_logic/background/transitions.py
+++ b/django_logic/background/transitions.py
@@ -26,7 +26,10 @@ from django.db import IntegrityError, transaction
 from django_logic.background import settings as bg_settings
 from django_logic.background.exceptions import AlreadyInProgress
 from django_logic.background.models import TransitionMessage
-from django_logic.background.serializers import serialize_kwargs
+from django_logic.background.serializers import (
+    KwargsSerializationError,
+    serialize_kwargs,
+)
 from django_logic.exceptions import TransitionNotAllowed
 from django_logic.logger import (
     redact_log_kwargs,
@@ -160,6 +163,10 @@ class BackgroundTransition(Transition):
         }
         try:
             serialized = serialize_kwargs(kwargs)
+        except KwargsSerializationError:
+            # Strict-mode contract violation — the message is already
+            # precise; wrapping it as "not JSON-serializable" would mislead.
+            raise
         except TypeError as e:
             raise ImproperlyConfigured(
                 f"BackgroundTransition '{self.action_name}' received a "

--- a/django_logic/process.py
+++ b/django_logic/process.py
@@ -394,42 +394,59 @@ def _validate_hook_signatures(process_cls) -> None:
     instance invisibly in ``args``, and typically reads ids out of kwargs
     the engine never passes — failing only at runtime, on the worker.
     Validating at bind time turns that latent failure into a boot-time
-    signal. Warns by default; ``DJANGO_LOGIC['STRICT_HOOK_SIGNATURES'] =
-    True`` raises ``ImproperlyConfigured`` instead.
+    signal. Covers transition-level hooks (side-effects, callbacks,
+    failure hooks, conditions, permissions) and process-level
+    ``conditions``/``permissions``. Warns by default;
+    ``DJANGO_LOGIC['STRICT_HOOK_SIGNATURES'] = True`` raises
+    ``ImproperlyConfigured`` instead.
     """
     from django.conf import settings
 
     offenders = []
-    for proc_cls in _iter_process_tree(process_cls):
-        for transition in proc_cls.transitions or []:
-            wrappers = (
-                transition.side_effects, transition.callbacks,
-                transition.failure_side_effects, transition.failure_callbacks,
-                transition.conditions, transition.permissions,
+
+    def check(fn, owner):
+        try:
+            params = list(inspect.signature(fn).parameters.values())
+        except (TypeError, ValueError):
+            return
+        ok = params and params[0].kind in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        )
+        if not ok:
+            offenders.append(
+                f'{getattr(fn, "__module__", "?")}.'
+                f'{getattr(fn, "__qualname__", fn)} (on {owner})'
             )
-            for wrapper in wrappers:
-                for fn in wrapper.commands:
-                    try:
-                        params = list(inspect.signature(fn).parameters.values())
-                    except (TypeError, ValueError):
-                        continue
-                    ok = params and params[0].kind in (
-                        inspect.Parameter.POSITIONAL_ONLY,
-                        inspect.Parameter.POSITIONAL_OR_KEYWORD,
-                    )
-                    if not ok:
-                        offenders.append(
-                            f'{getattr(fn, "__module__", "?")}.'
-                            f'{getattr(fn, "__qualname__", fn)} (on '
-                            f'{proc_cls.__module__}.{proc_cls.__name__}.'
-                            f'{transition.action_name})'
-                        )
+
+    _HOOK_ATTRS = (
+        'side_effects', 'callbacks', 'failure_side_effects',
+        'failure_callbacks', 'conditions', 'permissions',
+    )
+    for proc_cls in _iter_process_tree(process_cls):
+        owner = f'{proc_cls.__module__}.{proc_cls.__name__}'
+        # Process-level conditions/permissions are plain lists of callables
+        # (executed via Conditions/Permissions in Process.is_valid).
+        for fn in getattr(proc_cls, 'conditions', None) or []:
+            check(fn, owner)
+        for fn in getattr(proc_cls, 'permissions', None) or []:
+            check(fn, owner)
+        for transition in proc_cls.transitions or []:
+            # getattr-guarded: a duck-typed custom transition that the
+            # engine never asks for one of these must not fail to bind.
+            for attr in _HOOK_ATTRS:
+                wrapper = getattr(transition, attr, None)
+                for fn in getattr(wrapper, 'commands', None) or []:
+                    check(fn, f'{owner}.{getattr(transition, "action_name", "?")}')
     if not offenders:
         return
     message = (
         'FSM hooks without a named instance-first parameter — the engine '
-        'calls every hook as fn(instance, **kwargs), so rewrite as '
-        f'def hook(instance, **kwargs): {"; ".join(sorted(set(offenders)))}'
+        'calls hooks as fn(instance, **kwargs) (permissions as '
+        'fn(instance, user, **kwargs)), so give each hook a named first '
+        'parameter, e.g. def hook(instance, **kwargs); decorated hooks '
+        'need functools.wraps to expose the real signature: '
+        f'{"; ".join(sorted(set(offenders)))}'
     )
     conf = getattr(settings, 'DJANGO_LOGIC', {}) or {}
     if conf.get('STRICT_HOOK_SIGNATURES', False):

--- a/django_logic/process.py
+++ b/django_logic/process.py
@@ -5,6 +5,7 @@ nested processes. ``ProcessManager.bind_model_process`` attaches the
 process as a property on a Django model, after which callers use
 ``instance.my_process.action_name(...)`` to drive transitions.
 """
+import inspect
 import uuid
 from contextvars import ContextVar
 
@@ -385,9 +386,62 @@ def _validate_unique_background_action_names(process_cls):
             local_background[name] = _where(proc_cls, transition)
 
 
+def _validate_hook_signatures(process_cls) -> None:
+    """Every hook must accept the instance as a named first positional
+    parameter.
+
+    A task-style ``def hook(*args, **kwargs)`` binds fine, receives the
+    instance invisibly in ``args``, and typically reads ids out of kwargs
+    the engine never passes — failing only at runtime, on the worker.
+    Validating at bind time turns that latent failure into a boot-time
+    signal. Warns by default; ``DJANGO_LOGIC['STRICT_HOOK_SIGNATURES'] =
+    True`` raises ``ImproperlyConfigured`` instead.
+    """
+    from django.conf import settings
+
+    offenders = []
+    for proc_cls in _iter_process_tree(process_cls):
+        for transition in proc_cls.transitions or []:
+            wrappers = (
+                transition.side_effects, transition.callbacks,
+                transition.failure_side_effects, transition.failure_callbacks,
+                transition.conditions, transition.permissions,
+            )
+            for wrapper in wrappers:
+                for fn in wrapper.commands:
+                    try:
+                        params = list(inspect.signature(fn).parameters.values())
+                    except (TypeError, ValueError):
+                        continue
+                    ok = params and params[0].kind in (
+                        inspect.Parameter.POSITIONAL_ONLY,
+                        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                    )
+                    if not ok:
+                        offenders.append(
+                            f'{getattr(fn, "__module__", "?")}.'
+                            f'{getattr(fn, "__qualname__", fn)} (on '
+                            f'{proc_cls.__module__}.{proc_cls.__name__}.'
+                            f'{transition.action_name})'
+                        )
+    if not offenders:
+        return
+    message = (
+        'FSM hooks without a named instance-first parameter — the engine '
+        'calls every hook as fn(instance, **kwargs), so rewrite as '
+        f'def hook(instance, **kwargs): {"; ".join(sorted(set(offenders)))}'
+    )
+    conf = getattr(settings, 'DJANGO_LOGIC', {}) or {}
+    if conf.get('STRICT_HOOK_SIGNATURES', False):
+        raise ImproperlyConfigured(message)
+    transition_logger.warning(message)
+
+
 class ProcessManager:
     @classmethod
     def bind_model_process(cls, model, process_class, state_field: str = 'state') -> None:
+        _validate_hook_signatures(process_class)
+
         def make_process_getter(field_name, process_cls):
             return lambda self: process_cls(field_name=field_name, instance=self)
 

--- a/tests/background/test_kwargs_roundtrip.py
+++ b/tests/background/test_kwargs_roundtrip.py
@@ -15,6 +15,7 @@ from django.test import TestCase, override_settings
 
 from django_logic.background.models import TransitionMessage
 from django_logic.background.runner import run_background_transition
+from django_logic.background.serializers import KwargsSerializationError
 from tests.background import models as bg_models
 from tests.background.models import Widget
 
@@ -74,6 +75,18 @@ class KwargsRoundTripTests(TestCase):
         self.assertEqual(
             tm.owning_process_class, 'tests.background.models.WidgetProcess'
         )
+
+    @override_settings(
+        DJANGO_LOGIC={**_SYNC_SETTINGS, 'STRICT_KWARGS_SERIALIZATION': True})
+    def test_strict_request_drop_raises_typeerror_through_real_dispatch(self):
+        # The contract consumers actually see: the strict-mode rejection
+        # reaches the caller as the documented TypeError (not wrapped into
+        # the dispatcher's "not JSON-serializable" ImproperlyConfigured).
+        with self.assertRaisesMessage(
+                KwargsSerializationError, "'request' dropped"):
+            self.widget.process.fulfil(request=object())
+        # Phase 1 failed before persisting anything.
+        self.assertFalse(TransitionMessage.objects.exists())
 
     def test_owning_process_class_kept_out_of_nested_side_effect_kwargs(self):
         # Same contract for a NESTED owner: nested_fulfil is declared on

--- a/tests/background/test_kwargs_roundtrip.py
+++ b/tests/background/test_kwargs_roundtrip.py
@@ -7,6 +7,7 @@ point of django_logic.background.serializers is this boundary. Runs in sync
 mode (the default) so phase 1 + phase 2 execute inline.
 """
 from datetime import datetime
+from decimal import Decimal
 from uuid import UUID
 
 from django.contrib.auth import get_user_model
@@ -89,15 +90,43 @@ class KwargsRoundTripTests(TestCase):
             'tests.background.models.NestedBgChildProcess',
         )
 
-    def test_datetime_and_uuid_arrive_as_strings_documented_contract(self):
-        # The serialization round-trip is lossy by design: types are not
-        # preserved. This test pins that contract so a future "fix" that
-        # silently changes it is caught.
-        self.widget.process.fulfil(when=_WHEN, some_uuid=_UUID)
+    def test_typed_kwargs_arrive_with_original_types(self):
+        # The round-trip is type-faithful: a phase-2 side-effect receives the
+        # same Python types the identical synchronous transition would. This
+        # pins the contract so a regression back to lossy strings is caught.
+        self.widget.process.fulfil(
+            when=_WHEN,
+            some_uuid=_UUID,
+            amount=Decimal('19.99'),
+            pair=(1, 'two'),
+            tags={'a', 'b'},
+        )
         seen = bg_models.LAST_KWARGS
-        self.assertIsInstance(seen['when'], str)
+        self.assertEqual(seen['when'], _WHEN)
+        self.assertIs(type(seen['when']), datetime)
+        self.assertEqual(seen['some_uuid'], _UUID)
+        self.assertIs(type(seen['some_uuid']), UUID)
+        self.assertEqual(seen['amount'], Decimal('19.99'))
+        self.assertEqual(seen['pair'], (1, 'two'))
+        self.assertEqual(seen['tags'], {'a', 'b'})
+
+    def test_legacy_untagged_row_still_runs(self):
+        # A TransitionMessage written before the typed encoding carries plain
+        # ISO strings — phase 2 must pass them through unchanged, not crash.
+        self.widget.status = 'fulfilling'
+        self.widget.save(update_fields=['status'])
+        tm = TransitionMessage.objects.create(
+            app_label='bg_tests',
+            model_name='widget',
+            instance_id=str(self.widget.pk),
+            process_name='process',
+            transition_name='fulfil',
+            queue_name='django_logic.critical',
+            kwargs={'when': _WHEN.isoformat(), 'some_uuid': str(_UUID)},
+        )
+        run_background_transition(tm.pk)
+        seen = bg_models.LAST_KWARGS
         self.assertEqual(seen['when'], _WHEN.isoformat())
-        self.assertIsInstance(seen['some_uuid'], str)
         self.assertEqual(seen['some_uuid'], str(_UUID))
 
     def test_deleted_user_degrades_to_none(self):

--- a/tests/background/test_serializers.py
+++ b/tests/background/test_serializers.py
@@ -1,19 +1,39 @@
-"""kwargs serialization: JSON-safe values, user_id swap, round-trip."""
+"""kwargs serialization: typed round-trip, loud request drop, user_id swap."""
 import json
-from datetime import date, datetime, timezone as tz
+from datetime import date, datetime, time, timezone as tz
+from decimal import Decimal
 from unittest.mock import Mock
 from uuid import UUID
 
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, override_settings
 
-from django_logic.background.serializers import restore_user, serialize_kwargs
+from django_logic.background.serializers import (
+    decode_value, deserialize_kwargs, restore_user, serialize_kwargs,
+)
+
+
+def _roundtrip(kwargs):
+    persisted = serialize_kwargs(kwargs)
+    # The persisted form must be valid JSON as-is (what the DB row stores).
+    return json.loads(json.dumps(persisted))
 
 
 class SerializeKwargsTests(SimpleTestCase):
-    def test_request_is_dropped(self):
-        out = serialize_kwargs({'request': Mock(), 'x': 1})
+    def test_request_is_dropped_with_a_warning(self):
+        with self.assertLogs('django-logic.transition', level='WARNING') as logs:
+            out = serialize_kwargs({'request': Mock(), 'x': 1})
         self.assertNotIn('request', out)
         self.assertEqual(out['x'], 1)
+        self.assertIn("'request' dropped", logs.output[0])
+
+    @override_settings(DJANGO_LOGIC={'STRICT_KWARGS_SERIALIZATION': True})
+    def test_request_raises_under_strict_setting(self):
+        with self.assertRaisesMessage(TypeError, "'request' dropped"):
+            serialize_kwargs({'request': Mock(), 'x': 1})
+
+    @override_settings(DJANGO_LOGIC={'STRICT_KWARGS_SERIALIZATION': True})
+    def test_strict_setting_leaves_clean_kwargs_alone(self):
+        self.assertEqual(serialize_kwargs({'x': 1}), {'x': 1})
 
     def test_user_replaced_with_user_id(self):
         # serialize reads .pk (matching the phase-2 get(pk=...) restore and
@@ -24,25 +44,45 @@ class SerializeKwargsTests(SimpleTestCase):
         self.assertNotIn('user', out)
         self.assertEqual(out['user_id'], 42)
 
-    def test_uuid_stringified(self):
-        u = UUID('12345678-1234-5678-1234-567812345678')
-        out = serialize_kwargs({'some_id': u})
-        self.assertEqual(out['some_id'], str(u))
+    def test_typed_values_round_trip_identically(self):
+        aware = datetime(2024, 1, 2, 3, 4, 5, tzinfo=tz.utc)
+        naive = datetime(2026, 6, 4, 12, 30, 0)
+        original = {
+            'aware': aware,
+            'naive': naive,
+            'day': date(2024, 1, 2),
+            'at': time(23, 59, 1),
+            'amount': Decimal('19.99'),
+            'some_id': UUID('12345678-1234-5678-1234-567812345678'),
+            'pair': (1, 'two'),
+            'tags': {'a', 'b'},
+            'frozen': frozenset({3}),
+        }
+        restored = decode_value(_roundtrip(dict(original)))
+        self.assertEqual(restored, original)
+        for key in original:
+            self.assertIs(type(restored[key]), type(original[key]), key)
 
-    def test_datetime_isoformatted(self):
-        dt = datetime(2024, 1, 2, 3, 4, 5, tzinfo=tz.utc)
-        out = serialize_kwargs({'when': dt, 'day': date(2024, 1, 2)})
-        self.assertEqual(out['when'], dt.isoformat())
-        self.assertEqual(out['day'], '2024-01-02')
+    def test_nested_containers_round_trip(self):
+        original = {
+            'list': [UUID(int=1), date(2024, 1, 1), (Decimal('1'), {'x'})],
+            'dict': {'nested': {'deeper': datetime(2024, 5, 6, tzinfo=tz.utc)}},
+        }
+        self.assertEqual(decode_value(_roundtrip(dict(original))), original)
 
-    def test_nested_containers_serialized(self):
-        out = serialize_kwargs({
-            'list': [UUID(int=1), date(2024, 1, 1)],
-            'dict': {'nested': UUID(int=2)},
-        })
-        self.assertEqual(out['list'][0], str(UUID(int=1)))
-        self.assertEqual(out['list'][1], '2024-01-01')
-        self.assertEqual(out['dict']['nested'], str(UUID(int=2)))
+    def test_caller_dict_containing_the_tag_key_is_escaped(self):
+        original = {'payload': {'__dl_type__': 'not-ours', 'value': 1}}
+        self.assertEqual(decode_value(_roundtrip(dict(original))), original)
+
+    def test_legacy_untagged_rows_pass_through(self):
+        # A row written before the typed encoding: plain strings stay strings.
+        legacy = {'when': '2024-01-02T03:04:05+00:00', 'some_id': 'abc', 'n': 1}
+        self.assertEqual(decode_value(dict(legacy)), legacy)
+
+    def test_unknown_tag_passes_through_with_a_warning(self):
+        row = {'v': {'__dl_type__': 'from_the_future', 'value': 'x'}}
+        with self.assertLogs('django-logic.transition', level='WARNING'):
+            self.assertEqual(decode_value(dict(row)), row)
 
     def test_tr_ids_stringified_when_uuid(self):
         tr_id = UUID(int=99)
@@ -69,6 +109,12 @@ class SerializeKwargsTests(SimpleTestCase):
         out = serialize_kwargs({'a': 1, 'b': 'x', 'c': None})
         # Must be valid JSON as-is.
         self.assertEqual(json.loads(json.dumps(out)), out)
+
+
+class DeserializeKwargsTests(SimpleTestCase):
+    def test_none_and_empty_rows(self):
+        self.assertEqual(deserialize_kwargs(None), {})
+        self.assertEqual(deserialize_kwargs({}), {})
 
 
 class RestoreUserTests(SimpleTestCase):

--- a/tests/background/test_serializers.py
+++ b/tests/background/test_serializers.py
@@ -9,6 +9,7 @@ from django.test import SimpleTestCase, override_settings
 
 from django_logic.background.serializers import (
     decode_value, deserialize_kwargs, restore_user, serialize_kwargs,
+    KwargsSerializationError,
 )
 
 
@@ -109,6 +110,34 @@ class SerializeKwargsTests(SimpleTestCase):
         out = serialize_kwargs({'a': 1, 'b': 'x', 'c': None})
         # Must be valid JSON as-is.
         self.assertEqual(json.loads(json.dumps(out)), out)
+
+    def test_strict_raise_is_a_distinct_typeerror_subclass(self):
+        # The phase-1 dispatcher wraps generic TypeError in
+        # ImproperlyConfigured ("not JSON-serializable") — the strict-mode
+        # rejection must stay distinguishable so it propagates verbatim.
+        with override_settings(DJANGO_LOGIC={'STRICT_KWARGS_SERIALIZATION': True}):
+            with self.assertRaises(KwargsSerializationError):
+                serialize_kwargs({'request': Mock()})
+
+    def test_non_string_dict_keys_warn(self):
+        # JSON stringifies int keys silently ({1: 'a'} -> {"1": "a"}), which
+        # breaks the type-faithful contract — phase 1 must say so.
+        with self.assertLogs('django-logic.transition', level='WARNING') as logs:
+            out = serialize_kwargs({'m': {1: 'a'}})
+        self.assertIn('non-string dict keys', logs.output[0])
+        self.assertIn("'m'", logs.output[0])
+        # The documented (lossy) persisted contract: keys become strings.
+        self.assertEqual(json.loads(json.dumps(out)), {'m': {'1': 'a'}})
+
+    def test_non_string_dict_keys_nested_in_containers_warn(self):
+        with self.assertLogs('django-logic.transition', level='WARNING') as logs:
+            serialize_kwargs({'items': [{'deep': {2: 'b'}}]})
+        self.assertIn('non-string dict keys', logs.output[0])
+
+    @override_settings(DJANGO_LOGIC={'STRICT_KWARGS_SERIALIZATION': True})
+    def test_non_string_dict_keys_raise_under_strict_setting(self):
+        with self.assertRaisesMessage(TypeError, 'non-string dict keys'):
+            serialize_kwargs({'m': {1: 'a'}})
 
 
 class DeserializeKwargsTests(SimpleTestCase):

--- a/tests/test_hook_signature_validation.py
+++ b/tests/test_hook_signature_validation.py
@@ -48,9 +48,30 @@ class _BadProcess(Process):
     ]
 
 
+class _ProcessLevelBad(Process):
+    process_name = 'sig_proc_level_process'
+    conditions = [kwargs_only_hook]
+    permissions = [task_style_hook]
+    transitions = [
+        Transition('approve', sources=['draft'], target='approved'),
+    ]
+
+
+class _DuckTransition:
+    """Custom transition exposing only what it needs — the validator must
+    not require the full hook-attribute surface."""
+    action_name = 'quack'
+
+
+class _DuckProcess(Process):
+    process_name = 'sig_duck_process'
+    transitions = [_DuckTransition()]
+
+
 class HookSignatureValidationTests(SimpleTestCase):
     def tearDown(self):
-        for name in ('sig_ok_process', 'sig_bad_process'):
+        for name in ('sig_ok_process', 'sig_bad_process',
+                     'sig_proc_level_process', 'sig_duck_process'):
             if name in vars(Invoice):
                 delattr(Invoice, name)
         super().tearDown()
@@ -78,3 +99,21 @@ class HookSignatureValidationTests(SimpleTestCase):
     @override_settings(DJANGO_LOGIC={'STRICT_HOOK_SIGNATURES': True})
     def test_strict_setting_accepts_clean_hooks(self):
         ProcessManager.bind_model_process(Invoice, _GoodProcess, state_field='status')
+
+    def test_process_level_conditions_and_permissions_are_validated(self):
+        # Process.is_valid executes class-level conditions/permissions with
+        # the same instance-first convention — they must not escape the walk.
+        with self.assertLogs('django-logic.transition', level='WARNING') as logs:
+            ProcessManager.bind_model_process(
+                Invoice, _ProcessLevelBad, state_field='status')
+        message = logs.output[0]
+        self.assertIn('kwargs_only_hook', message)
+        self.assertIn('task_style_hook', message)
+        self.assertIn('_ProcessLevelBad', message)
+
+    def test_duck_typed_transition_without_hook_attributes_binds(self):
+        # Regardless of the strict flag, a transition object exposing only
+        # part of the hook surface must not crash bind_model_process.
+        with override_settings(DJANGO_LOGIC={'STRICT_HOOK_SIGNATURES': True}):
+            ProcessManager.bind_model_process(
+                Invoice, _DuckProcess, state_field='status')

--- a/tests/test_hook_signature_validation.py
+++ b/tests/test_hook_signature_validation.py
@@ -1,0 +1,80 @@
+"""Bind-time hook-signature validation (#113): a task-style
+``def hook(*args, **kwargs)`` fails only at runtime on the worker, so
+``bind_model_process`` flags every hook whose first parameter is not a
+named positional — warning by default, raising under
+``DJANGO_LOGIC['STRICT_HOOK_SIGNATURES']``."""
+from django.core.exceptions import ImproperlyConfigured
+from django.test import SimpleTestCase, override_settings
+
+from django_logic.process import Process, ProcessManager
+from django_logic.transition import Transition
+from tests.models import Invoice
+
+
+def good_hook(instance, **kwargs):
+    pass
+
+
+def task_style_hook(*args, **kwargs):
+    pass
+
+
+def kwargs_only_hook(**kwargs):
+    pass
+
+
+class _GoodProcess(Process):
+    process_name = 'sig_ok_process'
+    transitions = [
+        Transition('approve', sources=['draft'], target='approved',
+                   side_effects=[good_hook], callbacks=[good_hook],
+                   conditions=[lambda instance: True]),
+    ]
+
+
+class _NestedBad(Process):
+    transitions = [
+        Transition('reject', sources=['draft'], target='rejected',
+                   callbacks=[kwargs_only_hook]),
+    ]
+
+
+class _BadProcess(Process):
+    process_name = 'sig_bad_process'
+    nested_processes = [_NestedBad]
+    transitions = [
+        Transition('approve', sources=['draft'], target='approved',
+                   side_effects=[task_style_hook]),
+    ]
+
+
+class HookSignatureValidationTests(SimpleTestCase):
+    def tearDown(self):
+        for name in ('sig_ok_process', 'sig_bad_process'):
+            if name in vars(Invoice):
+                delattr(Invoice, name)
+        super().tearDown()
+
+    def test_clean_hooks_bind_silently(self):
+        with self.assertNoLogs('django-logic.transition', level='WARNING'):
+            ProcessManager.bind_model_process(Invoice, _GoodProcess, state_field='status')
+
+    def test_task_style_hooks_warn_at_bind_time(self):
+        with self.assertLogs('django-logic.transition', level='WARNING') as logs:
+            ProcessManager.bind_model_process(Invoice, _BadProcess, state_field='status')
+        message = logs.output[0]
+        # Both the direct and the nested offender, each with its owner.
+        self.assertIn('task_style_hook', message)
+        self.assertIn('_BadProcess.approve', message)
+        self.assertIn('kwargs_only_hook', message)
+        self.assertIn('_NestedBad.reject', message)
+        self.assertIn('fn(instance, **kwargs)', message)
+
+    @override_settings(DJANGO_LOGIC={'STRICT_HOOK_SIGNATURES': True})
+    def test_strict_setting_raises(self):
+        with self.assertRaises(ImproperlyConfigured):
+            ProcessManager.bind_model_process(Invoice, _BadProcess, state_field='status')
+
+    @override_settings(DJANGO_LOGIC={'STRICT_HOOK_SIGNATURES': True})
+    def test_strict_setting_accepts_clean_hooks(self):
+        ProcessManager.bind_model_process(Invoice, _GoodProcess, state_field='status')


### PR DESCRIPTION
Closes #107, closes #108, closes #113. Motivated by real consumer breakage found in the Borderless360/gv FSM-migration audit (gv PR #9057): a background side-effect reading `kwargs['request'].user` that could only KeyError in phase 2, and a task-style courier hook latent-broken for years.

## Commit 1 — kwargs serialization (#107, #108)

- **Type-faithful round-trip (#108):** phase-1 kwargs are tag-encoded (`__dl_type__`) and phase 2 restores original Python types via the new `deserialize_kwargs()`: `datetime`/`date`/`time`/`Decimal`/`UUID`/`tuple`/`set`/`frozenset`, recursively inside containers. A side-effect now sees identical types whether its transition is sync or background. `Decimal`/`set`, previously rejected, now work. Model instances stay rejected (pass a pk — phase 2 must re-fetch fresh rows).
- **Legacy + skew safety:** untagged rows (written by older versions) decode unchanged; unknown future tags pass through with a warning instead of crashing the worker. Deploy web + workers together across this upgrade (noted in the module docstring + CHANGELOG).
- **Loud request drop (#107):** phase 1 logs a warning (with tr_id) when it drops `request`; `DJANGO_LOGIC['STRICT_KWARGS_SERIALIZATION'] = True` raises `TypeError` instead. Default stays warn because generic API layers pass `request` to every transition uniformly.

The previously-pinned lossy contract test (`test_datetime_and_uuid_arrive_as_strings_documented_contract`) is deliberately replaced by the typed contract + a legacy-row passthrough test.

## Commit 2 — bind-time hook-signature validation (#113)

`bind_model_process` walks the process tree and flags any hook (side-effects, callbacks, failure hooks, conditions, permissions) whose first parameter is not a named positional — the engine calls hooks as `fn(instance, **kwargs)`, so task-style `(*args, **kwargs)` signatures fail only at runtime today. Warns by default; `DJANGO_LOGIC['STRICT_HOOK_SIGNATURES'] = True` raises `ImproperlyConfigured`. Supersedes gv's local guard test on the next pin bump.

## Verification

Full suite: **347 tests OK** (13 service-gated skips), up from 337 at baseline; the new warn/strict/round-trip/legacy paths are all covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes background phase-2 kwargs semantics and upgrade skew (web/workers must deploy together for tagged encoding); defaults stay warn-only, but misconfigured hooks or kwargs can surface new runtime or bind-time failures when strict flags are enabled.
> 
> **Overview**
> Background transition kwargs now **round-trip with original Python types** via `__dl_type__` tag encoding in phase 1 and the new `deserialize_kwargs()` in phase 2 (`datetime`, `date`, `time`, `Decimal`, `UUID`, `tuple`, `set`, `frozenset`, nested containers). Phase-2 side-effects see the same types as sync transitions; legacy untagged rows still decode as plain strings.
> 
> **Loud / strict serialization (#107):** Dropping `request` and non-string dict keys (which JSON cannot preserve) now logs warnings by default; `STRICT_KWARGS_SERIALIZATION` raises `KwargsSerializationError` instead. `BackgroundTransition` re-raises that error without wrapping it as “not JSON-serializable.”
> 
> **Bind-time hook validation (#113):** `ProcessManager.bind_model_process` walks the process tree and flags hooks whose first parameter is not a named `instance` (e.g. `*args, **kwargs`), warning by default or raising with `STRICT_HOOK_SIGNATURES`.
> 
> README/CHANGELOG document the new settings; tests replace the old lossy kwargs contract with typed round-trip, legacy rows, strict mode, and hook-signature cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bab86f1f1eac514ea07e6224c7c53784eac96cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->