### PR TITLE
release: django-logic 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,42 @@
 
 ## [Unreleased]
 
+## [0.5.0] — 2026-07-17
+
+Type-faithful background kwargs (#107, #108), bind-time hook-signature
+validation (#113), and a Django-version CI matrix plus a downstream
+consumer-contract job (#110, #112).
+
+### Upgrade notes
+
+The typed kwargs round-trip **changes what background hooks receive in
+phase 2** — this is the headline behavioural change of this release:
+
+- **Audit background hooks written against the 0.4.x contract.** Hooks
+  that parse ISO strings back into `datetime`/`UUID`, or re-wrap values
+  (`UUID(kwargs['some_id'])`), now receive the original types directly.
+  While pre-upgrade rows drain, a hook can see *both* forms — tolerate
+  both (e.g. `v if isinstance(v, UUID) else UUID(v)`) until the queue is
+  clean, then simplify to the typed form.
+- **Deploy web and workers together.** A 0.4.x worker passes 0.5.0's
+  tagged kwargs dicts through verbatim (it cannot decode them), and
+  rolling back to 0.4.x leaves any 0.5.0-written pending rows undecodable.
+  Drain or requeue pending `TransitionMessage` rows if you must roll back.
+- **Snapshot assertions on persisted kwargs change shape.** The testing
+  snapshot helper (`django_logic.testing.snapshot`) exposes the stored
+  `TransitionMessage.kwargs`, which now contains `__dl_type__` tag dicts
+  for non-JSON-native values.
+- **New warnings are on by default.** Passing `request` to a background
+  transition, hooks without a named instance-first parameter, and
+  non-string dict keys in kwargs each log a warning. Silence them by
+  fixing the call sites — or make them hard errors with
+  `DJANGO_LOGIC['STRICT_KWARGS_SERIALIZATION']` /
+  `DJANGO_LOGIC['STRICT_HOOK_SIGNATURES']`.
+- **Trove classifiers now match what CI tests**: Django 4.2 / 5.1 / 5.2 /
+  6.0. Dropped 4.0 (never installable under the `requires-python >= 3.11`
+  floor this package already had) and 5.0 (end-of-life, untested); added
+  4.2, which CI has always tested.
+
 ### Added — bind-time hook-signature validation (#113)
 
 - `ProcessManager.bind_model_process` now validates every hook across the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-logic"
-version = "0.4.1"
+version = "0.5.0"
 description = "Declarative business logic & state machines for Django — sync and durable background transitions"
 readme = "README.md"
 license = { text = "MIT License" }
@@ -20,8 +20,7 @@ classifiers = [
     "Operating System :: OS Independent",
     "Intended Audience :: Developers",
     "Framework :: Django",
-    "Framework :: Django :: 4.0",
-    "Framework :: Django :: 5.0",
+    "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.1",
     "Framework :: Django :: 5.2",
     "Framework :: Django :: 6.0",


### PR DESCRIPTION
Release prep for 0.5.0: version bump, CHANGELOG section with upgrade notes for the typed-kwargs contract change, and trove classifiers aligned with the CI matrix (drop Django 4.0 — never installable under requires-python>=3.11 — and EOL 5.0; add 4.2, which CI tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging and documentation only—no library code changes in this diff.
> 
> **Overview**
> **Release 0.5.0** — bumps `pyproject.toml` from `0.4.1` to `0.5.0` and adds a dated **0.5.0** section to `CHANGELOG.md` (the prior `[Unreleased]` content is now under that release).
> 
> The changelog **upgrade notes** document the behavioural contract for this line: type-faithful background kwargs in phase 2, co-deploying web/workers, snapshot shape for `TransitionMessage.kwargs`, new default warnings and strict settings, plus pointers to bind-time hook validation and CI-tested Django versions.
> 
> **PyPI trove classifiers** are aligned with CI: **Framework :: Django :: 4.2** added; **4.0** and **5.0** removed (metadata only; `django>=4.0` dependency unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b0c22304a7c7db0f16ac28a38b62c8f6bf55379. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->