### PR TITLE
release: django-logic 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+## [0.6.0] — 2026-07-17
+
+Consumer-facing observability: a first-class bindings registry and a
+Django system check that makes warn-mode hook-signature offenders
+impossible to miss (#125). Also lands the sync/background parity contract
+matrix (#111) — test-only, but it pins the cross-class contracts consumer
+migrations depend on.
+
 ### Added — bindings registry + system checks (#125)
 
 - **`ProcessManager.bindings`** — a public registry of

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-logic"
-version = "0.5.1"
+version = "0.6.0"
 description = "Declarative business logic & state machines for Django — sync and durable background transitions"
 readme = "README.md"
 license = { text = "MIT License" }


### PR DESCRIPTION
Release prep for 0.6.0: bindings registry + django_logic.W001 system check (#125, PR #126) and the sync/background parity contract matrix (#111, PR #124). Version bump + CHANGELOG section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only release prep with no runtime code changes in this PR.
> 
> **Overview**
> **Release 0.6.0** — bumps the package version in `pyproject.toml` from **0.5.1** to **0.6.0** and adds a dated **CHANGELOG** section for that release.
> 
> The new changelog entry documents what ships in this version (already merged elsewhere): **`ProcessManager.bindings`** and the **`django_logic.W001`** Django system check for hook-signature validation (#125), plus the sync/background parity contract matrix (#111) as test-only contract coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b699679057362ac74b444a05a6de27430f43797a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->