### PR TITLE
release: django-logic 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.5.1] — 2026-07-17
+
 ### Fixed
 
 - **0.5.0 regression:** bind-time hook validation crashed with

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-logic"
-version = "0.5.0"
+version = "0.5.1"
 description = "Declarative business logic & state machines for Django — sync and durable background transitions"
 readme = "README.md"
 license = { text = "MIT License" }


### PR DESCRIPTION
Patch release: the #121 bind-crash regression fix (#122). Version bump + CHANGELOG section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only change with no runtime code in the diff.
> 
> **Overview**
> **Patch release metadata** for **0.5.1**: `pyproject.toml` version moves **0.5.0 → 0.5.1**, and `CHANGELOG.md` adds a **[0.5.1] — 2026-07-17** section under **Fixed** documenting the **0.5.0 regression** where bind-time hook validation raised `TypeError: 'property' object is not iterable` when a Process used a class-level **property/descriptor** for `conditions`/`permissions` (#121, fix noted as #122).
> 
> No library code changes appear in this diff—only release notes and the version string for publishing the already-merged patch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11f298caf61674beda7e87338bef3cf5fe5e7c33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->