### PR TITLE
CI: Django version matrix + gv consumer-contract job (#110, #112)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,20 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      # Test every Django version the trove classifiers claim (#112),
+      # on the Python versions each Django release supports.
       matrix:
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
+        include:
+          - { python-version: "3.11", django: "4.2" }
+          - { python-version: "3.11", django: "5.1" }
+          - { python-version: "3.12", django: "4.2" }
+          - { python-version: "3.12", django: "5.1" }
+          - { python-version: "3.12", django: "5.2" }
+          - { python-version: "3.12", django: "6.0" }
+          - { python-version: "3.13", django: "5.1" }
+          - { python-version: "3.13", django: "5.2" }
+          - { python-version: "3.13", django: "6.0" }
+          - { python-version: "3.14", django: "6.0" }
 
     steps:
       - uses: actions/checkout@v4
@@ -26,6 +38,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e .
+          pip install "Django~=${{ matrix.django }}.0"
           pip install coverage
 
       - name: Run tests with coverage
@@ -35,7 +48,27 @@ jobs:
           coverage xml
 
       - name: Upload coverage to Coveralls
-        if: matrix.python-version == '3.12'
+        if: matrix.python-version == '3.12' && matrix.django == '5.2'
         uses: coverallsapp/github-action@v2
         with:
           file: coverage.xml
+
+  # Early warning against unreleased Django; failure does not block merges.
+  test-django-main:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies (Django main)
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install "git+https://github.com/django/django@main"
+
+      - name: Run tests
+        run: python tests/manage.py test

--- a/.github/workflows/consumer-gv.yml
+++ b/.github/workflows/consumer-gv.yml
@@ -1,0 +1,106 @@
+name: Consumer contract (gv)
+
+# Runs gv's FSM test subset against django-logic at this ref (issue #110):
+# the engine's one serious consumer is the best regression detector it has,
+# and RELEASING.md gates releases on this job being green.
+#
+# Requires a repository secret GV_REPO_TOKEN with read access to
+# Borderless360/gv. Without it the job skips with a warning (so forks and
+# tokenless runs stay green).
+
+on:
+  schedule:
+    - cron: '0 4 * * *'
+  workflow_dispatch:
+  pull_request:
+    branches: [master, main]
+    paths:
+      - 'django_logic/**'
+      - 'pyproject.toml'
+
+jobs:
+  gv-contract:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_DB: gv
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d gv"
+          --health-interval 2s
+          --health-timeout 5s
+          --health-retries 10
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 2s
+          --health-timeout 5s
+          --health-retries 10
+
+    steps:
+      - name: Check for gv access token
+        id: token
+        env:
+          GV_REPO_TOKEN: ${{ secrets.GV_REPO_TOKEN }}
+        run: |
+          if [ -z "$GV_REPO_TOKEN" ]; then
+            echo "have=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::GV_REPO_TOKEN is not configured — skipping the gv consumer contract job"
+          else
+            echo "have=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@v4
+        if: steps.token.outputs.have == 'true'
+        with:
+          path: django-logic
+
+      - uses: actions/checkout@v4
+        if: steps.token.outputs.have == 'true'
+        with:
+          repository: Borderless360/gv
+          token: ${{ secrets.GV_REPO_TOKEN }}
+          ref: staging
+          path: gv
+
+      - uses: astral-sh/setup-uv@v5
+        if: steps.token.outputs.have == 'true'
+
+      - name: System deps (gettext for compilemessages)
+        if: steps.token.outputs.have == 'true'
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq gettext
+
+      - name: Install gv with django-logic at this ref
+        if: steps.token.outputs.have == 'true'
+        working-directory: gv
+        run: |
+          uv sync --group dev
+          uv pip install ../django-logic
+
+      - name: Run gv FSM contract subset
+        if: steps.token.outputs.have == 'true'
+        working-directory: gv
+        env:
+          DATABASE_URL: postgres://postgres:postgres@127.0.0.1:5432/gv
+          REDIS_URL: redis://127.0.0.1:6379/1
+          SKIP_MIGRATIONS: 'True'
+        run: |
+          source .venv/bin/activate
+          python manage.py compilemessages -l en > /dev/null
+          # Engine-facing subset: per-machine lifecycle scenarios, the
+          # cross-process journey suites, and gv's FSM guard tests.
+          python manage.py test --settings=gv.settings.test --noinput --parallel 4 \
+            --pattern 'test_*lifecycle_scenario.py'
+          python manage.py test --settings=gv.settings.test --noinput --parallel 4 \
+            --pattern 'test_journey_*.py'
+          python manage.py test --settings=gv.settings.test --noinput \
+            gv.tests order.tests.test_golden_journey

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -30,27 +30,34 @@ Everything runs through [`uv`](https://github.com/astral-sh/uv) (build) and
 3. **Update `CHANGELOG.md`**: move `[Unreleased]` into a dated `[X.Y.Z]`
    section; leave a fresh empty `[Unreleased]`.
 4. **Run the tests**: `python tests/manage.py test` (or `make test`).
-5. **Build + validate the artifacts**:
+5. **Check the consumer contract job is green**: the `Consumer contract (gv)`
+   workflow (nightly + `workflow_dispatch`) runs gv's FSM test subset against
+   django-logic@master. Trigger it manually for the release candidate and do
+   not publish while it is red:
+   ```bash
+   gh workflow run consumer-gv.yml && gh run watch
+   ```
+6. **Build + validate the artifacts**:
    ```bash
    make dist          # rm -rf dist/ build/ *.egg-info && uv build && twine check dist/*
    ```
-6. **Publish to PyPI**:
+7. **Publish to PyPI**:
    ```bash
    make publish       # uploads dist/* using .pypirc
    ```
-7. **Tag and push**:
+8. **Tag and push**:
    ```bash
    git tag -a vX.Y.Z -m "django-logic X.Y.Z"
    git push origin master vX.Y.Z
    ```
-8. **Create the GitHub release** with the changelog section as notes and the
+9. **Create the GitHub release** with the changelog section as notes and the
    built artifacts attached:
    ```bash
    gh release create vX.Y.Z --title "django-logic X.Y.Z" \
      --notes-file <notes.md> --latest \
      dist/django_logic-X.Y.Z-py3-none-any.whl dist/django_logic-X.Y.Z.tar.gz
    ```
-9. **Verify**: `pip install django-logic==X.Y.Z` in a clean venv imports cleanly.
+10. **Verify**: `pip install django-logic==X.Y.Z` in a clean venv imports cleanly.
 
 > PyPI uploads are **irreversible** — a version number can never be re-uploaded.
 > Always `make dist` + install-check before `make publish`.


### PR DESCRIPTION
Closes #110, closes #112.

- **ci.yml (#112):** tests every Django version the trove classifiers claim — 4.2 / 5.1 / 5.2 / 6.0 across the Python versions each supports — plus an allowed-failure Django-main job for early warning. Coveralls upload pinned to the 3.12 + 5.2 cell.
- **consumer-gv.yml (#110):** runs gv's FSM contract subset (all `*_lifecycle_scenario` suites, the `test_journey_*` cross-process suites, `gv.tests` guards + golden journey) against django-logic at the current ref — nightly, on engine-touching PRs, and via `workflow_dispatch`. Postgres 16 + Redis 7 services, gv installed via `uv sync` with this checkout pip-installed over the pin. **Requires a `GV_REPO_TOKEN` repo secret** (read access to Borderless360/gv); skips with a warning when absent so forks stay green.
- **RELEASING.md:** publishing now gates on the consumer job being green (new checklist step 5).

Note: the consumer workflow can only be exercised end-to-end once the `GV_REPO_TOKEN` secret is configured — the YAML is validated, but expect one shakedown run to iterate on gv's CI bootstrap details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to GitHub Actions and release documentation; no runtime library or application code is modified.
> 
> **Overview**
> Expands **CI** from a single Python matrix to explicit **Python × Django** cells (4.2 / 5.1 / 5.2 / 6.0 per supported Python), installs `Django~=${{ matrix.django }}.0` in each run, and limits **Coveralls** upload to the **3.12 + Django 5.2** cell. Adds a separate **`test-django-main`** job (Django from `main`, `continue-on-error`) as an early warning without blocking merges.
> 
> Introduces **`consumer-gv.yml`**: nightly, `workflow_dispatch`, and PRs touching `django_logic/**` or `pyproject.toml` run gv’s FSM contract tests against this checkout (Postgres/Redis services, gv `staging` via `GV_REPO_TOKEN`; skips with a warning if the secret is missing).
> 
> **`RELEASING.md`** adds a release gate: do not publish until the consumer contract workflow is green (manual `gh workflow run` step), and renumbers later checklist steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f738c9dcdb5841b69ab5a3e27f7f6560cad0c185. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->