### PR TITLE
NextTransition: don't forward request into background follow-ups (#129)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **NextTransition no longer forwards `request` into background
+  follow-ups** (#129). Under `STRICT_KWARGS_SERIALIZATION` the follow-up's
+  phase-1 failure is swallowed by the best-effort next-transition hand-off,
+  silently killing sync→background chains; sync follow-ups keep receiving
+  `request`.
+
 ## [0.6.0] — 2026-07-17
 
 Consumer-facing observability: a first-class bindings registry and a

--- a/django_logic/commands.py
+++ b/django_logic/commands.py
@@ -160,6 +160,13 @@ class NextTransition:
             )
             return None
 
+        if getattr(transitions[0], 'is_background', False):
+            # request is phase-1-only and unserializable; forwarding it into
+            # a background follow-up would fail phase-1 serialization under
+            # STRICT_KWARGS_SERIALIZATION — and that failure is swallowed
+            # below, silently killing the chain (#129).
+            kwargs = {k: v for k, v in kwargs.items() if k != 'request'}
+
         try:
             # Invoke through the Process entrypoint so the follow-up mints
             # its own tr_id and manages _transition_context (root_id chains,

--- a/tests/background/test_bg_chain.py
+++ b/tests/background/test_bg_chain.py
@@ -26,7 +26,7 @@ Two cases:
    (``GmailChainProcess`` / ``DummyChainProcess``), not the bound parent
    and not the predecessor — the riskiest owner-overwrite case.
 """
-from django.test import override_settings
+from django.test import TestCase, override_settings
 
 from django_logic.background.models import TransitionMessage
 from django_logic.testing import JourneyStep, ProcessScenario
@@ -205,3 +205,73 @@ class NestedDisambiguatedBgChainScenario(ProcessScenario):
         self.assertNotIn('dummy_', gmail.se_log)
         self.assertIn('dummy_report,', dummy.se_log)
         self.assertNotIn('gmail_', dummy.se_log)
+
+
+_STRICT_SYNC_SETTINGS = {**_SYNC_SETTINGS, 'STRICT_KWARGS_SERIALIZATION': True}
+
+_CHAIN_SEEN: dict = {}
+
+
+def _record_chain_kwargs(instance, **kwargs):
+    _CHAIN_SEEN.clear()
+    _CHAIN_SEEN.update(kwargs)
+
+
+@override_settings(DJANGO_LOGIC=_STRICT_SYNC_SETTINGS)
+class SyncToBackgroundRequestChainTests(TestCase):
+    """#129: a sync transition's next_transition into a BACKGROUND follow-up
+    must not forward ``request`` — under STRICT_KWARGS_SERIALIZATION the
+    follow-up's phase-1 failure is swallowed by NextTransition, silently
+    killing the chain. Sync follow-ups keep receiving request."""
+
+    @classmethod
+    def setUpClass(cls):
+        from django_logic import Process, Transition
+        from django_logic.background import BackgroundTransition
+        from django_logic.process import ProcessManager
+
+        super().setUpClass()
+
+        class RequestChainProcess(Process):
+            process_name = 'request_chain_process'
+            transitions = [
+                Transition('kick', sources=['draft'], target='kicked',
+                           next_transition='bg_finish'),
+                BackgroundTransition('bg_finish', sources=['kicked'], target='done',
+                                     side_effects=[_record_chain_kwargs]),
+                Transition('kick_sync', sources=['draft'], target='kicked',
+                           next_transition='sync_finish'),
+                Transition('sync_finish', sources=['kicked'], target='done',
+                           side_effects=[_record_chain_kwargs]),
+            ]
+
+        cls.process_class = RequestChainProcess
+        ProcessManager.bind_model_process(Widget, RequestChainProcess,
+                                          state_field='status')
+
+    @classmethod
+    def tearDownClass(cls):
+        from django_logic.process import ProcessManager
+
+        if 'request_chain_process' in vars(Widget):
+            delattr(Widget, 'request_chain_process')
+        ProcessManager.bindings = [
+            b for b in ProcessManager.bindings if b.process_class is not cls.process_class]
+        super().tearDownClass()
+
+    def setUp(self):
+        _CHAIN_SEEN.clear()
+        self.widget = Widget.objects.create(status='draft')
+
+    def test_background_follow_up_runs_despite_request_under_strict(self):
+        self.widget.request_chain_process.kick(request=object())
+        self.widget.refresh_from_db()
+        self.assertEqual(self.widget.status, 'done')
+        self.assertNotIn('request', _CHAIN_SEEN)
+
+    def test_sync_follow_up_still_receives_request(self):
+        sentinel = object()
+        self.widget.request_chain_process.kick_sync(request=sentinel)
+        self.widget.refresh_from_db()
+        self.assertEqual(self.widget.status, 'done')
+        self.assertIs(_CHAIN_SEEN.get('request'), sentinel)


### PR DESCRIPTION
Closes #129. Found by Cursor Bugbot on gv PR #9057 and confirmed in the engine: `NextTransition.execute` forwards the parent's full kwargs, and when the resolved follow-up is background under `STRICT_KWARGS_SERIALIZATION`, its phase-1 serialization failure is **swallowed** by the best-effort except — the chain silently dies (gv: imports stranded in `validating`/`in_progress`).

Fix: pop `request` from the forwarded kwargs only when the resolved follow-up `is_background` — request is phase-1-only by contract; sync follow-ups keep receiving it (no consumer regression).

Regression tests drive a real sync→background chain with `request` under strict (negative-checked: without the fix the object strands in the intermediate state) and pin the sync→sync path keeping `request`. Suite: 366 tests OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core transition chaining in `NextTransition` with behavior change only for sync→background paths; risk is moderate because incorrect filtering could break chains or drop expected kwargs, but scope is narrow (`request` only) and covered by new tests.
> 
> **Overview**
> Fixes **silent breakage of sync→background `next_transition` chains** when callers pass `request` and `STRICT_KWARGS_SERIALIZATION` is enabled.
> 
> `NextTransition.execute` used to forward the parent transition’s full kwargs into the follow-up. For a **background** follow-up, `request` is phase-1-only and cannot be serialized; under strict mode that raises during phase 1, but `NextTransition` **swallows** follow-up exceptions—so the chain dies with no visible error and instances can strand in an intermediate state. The change **drops `request` from forwarded kwargs only when the resolved follow-up is background** (`is_background`); **sync** follow-ups still receive `request` unchanged.
> 
> Adds regression tests (strict sync mode) for sync→background completing to `done` without `request` in the follow-up side-effect kwargs, and sync→sync still passing the sentinel `request`. Changelog documents the fix (#129).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c2ca0cd17ecbf7ec8a048127054fc988c1c8041. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->