### PR TITLE
Bindings registry + django_logic.W001 system check (#125)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## [Unreleased]
 
+### Added — bindings registry + system checks (#125)
+
+- **`ProcessManager.bindings`** — a public registry of
+  `(model, process_class, state_field)` recorded by every
+  `bind_model_process` call, so consumer tooling (coverage audits,
+  contract tests) no longer re-derives bindings from model attributes.
+- **`django_logic.W001` system check** — re-runs hook-signature
+  validation over the registry through Django's checks framework, so
+  warn-mode offenders surface in `manage.py check`, every test run and
+  deploy checks. Bind-time logger warnings alone are emitted during
+  `ready()`, before logging is configured, and can go entirely unseen —
+  a consumer's warn-mode suite showed zero warnings on a tree where
+  strict mode found three real offenders.
+
 ## [0.5.1] — 2026-07-17
 
 ### Fixed

--- a/django_logic/background/apps.py
+++ b/django_logic/background/apps.py
@@ -10,3 +10,4 @@ class BackgroundConfig(AppConfig):
     def ready(self) -> None:
         from django_logic.background.settings import validate_on_ready
         validate_on_ready()
+        from django_logic import checks  # noqa: F401 — registers system checks

--- a/django_logic/checks.py
+++ b/django_logic/checks.py
@@ -1,0 +1,37 @@
+"""Django system checks for django-logic.
+
+Bind-time validation warns through the transition logger, which runs
+during ``AppConfig.ready()`` — before test/dev logging is configured, so
+warn-mode consumers can miss it entirely. The checks framework runs after
+setup and is surfaced by ``manage.py check``, every test run, and deploy
+checks, regardless of logging configuration.
+"""
+from django.core import checks
+
+from django_logic.process import (
+    ProcessManager, collect_hook_signature_offenders,
+)
+
+
+@checks.register('django_logic')
+def check_hook_signatures(app_configs, **kwargs):
+    """Re-run hook-signature validation over every bound machine
+    (``django_logic.W001``)."""
+    findings = []
+    seen = set()
+    for binding in ProcessManager.bindings:
+        for offender in collect_hook_signature_offenders(binding.process_class):
+            key = (binding.model, binding.process_class, offender)
+            if key in seen:
+                continue
+            seen.add(key)
+            findings.append(checks.Warning(
+                f'FSM hook without a named instance-first parameter: {offender}',
+                hint='The engine calls hooks as fn(instance, **kwargs) '
+                     '(permissions as fn(instance, user, **kwargs)); give the '
+                     'hook a named first parameter. Decorated hooks need '
+                     'functools.wraps to expose the real signature.',
+                obj=f'{binding.model._meta.label} ({binding.process_class.__name__})',
+                id='django_logic.W001',
+            ))
+    return findings

--- a/django_logic/process.py
+++ b/django_logic/process.py
@@ -7,6 +7,7 @@ process as a property on a Django model, after which callers use
 """
 import inspect
 import uuid
+from collections import namedtuple
 from contextvars import ContextVar
 
 from django.core.exceptions import ImproperlyConfigured
@@ -402,6 +403,33 @@ def _validate_hook_signatures(process_cls) -> None:
     """
     from django.conf import settings
 
+    offenders = collect_hook_signature_offenders(process_cls)
+    if not offenders:
+        return
+    message = _hook_signature_message(offenders)
+    conf = getattr(settings, 'DJANGO_LOGIC', {}) or {}
+    if conf.get('STRICT_HOOK_SIGNATURES', False):
+        raise ImproperlyConfigured(message)
+    transition_logger.warning(message)
+
+
+def _hook_signature_message(offenders) -> str:
+    return (
+        'FSM hooks without a named instance-first parameter — the engine '
+        'calls hooks as fn(instance, **kwargs) (permissions as '
+        'fn(instance, user, **kwargs)), so give each hook a named first '
+        'parameter, e.g. def hook(instance, **kwargs); decorated hooks '
+        'need functools.wraps to expose the real signature: '
+        f'{"; ".join(sorted(set(offenders)))}'
+    )
+
+
+def collect_hook_signature_offenders(process_cls) -> list:
+    """Every hook across ``process_cls``'s tree whose first parameter is not
+    a named positional, as ``module.qualname (on Owner[.action])`` strings.
+    Pure collection — enforcement lives in bind-time validation and the
+    ``django_logic`` system check.
+    """
     offenders = []
 
     def check(fn, owner):
@@ -441,26 +469,25 @@ def _validate_hook_signatures(process_cls) -> None:
                 wrapper = getattr(transition, attr, None)
                 for fn in getattr(wrapper, 'commands', None) or []:
                     check(fn, f'{owner}.{getattr(transition, "action_name", "?")}')
-    if not offenders:
-        return
-    message = (
-        'FSM hooks without a named instance-first parameter — the engine '
-        'calls hooks as fn(instance, **kwargs) (permissions as '
-        'fn(instance, user, **kwargs)), so give each hook a named first '
-        'parameter, e.g. def hook(instance, **kwargs); decorated hooks '
-        'need functools.wraps to expose the real signature: '
-        f'{"; ".join(sorted(set(offenders)))}'
-    )
-    conf = getattr(settings, 'DJANGO_LOGIC', {}) or {}
-    if conf.get('STRICT_HOOK_SIGNATURES', False):
-        raise ImproperlyConfigured(message)
-    transition_logger.warning(message)
+    return offenders
+
+
+#: One record per ``bind_model_process`` call.
+ModelProcessBinding = namedtuple(
+    'ModelProcessBinding', ['model', 'process_class', 'state_field'])
 
 
 class ProcessManager:
+    #: Public registry of every bound machine, in bind order. Consumer
+    #: tooling (coverage audits, contract tests, the ``django_logic``
+    #: system check) reads this instead of re-deriving bindings from
+    #: model attributes.
+    bindings: list = []
+
     @classmethod
     def bind_model_process(cls, model, process_class, state_field: str = 'state') -> None:
         _validate_hook_signatures(process_class)
+        cls.bindings.append(ModelProcessBinding(model, process_class, state_field))
 
         def make_process_getter(field_name, process_cls):
             return lambda self: process_cls(field_name=field_name, instance=self)

--- a/tests/test_hook_signature_validation.py
+++ b/tests/test_hook_signature_validation.py
@@ -74,6 +74,8 @@ class HookSignatureValidationTests(SimpleTestCase):
                      'sig_proc_level_process', 'sig_duck_process'):
             if name in vars(Invoice):
                 delattr(Invoice, name)
+        ProcessManager.bindings = [
+            b for b in ProcessManager.bindings if b.model is not Invoice]
         super().tearDown()
 
     def test_clean_hooks_bind_silently(self):
@@ -141,3 +143,5 @@ class PropertyConditionsRegressionTests(SimpleTestCase):
         finally:
             if 'sig_dynamic_process' in vars(Invoice):
                 delattr(Invoice, 'sig_dynamic_process')
+            ProcessManager.bindings = [
+                b for b in ProcessManager.bindings if b.model is not Invoice]

--- a/tests/test_system_checks.py
+++ b/tests/test_system_checks.py
@@ -1,0 +1,66 @@
+"""Bindings registry + the django_logic.W001 system check (#125): warn-mode
+hook validation logs during ready(), before logging is configured, so the
+checks framework is the surface that cannot be missed."""
+from django.core.checks import run_checks
+from django.test import SimpleTestCase
+
+from django_logic.process import ModelProcessBinding, Process, ProcessManager
+from django_logic.transition import Transition
+from tests.models import Invoice
+
+
+def good_hook(instance, **kwargs):
+    pass
+
+
+def task_style_hook(*args, **kwargs):
+    pass
+
+
+class _CleanProcess(Process):
+    process_name = 'checks_clean_process'
+    transitions = [
+        Transition('approve', sources=['draft'], target='approved',
+                   side_effects=[good_hook]),
+    ]
+
+
+class _OffendingProcess(Process):
+    process_name = 'checks_offending_process'
+    transitions = [
+        Transition('approve', sources=['draft'], target='approved',
+                   side_effects=[task_style_hook]),
+    ]
+
+
+class BindingsRegistryTests(SimpleTestCase):
+    def tearDown(self):
+        ProcessManager.bindings = [
+            b for b in ProcessManager.bindings
+            if b.process_class not in (_CleanProcess, _OffendingProcess)
+        ]
+        for name in ('checks_clean_process', 'checks_offending_process'):
+            if name in vars(Invoice):
+                delattr(Invoice, name)
+        super().tearDown()
+
+    def test_bind_records_a_registry_entry(self):
+        ProcessManager.bind_model_process(Invoice, _CleanProcess, state_field='status')
+        self.assertIn(
+            ModelProcessBinding(Invoice, _CleanProcess, 'status'),
+            ProcessManager.bindings,
+        )
+
+    def test_w001_emitted_for_offending_hooks_only(self):
+        ProcessManager.bind_model_process(Invoice, _CleanProcess, state_field='status')
+        with self.assertLogs('django-logic.transition', level='WARNING'):
+            ProcessManager.bind_model_process(Invoice, _OffendingProcess, state_field='status')
+
+        findings = [f for f in run_checks() if f.id == 'django_logic.W001']
+        self.assertEqual(len(findings), 1)
+        self.assertIn('task_style_hook', findings[0].msg)
+        self.assertIn('_OffendingProcess', findings[0].obj)
+
+    def test_no_findings_when_all_bound_hooks_are_clean(self):
+        ProcessManager.bind_model_process(Invoice, _CleanProcess, state_field='status')
+        self.assertEqual([f for f in run_checks() if f.id == 'django_logic.W001'], [])


### PR DESCRIPTION
Closes #125.

- **`ProcessManager.bindings`**: public registry of `ModelProcessBinding(model, process_class, state_field)`, appended by every `bind_model_process`. Consumer tooling (gv's coverage audit had to reconstruct bindings from model-property closures) gets a first-class surface.
- **`django_logic.W001`**: a system check (tag `django_logic`) that re-runs `collect_hook_signature_offenders` over the registry and reports through Django's checks framework — visible in `manage.py check`, **every test run**, and deploy checks, independent of logging config. Motivation: bind-time warnings are logged during `ready()` before logging is configured; gv's warn-mode suite showed **zero** warnings on a tree where strict mode found three real offenders.
- Bind-time behavior unchanged (warn by default, `STRICT_HOOK_SIGNATURES` raises); the validator's collection half is now reusable (`collect_hook_signature_offenders`).

Suite: 358 tests OK. Binding tests now also clean the registry (it's global state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive registry and read-only system check; bind-time validation behavior is preserved with extracted collection logic.
> 
> **Overview**
> Adds a **first-class bindings registry** and a **Django system check** so hook-signature problems are visible even when bind-time logger warnings are lost during `AppConfig.ready()`.
> 
> Every `ProcessManager.bind_model_process` call now appends a **`ModelProcessBinding`** `(model, process_class, state_field)` to **`ProcessManager.bindings`**, giving consumer tooling a stable list instead of inferring bindings from model properties.
> 
> Hook validation is refactored: **`collect_hook_signature_offenders`** owns the inspection logic; bind-time **`_validate_hook_signatures`** still warns or raises under **`STRICT_HOOK_SIGNATURES`** unchanged. **`django_logic.W001`** re-runs that collection over the registry via **`django_logic/checks.py`**, registered when the background app's **`ready()`** imports checks — surfaced by **`manage.py check`**, test runs, and deploy checks.
> 
> Tests clear **`ProcessManager.bindings`** in teardown and add **`tests/test_system_checks.py`** for registry and W001 behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6575c09c196117abc65a3db966789524d303a31e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->