### PR TITLE
Fix 0.5.0 bind crash on property-defined process-level conditions/permissions (#121)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **0.5.0 regression:** bind-time hook validation crashed with
+  `TypeError: 'property' object is not iterable` on a Process whose
+  class-level `conditions`/`permissions` is a property/descriptor
+  (computed per instance). Such definitions cannot be inspected at bind
+  time and are now skipped (#121).
+
 ## [0.5.0] — 2026-07-17
 
 Type-faithful background kwargs (#107, #108), bind-time hook-signature

--- a/django_logic/process.py
+++ b/django_logic/process.py
@@ -426,11 +426,14 @@ def _validate_hook_signatures(process_cls) -> None:
     for proc_cls in _iter_process_tree(process_cls):
         owner = f'{proc_cls.__module__}.{proc_cls.__name__}'
         # Process-level conditions/permissions are plain lists of callables
-        # (executed via Conditions/Permissions in Process.is_valid).
-        for fn in getattr(proc_cls, 'conditions', None) or []:
-            check(fn, owner)
-        for fn in getattr(proc_cls, 'permissions', None) or []:
-            check(fn, owner)
+        # (executed via Conditions/Permissions in Process.is_valid). A
+        # subclass may instead define them as a property/descriptor computed
+        # per instance — those cannot be inspected at bind time; skip them.
+        for attr in ('conditions', 'permissions'):
+            hooks = getattr(proc_cls, attr, None)
+            if isinstance(hooks, (list, tuple)):
+                for fn in hooks:
+                    check(fn, owner)
         for transition in proc_cls.transitions or []:
             # getattr-guarded: a duck-typed custom transition that the
             # engine never asks for one of these must not fail to bind.

--- a/tests/test_hook_signature_validation.py
+++ b/tests/test_hook_signature_validation.py
@@ -117,3 +117,27 @@ class HookSignatureValidationTests(SimpleTestCase):
         with override_settings(DJANGO_LOGIC={'STRICT_HOOK_SIGNATURES': True}):
             ProcessManager.bind_model_process(
                 Invoice, _DuckProcess, state_field='status')
+
+
+class PropertyConditionsRegressionTests(SimpleTestCase):
+    def test_process_with_property_conditions_binds(self):
+        # A subclass may compute conditions per instance via a property; at
+        # class level that is a non-iterable descriptor and must be skipped,
+        # not crash the bind (issue #121).
+        class DynamicConditionsProcess(Process):
+            process_name = 'sig_dynamic_process'
+            transitions = [
+                Transition('approve', sources=['draft'], target='approved',
+                           side_effects=[good_hook]),
+            ]
+
+            @property
+            def conditions(self):
+                return []
+
+        try:
+            ProcessManager.bind_model_process(Invoice, DynamicConditionsProcess,
+                                              state_field='status')
+        finally:
+            if 'sig_dynamic_process' in vars(Invoice):
+                delattr(Invoice, 'sig_dynamic_process')


### PR DESCRIPTION
Closes #121. gv cannot boot on 0.5.0: `_validate_hook_signatures` iterates class-level `conditions`/`permissions`, and gv's `BaseCourierManifestProcess` defines `conditions` as a per-instance property — a truthy, non-iterable descriptor at class level → `TypeError` in every `bind_model_process`.

Fix: inspect process-level hook declarations only when they are plain `list`/`tuple`; descriptor-based definitions are per-instance and skipped. Regression test binds a property-conditions process. Suite: 355 tests OK.

Found within minutes of booting gv on 0.5.0 — the exact break class the #110 consumer-contract job will catch pre-release once `GV_REPO_TOKEN` is configured. Suggest releasing as **0.5.1** and gating it on that job if the secret is in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow guard in bind-time validation only; runtime `Process.is_valid` still uses instance `self.conditions`/`self.permissions` unchanged.
> 
> **Overview**
> Fixes a **0.5.0 regression** where `ProcessManager.bind_model_process` could raise `TypeError: 'property' object is not iterable` during `_validate_hook_signatures` when a `Process` subclass defines **`conditions` or `permissions` as a `@property`** (per-instance lists) instead of class-level `list`/`tuple` hooks.
> 
> Bind-time validation now **only walks process-level `conditions`/`permissions` when the class attribute is a plain `list` or `tuple`**; descriptor/property definitions are skipped because their callables cannot be inspected without an instance. Transition-level hook validation is unchanged.
> 
> Adds a regression test that binds a process with property-defined `conditions`, and documents the fix in **CHANGELOG**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4814e353fc8034204359ebec5460d80b44334bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->