### PR TITLE
release: django-logic 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 ## [Unreleased]
 
+## [0.7.0] — 2026-07-17
+
+Robustness and testing: the sync→background chain fix (#129), phase-2
+decode hardening (#117), loud NaN/Infinity rejection (#118), an
+`assert_idempotent` testing helper (#106), and parity-matrix coverage of
+hook ordering and `next_transition` chaining (#127).
+
+### Added
+
+- **`django_logic.testing.assert_idempotent(fn, instance, *, fields=None,
+  capture=None, refresh_from_db=True, **kwargs)`** (#106). Applies the
+  side-effect twice and asserts the second application changes nothing
+  observable (named instance fields and/or a `capture(instance)` callable
+  for off-instance effects). Background side-effects re-run from scratch
+  on every retry, so idempotence is a contract worth pinning per hook.
+- **Parity matrix extensions** (#127): hook ordering (side-effects before
+  the target write, callbacks after; on terminal failure `failed_state`
+  first, then `failure_side_effects`, then `failure_callbacks`) and
+  `next_transition` chaining are now pinned as identical across
+  `Transition` / `Action` / `BackgroundTransition` / `BackgroundAction`.
+  (The `Transition` docstring previously listed the failure order
+  backwards; fixed to match all implementation sites.)
+
+### Changed
+
+- **Non-finite floats are rejected at phase 1** (#118). `float('nan')` /
+  `float('inf')` pass Python's `json.dumps` (non-standard tokens) but are
+  not valid JSON, so they previously failed backend-dependently at the
+  row write (opaque on PostgreSQL, silently stored on SQLite). They now
+  raise at dispatch with the offending path named, surfacing as
+  `ImproperlyConfigured` like any unserializable kwarg. Pass `None` or an
+  explicit sentinel instead. `Decimal('NaN')` is unaffected.
+
 ### Fixed
 
 - **NextTransition no longer forwards `request` into background
@@ -9,6 +42,20 @@
   phase-1 failure is swallowed by the best-effort next-transition hand-off,
   silently killing sync→background chains; sync follow-ups keep receiving
   `request`.
+- **Phase-2 decode failures can no longer wedge an instance** (#117). A
+  malformed payload for a known kwargs type tag warns and passes the raw
+  tagged value through (mirroring the unknown-tag path) instead of
+  crashing phase 2; and any residual `deserialize_kwargs` failure (e.g. a
+  corrupt `user_id`) is accounted like an attempt failure — `errors_count`
+  increments, retries honor `TRANSITION_MESSAGE_MAX_ERRORS`, and
+  exhaustion routes `failed_state` — instead of escaping before the error
+  bookkeeping and being re-dispatched forever. Watchdog terminal
+  finalization proceeds with empty kwargs when a row no longer decodes.
+- **Documented isoformat fidelity limits** (#118): a `ZoneInfo` tzinfo
+  degrades to a fixed-offset `timezone` across the round-trip (UTC
+  instant preserved, zone identity not) and `datetime.fold` is not
+  preserved. `docs/PLAN.md` no longer describes the pre-0.5.0 lossy
+  encoding (#120).
 
 ## [0.6.0] — 2026-07-17
 

--- a/django_logic/background/runner.py
+++ b/django_logic/background/runner.py
@@ -303,7 +303,20 @@ def _finalize_terminal_from_watchdog(
         tm.mark_as_completed(measure_duration=False)
         return None
 
-    kwargs = deserialize_kwargs(tm.kwargs)
+    try:
+        with transaction.atomic():
+            kwargs = deserialize_kwargs(tm.kwargs)
+    except Exception as exc:
+        # Terminal finalization must not be blocked by kwargs that no
+        # longer decode: proceed with empty kwargs so failed_state and
+        # completion still land and the retry loop stops. The savepoint
+        # keeps the outer transaction healthy if the failure was a
+        # genuine DatabaseError (restore_user queries the user table).
+        transition_logger.error(
+            f'{source}: TransitionMessage#{tm.pk} kwargs failed to decode '
+            f'({type(exc).__name__}: {exc}); finalizing with empty kwargs.'
+        )
+        kwargs = {}
     # Mirror the sync path: side-effects/callbacks may read ``context``.
     kwargs.setdefault('context', {})
     state = process.state
@@ -397,7 +410,21 @@ def _run_atomic(tm_id: int) -> _Outcome:
         # best-effort, no-op without sentry-sdk. See observability.py / issue #78.
         set_sentry_context(tm)
 
-        kwargs = deserialize_kwargs(tm.kwargs)
+        # A decode failure must be accounted like any attempt failure —
+        # raised here it would escape before record_error with errors_count
+        # still 0, and retry_stale_transitions would re-dispatch the row
+        # forever. Hold the error and route it through _handle_failure once
+        # the row is restored below. The savepoint keeps the outer
+        # transaction healthy if the failure was a genuine DatabaseError
+        # (restore_user queries the user table), so the error bookkeeping
+        # always works.
+        decode_error = None
+        try:
+            with transaction.atomic():
+                kwargs = deserialize_kwargs(tm.kwargs)
+        except Exception as exc:
+            decode_error = exc
+            kwargs = {}
         # Mirror the synchronous path (Transition._init_transition_context):
         # side-effects/callbacks may read a framework-provided ``context``
         # dict. serialize_kwargs drops it at phase 1, so rebuild it here —
@@ -463,6 +490,10 @@ def _run_atomic(tm_id: int) -> _Outcome:
                 f'{transition.action_name} {state.instance_key} '
                 f'queue={tm.queue_name}'
             )
+            if decode_error is not None:
+                return _handle_failure(
+                    tm, transition, state, kwargs, decode_error
+                )
             try:
                 # Savepoint: a failed attempt rolls back every side-effect
                 # write (all-or-nothing per attempt), and a genuine

--- a/django_logic/background/serializers.py
+++ b/django_logic/background/serializers.py
@@ -15,7 +15,10 @@ Deliberate handling:
 * ``user`` — replaced with ``user_id`` (restored on the phase-2 side).
 * ``datetime`` / ``date`` / ``time`` / ``Decimal`` / ``UUID`` / ``tuple``
   / ``set`` / ``frozenset`` — tag-encoded, restored in phase 2 with the
-  original type (recursively, inside dicts/lists/tuples/sets).
+  original type (recursively, inside dicts/lists/tuples/sets). Two known
+  fidelity limits of the isoformat round-trip: a ``ZoneInfo`` tzinfo
+  degrades to a fixed-offset ``timezone`` (the UTC instant is preserved,
+  the zone identity is not), and ``datetime.fold`` is not preserved.
 * ``_transition_context``-managed keys (``tr_id``, ``root_id``,
   ``parent_id``) — stringified when present.
 * Model instances and arbitrary objects — rejected at phase 1 via
@@ -37,6 +40,7 @@ Deliberate handling:
 from __future__ import annotations
 
 import json
+import math
 from datetime import date, datetime, time
 from decimal import Decimal
 from uuid import UUID
@@ -127,24 +131,35 @@ def decode_value(value):
         if tag is None:
             return {k: decode_value(v) for k, v in value.items()}
         inner = value.get('value')
-        if tag == 'dict':
-            return {k: decode_value(v) for k, v in inner.items()}
-        if tag == 'tuple':
-            return tuple(decode_value(v) for v in inner)
-        if tag == 'set':
-            return {decode_value(v) for v in inner}
-        if tag == 'frozenset':
-            return frozenset(decode_value(v) for v in inner)
-        decoder = _SCALAR_DECODERS.get(tag)
-        if decoder is None:
-            # A row written by a newer version than this worker: pass the
-            # tagged form through rather than crash phase 2.
+        try:
+            if tag == 'dict':
+                return {k: decode_value(v) for k, v in inner.items()}
+            if tag == 'tuple':
+                return tuple(decode_value(v) for v in inner)
+            if tag == 'set':
+                return {decode_value(v) for v in inner}
+            if tag == 'frozenset':
+                return frozenset(decode_value(v) for v in inner)
+            decoder = _SCALAR_DECODERS.get(tag)
+            if decoder is not None:
+                return decoder(inner)
+        except Exception as e:
+            # A known tag whose payload no longer decodes (hand-edited row,
+            # cross-version writer bug): mirror the unknown-tag passthrough
+            # below rather than crash phase 2 — the raw tagged form stays
+            # visible to the side-effect and the log says why.
             transition_logger.warning(
-                f"unknown kwargs type tag {tag!r} — passing value through "
-                f"undecoded (worker older than the row writer?)"
+                f"malformed payload for kwargs type tag {tag!r} "
+                f"({type(e).__name__}: {e}) — passing value through undecoded"
             )
             return value
-        return decoder(inner)
+        # A row written by a newer version than this worker: pass the
+        # tagged form through rather than crash phase 2.
+        transition_logger.warning(
+            f"unknown kwargs type tag {tag!r} — passing value through "
+            f"undecoded (worker older than the row writer?)"
+        )
+        return value
     return value
 
 
@@ -167,6 +182,26 @@ def _non_string_key_paths(value, path='kwargs'):
             yield from _non_string_key_paths(item, f'{path}[]')
 
 
+def _non_finite_float_paths(value, path='kwargs'):
+    """Yield ``path=value`` for every float that is NaN or +/-Infinity.
+
+    ``json.dumps`` accepts them by default — Python emits the non-standard
+    ``NaN``/``Infinity`` tokens — so they pass the phase-1 round-trip guard
+    but are not valid JSON: the failure then surfaces backend-dependently
+    (PostgreSQL rejects them opaquely at the row write). Phase 1 must
+    reject them loudly, naming the offending value.
+    """
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            yield f'{path}={value!r}'
+    elif isinstance(value, dict):
+        for k, v in value.items():
+            yield from _non_finite_float_paths(v, f'{path}[{k!r}]')
+    elif isinstance(value, (list, tuple, set, frozenset)):
+        for item in value:
+            yield from _non_finite_float_paths(item, f'{path}[]')
+
+
 def serialize_kwargs(kwargs: dict) -> dict:
     """Return a JSON-serializable copy of ``kwargs`` fit for storage.
 
@@ -175,9 +210,12 @@ def serialize_kwargs(kwargs: dict) -> dict:
     Tag-encodes non-JSON-native values so phase 2 restores real types.
     Non-string dict keys are stringified by JSON persistence and cannot
     round-trip — flagged with a warning (or ``TypeError`` under the strict
-    setting). Raises ``TypeError`` via ``json.dumps`` if something
-    unexpected slips through — the caller should let that propagate so the
-    failure is visible at phase 1 rather than at phase 2.
+    setting). Non-finite floats (``float('nan')`` / ``float('inf')``) are
+    not valid JSON despite passing ``json.dumps`` — rejected with a
+    ``TypeError`` naming the offending value. Raises ``TypeError`` via
+    ``json.dumps`` if something unexpected slips through — the caller
+    should let that propagate so the failure is visible at phase 1 rather
+    than at phase 2.
     """
     out = dict(kwargs)
     if 'request' in out:
@@ -222,11 +260,30 @@ def serialize_kwargs(kwargs: dict) -> dict:
             raise KwargsSerializationError(message)
         transition_logger.warning(message)
 
+    bad_floats = sorted(set(_non_finite_float_paths(out)))
+    if bad_floats:
+        raise TypeError(
+            f"{out.get('tr_id')} non-finite float in background transition "
+            f"kwargs ({', '.join(bad_floats)}): NaN/Infinity pass Python's "
+            f"json.dumps but are not valid JSON, so the failure would "
+            f"surface backend-dependently at the row write. Pass None, or "
+            f"encode the sentinel explicitly."
+        )
+
     out = encode_value(out)
 
     # Round-trip through json to surface any remaining non-serializable
     # types at phase 1. Cheap on small dicts and invaluable in tests.
-    json.dumps(out)
+    # allow_nan=False so a non-finite float the scan above could not reach
+    # (e.g. one hiding in a dict key) still fails here rather than at the
+    # row write; translated to TypeError to keep the dispatcher contract
+    # (ImproperlyConfigured wraps TypeError, not ValueError).
+    try:
+        json.dumps(out, allow_nan=False)
+    except ValueError as e:
+        raise TypeError(
+            f"{out.get('tr_id')} kwargs are not valid JSON: {e}"
+        ) from e
     return out
 
 

--- a/django_logic/testing/__init__.py
+++ b/django_logic/testing/__init__.py
@@ -21,6 +21,7 @@ JSON and rebuild it in a test, turning a production bug into a regression test.
 
 See ``docs/design/TESTING_SCENARIOS.md`` for the full design.
 """
+from django_logic.testing.idempotency import assert_idempotent
 from django_logic.testing.scenario import ProcessScenario, JourneyStep
 from django_logic.testing.snapshot import from_snapshot, snapshot, to_json
 from django_logic.testing.tracking import ExecutionTracker
@@ -32,4 +33,5 @@ __all__ = [
     'from_snapshot',
     'to_json',
     'ExecutionTracker',
+    'assert_idempotent',
 ]

--- a/django_logic/testing/idempotency.py
+++ b/django_logic/testing/idempotency.py
@@ -1,0 +1,68 @@
+"""Idempotency assertion for background side-effects (issue #106).
+
+Background side-effects re-run FROM SCRATCH on every retry (crash
+re-delivery, watchdog requeue, the periodic starter), so every side-effect
+must be idempotent: a second application must change nothing observable.
+Consumers hand-rolled "call twice, compare" — or skipped the check.
+``assert_idempotent`` makes it one call::
+
+    from django_logic.testing import assert_idempotent
+
+    assert_idempotent(send_invoice, invoice,
+                      fields=['sent_at'],
+                      capture=lambda i: i.emails.count())
+"""
+from __future__ import annotations
+
+import copy
+
+
+def assert_idempotent(fn, instance, *, fields=None, capture=None,
+                      refresh_from_db=True, **kwargs):
+    """Apply ``fn(instance, **kwargs)`` twice and assert the second
+    application changes nothing observable.
+
+    Background side-effects re-run from scratch on every retry, so they must
+    be idempotent — this pins that contract for one side-effect the way a
+    consumer would otherwise hand-roll ("call twice, compare").
+
+    The observation is the named ``fields`` read off ``instance`` (refreshed
+    from the DB first unless ``refresh_from_db=False``) plus, when given, the
+    result of ``capture(instance)`` — use ``capture`` for effects the
+    instance's own columns can't see (related-row counts, mock call_counts).
+    At least one of ``fields``/``capture`` is required: with neither, the
+    observation is empty and the assertion would pass vacuously. Observed
+    values are deep-copied, so mutable values (lists, dicts) are compared by
+    value at observation time, not by a shared reference ``fn`` mutated.
+
+    Raises ``AssertionError`` with the first-vs-second observation diff.
+    """
+    fields = list(fields or ())
+    if not fields and capture is None:
+        raise TypeError(
+            'assert_idempotent requires fields=[...] and/or '
+            'capture=callable — with neither, nothing is observed and the '
+            'assertion would pass vacuously.')
+
+    def observe():
+        if refresh_from_db:
+            instance.refresh_from_db()
+        obs = {field: getattr(instance, field) for field in fields}
+        if capture is not None:
+            obs['capture()'] = capture(instance)
+        return copy.deepcopy(obs)
+
+    fn(instance, **kwargs)
+    first = observe()
+    fn(instance, **kwargs)
+    second = observe()
+
+    if first != second:
+        name = getattr(fn, '__name__', repr(fn))
+        diff = [f'{key}: {first[key]!r} -> {second[key]!r}'
+                for key in first if first[key] != second[key]]
+        raise AssertionError(
+            f'{name} is not idempotent — the second application changed '
+            'the observation:\n  ' + '\n  '.join(diff) + '\n'
+            'Background side-effects re-run from scratch on every retry, '
+            'so a second application must change nothing observable.')

--- a/django_logic/transition.py
+++ b/django_logic/transition.py
@@ -84,8 +84,9 @@ class Transition(BaseTransition):
       3. optionally set ``in_progress_state``
       4. run side-effects
       5. on success: set ``target``, unlock, run callbacks, run ``next_transition``
-      6. on failure: run ``failure_side_effects``, set ``failed_state``,
-         unlock, run ``failure_callbacks`` (and re-raise)
+      6. on failure: set ``failed_state`` (so failure hooks observe the
+         contained state), run ``failure_side_effects``, unlock, run
+         ``failure_callbacks`` (and re-raise)
     """
 
     def __init__(self, action_name: str, sources: list, target: str, **kwargs):

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -596,12 +596,44 @@ written to the TransitionMessage, then read back in phase 2). This
 means tests catch serialization bugs that `task_always_eager` would
 miss.
 
-Built-in handling for non-serializable values at TransitionMessage
-creation:
-- `request` → stripped (framework pulls `user` first)
-- `user` → `user_id`
-- `UUID` → `str`
-- `datetime` / `date` → `.isoformat()`
+> **Historical — the design as shipped in 0.3.0, superseded by the
+> typed round-trip in 0.5.0 (#107, #108).** Non-serializable values
+> were coerced lossily at TransitionMessage creation, so a phase-2
+> hook received strings where the synchronous path passed real
+> `UUID`/`datetime` objects:
+>
+> - `request` → stripped (framework pulls `user` first)
+> - `user` → `user_id`
+> - `UUID` → `str`
+> - `datetime` / `date` → `.isoformat()`
+
+Since 0.5.0 the round-trip is type-faithful. Values that JSON cannot
+represent natively are persisted with a self-describing `__dl_type__`
+tag and restored to their original Python types in phase 2, so a
+side-effect receives the same types whether its transition is
+synchronous or background:
+
+- `request` → dropped loudly: a warning is logged, and
+  `DJANGO_LOGIC['STRICT_KWARGS_SERIALIZATION'] = True` raises instead.
+  A live request cannot cross the phase boundary; extract `user`
+  (which is rehydrated) or pass plain values.
+- `user` → `user_id`, restored to a live `user` in phase 2.
+- `datetime` / `date` / `time` / `Decimal` / `UUID` / `tuple` / `set`
+  / `frozenset` → tag-encoded, restored in phase 2 with the original
+  type (recursively, inside containers). `Decimal` and `set`,
+  previously rejected at phase 1, are supported.
+- Model instances and arbitrary objects → still rejected at phase 1
+  (`TypeError`). Pass a pk and re-fetch in the hook: phase 2 may run
+  much later and must see fresh rows, not a stale snapshot.
+- Non-string dict keys → JSON objects only have string keys, so these
+  cannot round-trip; flagged loudly at phase 1 (warning, or
+  `TypeError` under the strict setting).
+
+Rows written before the typed encoding (plain ISO strings) still
+decode; deploy web and workers together when upgrading across this
+boundary — an older worker passes the tagged dicts through verbatim.
+The authoritative contract lives in the
+`django_logic/background/serializers.py` module docstring.
 
 ### 2.13 Django app setup
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-logic"
-version = "0.6.0"
+version = "0.7.0"
 description = "Declarative business logic & state machines for Django — sync and durable background transitions"
 readme = "README.md"
 license = { text = "MIT License" }

--- a/tests/background/test_kwargs_roundtrip.py
+++ b/tests/background/test_kwargs_roundtrip.py
@@ -142,6 +142,63 @@ class KwargsRoundTripTests(TestCase):
         self.assertEqual(seen['when'], _WHEN.isoformat())
         self.assertEqual(seen['some_uuid'], str(_UUID))
 
+    def test_malformed_tagged_row_passes_through_and_completes(self):
+        # A KNOWN tag whose payload no longer decodes (hand-edited row,
+        # cross-version writer bug) must not wedge phase 2: the raw tagged
+        # form passes through to the side-effect and the row completes.
+        self.widget.status = 'fulfilling'
+        self.widget.save(update_fields=['status'])
+        bad = {'__dl_type__': 'datetime', 'value': 'not-a-datetime'}
+        tm = TransitionMessage.objects.create(
+            app_label='bg_tests',
+            model_name='widget',
+            instance_id=str(self.widget.pk),
+            process_name='process',
+            transition_name='fulfil',
+            queue_name='django_logic.critical',
+            kwargs={'when': bad},
+        )
+        with self.assertLogs('django-logic.transition', level='WARNING'):
+            run_background_transition(tm.pk)
+        tm.refresh_from_db()
+        self.assertTrue(tm.is_completed)
+        self.assertEqual(tm.errors_count, 0)
+        self.assertEqual(bg_models.LAST_KWARGS['when'], bad)
+
+    def test_undecodable_kwargs_row_counts_errors_and_routes_failed_state(self):
+        # kwargs whose decode genuinely raises (a user_id that cannot be a
+        # pk) must be accounted like any attempt failure — errors_count
+        # increments per attempt instead of escaping at 0 and being
+        # re-dispatched by retry_stale_transitions forever, and exhaustion
+        # routes failed_state (issue #117).
+        self.widget.status = 'fulfilling'
+        self.widget.save(update_fields=['status'])
+        tm = TransitionMessage.objects.create(
+            app_label='bg_tests',
+            model_name='widget',
+            instance_id=str(self.widget.pk),
+            process_name='process',
+            transition_name='fulfil',
+            queue_name='django_logic.critical',
+            kwargs={'user_id': ['not', 'a', 'pk']},
+        )
+        with self.assertRaises(TypeError):
+            run_background_transition(tm.pk)
+        tm.refresh_from_db()
+        self.assertFalse(tm.is_completed)
+        self.assertEqual(tm.errors_count, 1)
+
+        # Drive the remaining attempts as the worker would (the periodic
+        # starter only picks rows up once RETRY_MINUTES have elapsed).
+        for _ in range(2):
+            with self.assertRaises(TypeError):
+                run_background_transition(tm.pk)
+        tm.refresh_from_db()
+        self.assertTrue(tm.is_completed)
+        self.assertEqual(tm.errors_count, 3)
+        self.widget.refresh_from_db()
+        self.assertEqual(self.widget.status, 'fulfilment_failed')
+
     def test_deleted_user_degrades_to_none(self):
         # A user that vanished between phase 1 and phase 2 restores to None
         # (the work becomes "system-initiated"). Drive phase 2 directly with

--- a/tests/background/test_parity_matrix.py
+++ b/tests/background/test_parity_matrix.py
@@ -158,6 +158,22 @@ class ParityMatrixTests(TestCase):
             with self.assertRaises(ImproperlyConfigured, msg=action):
                 _drive(self._fresh(), action, blob=Blob())
 
+    def test_non_finite_float_kwarg_fails_at_phase1_for_background_only(self):
+        # NaN/Infinity pass Python's json.dumps (non-standard tokens) but
+        # are not valid JSON — without the phase-1 guard the failure
+        # surfaces backend-dependently at the row write (issue #118). Same
+        # dispatcher contract as an unserializable kwarg above.
+        from django.core.exceptions import ImproperlyConfigured
+        from django_logic.background.models import TransitionMessage
+
+        for action in BACKGROUND_ACTIONS:
+            for bad in (float('nan'), float('inf'), float('-inf')):
+                with self.assertRaises(
+                        ImproperlyConfigured, msg=f'{action} {bad!r}'):
+                    _drive(self._fresh(), action, rate=bad)
+        # Phase 1 failed before persisting anything.
+        self.assertFalse(TransitionMessage.objects.exists())
+
     def test_callbacks_observe_the_target_state_in_all_four_classes(self):
         expected = {'sync_transition': 'done', 'sync_action': 'draft',
                     'bg_transition': 'done', 'bg_action': 'draft'}

--- a/tests/background/test_parity_matrix.py
+++ b/tests/background/test_parity_matrix.py
@@ -18,7 +18,16 @@ Contracts pinned per class:
 * failure routing — sync raises to the caller and routes failed_state
   immediately; background absorbs at the caller and routes after
   retries are exhausted;
-* callbacks observe the target state in all four classes.
+* callbacks observe the target state in all four classes;
+* hook ordering — side-effects run while the persisted state is still
+  the source, callbacks only after the target write is observable; on
+  terminal failure, failed_state is written first, then
+  failure_side_effects, then failure_callbacks — the same sequence
+  sync and background;
+* ``next_transition`` — the same background follow-up runs with the
+  same typed kwargs and a live ``user`` whether the parent is sync or
+  background, and never sees ``request``; the declared difference: a
+  sync ``Action`` never chains, a ``BackgroundAction`` does.
 """
 from datetime import datetime, timezone as tz
 from decimal import Decimal
@@ -56,6 +65,8 @@ _ENGINE_KEYS = {'tr_id', 'root_id', 'parent_id', 'context', 'user', 'process_cla
 SEEN: dict = {}
 CALLBACK_STATE: dict = {}
 FAIL = {'on': False}
+ORDER: list = []
+HOP_SEEN: dict = {}
 
 
 def record_kwargs(instance, **kwargs):
@@ -70,25 +81,74 @@ def record_callback_state(instance, **kwargs):
     CALLBACK_STATE['status'] = instance.status
 
 
+def record_order_side_effect(instance, **kwargs):
+    instance.refresh_from_db()
+    ORDER.append(('side_effect', instance.status))
+
+
+def record_order_callback(instance, **kwargs):
+    instance.refresh_from_db()
+    ORDER.append(('callback', instance.status))
+
+
+def record_order_failure_side_effect(instance, **kwargs):
+    instance.refresh_from_db()
+    ORDER.append(('failure_side_effect', instance.status))
+
+
+def record_order_failure_callback(instance, **kwargs):
+    instance.refresh_from_db()
+    ORDER.append(('failure_callback', instance.status))
+
+
+def record_hop_kwargs(instance, **kwargs):
+    HOP_SEEN.clear()
+    HOP_SEEN.update(kwargs)
+
+
 class ParityProcess(Process):
     process_name = 'parity_process'
     transitions = [
         Transition('sync_transition', sources=['draft'], target='done',
                    failed_state='failed',
-                   side_effects=[record_kwargs], callbacks=[record_callback_state]),
+                   side_effects=[record_kwargs, record_order_side_effect],
+                   callbacks=[record_callback_state, record_order_callback],
+                   failure_side_effects=[record_order_failure_side_effect],
+                   failure_callbacks=[record_order_failure_callback]),
         Action('sync_action', sources=['draft'],
-               side_effects=[record_kwargs], callbacks=[record_callback_state]),
+               side_effects=[record_kwargs, record_order_side_effect],
+               callbacks=[record_callback_state, record_order_callback]),
         BackgroundTransition('bg_transition', sources=['draft'], target='done',
                              failed_state='failed',
-                             side_effects=[record_kwargs], callbacks=[record_callback_state]),
+                             side_effects=[record_kwargs, record_order_side_effect],
+                             callbacks=[record_callback_state, record_order_callback],
+                             failure_side_effects=[record_order_failure_side_effect],
+                             failure_callbacks=[record_order_failure_callback]),
         BackgroundAction('bg_action', sources=['draft'],
-                         side_effects=[record_kwargs], callbacks=[record_callback_state]),
+                         side_effects=[record_kwargs, record_order_side_effect],
+                         callbacks=[record_callback_state, record_order_callback]),
+        # next_transition parity: one parent per class, every one chaining
+        # into the same background follow-up. The hop accepts both 'draft'
+        # (Action parents change no state) and 'chained_src' (Transition
+        # parents' target).
+        Transition('sync_transition_chain', sources=['draft'],
+                   target='chained_src', next_transition='chain_hop'),
+        Action('sync_action_chain', sources=['draft'],
+               next_transition='chain_hop'),
+        BackgroundTransition('bg_transition_chain', sources=['draft'],
+                             target='chained_src', next_transition='chain_hop'),
+        BackgroundAction('bg_action_chain', sources=['draft'],
+                         next_transition='chain_hop'),
+        BackgroundTransition('chain_hop', sources=['draft', 'chained_src'],
+                             target='chained', side_effects=[record_hop_kwargs]),
     ]
 
 
 ALL_ACTIONS = ('sync_transition', 'sync_action', 'bg_transition', 'bg_action')
 BACKGROUND_ACTIONS = ('bg_transition', 'bg_action')
 SYNC_ACTIONS = ('sync_transition', 'sync_action')
+CHAIN_PARENTS = ('sync_transition_chain', 'sync_action_chain',
+                 'bg_transition_chain', 'bg_action_chain')
 
 
 def _drive(widget, action, **kwargs):
@@ -111,6 +171,8 @@ class ParityMatrixTests(TestCase):
     def setUp(self):
         SEEN.clear()
         CALLBACK_STATE.clear()
+        ORDER.clear()
+        HOP_SEEN.clear()
         FAIL['on'] = False
         self.user = get_user_model().objects.create(username='parity-actor')
 
@@ -165,6 +227,93 @@ class ParityMatrixTests(TestCase):
             CALLBACK_STATE.clear()
             _drive(self._fresh(), action)
             self.assertEqual(CALLBACK_STATE.get('status'), expected[action], action)
+
+    def test_side_effects_precede_the_target_write_and_callbacks_follow_it(self):
+        # The callback-state test above pins WHICH state callbacks observe;
+        # this pins the ORDER around the state write: the side-effect runs
+        # while the persisted state is still the SOURCE (this process
+        # declares no in_progress_state; when one is declared, the sync
+        # path and background phase 1 both write it before side-effects
+        # run, so the pre-target contract stays symmetric), and the
+        # callback runs only after the target write is observable. Actions
+        # differ only in the state the callback sees — they never write one.
+        expected = {'sync_transition': 'done', 'sync_action': 'draft',
+                    'bg_transition': 'done', 'bg_action': 'draft'}
+        for action in ALL_ACTIONS:
+            ORDER.clear()
+            _drive(self._fresh(), action)
+            self.assertEqual(
+                ORDER,
+                [('side_effect', 'draft'), ('callback', expected[action])],
+                action,
+            )
+
+    def test_terminal_failure_order_is_identical_for_both_failure_capable_classes(self):
+        # failed_state is written FIRST, so both failure hooks observe the
+        # contained state; failure_side_effects run before failure_callbacks.
+        # Every implementation site agrees on this sequence — the sync path
+        # (Transition.fail_transition), the background terminal attempt
+        # (runner._handle_failure), and the watchdog finalizer that mirrors
+        # it — and that cross-class symmetry is the contract pinned here.
+        # (Transition's class docstring lists failure_side_effects before
+        # the failed_state write; the code does not, in any class.)
+        from django_logic.background.models import TransitionMessage
+        from django_logic.background.runner import run_background_transition
+
+        FAIL['on'] = True
+        results = {}
+        for action in ('sync_transition', 'bg_transition'):
+            ORDER.clear()
+            widget = self._fresh()
+            with self.assertRaises(ValueError):
+                _drive(widget, action)
+            if action == 'bg_transition':
+                # sync runs the terminal sequence on its only attempt; the
+                # background one runs at MAX_ERRORS — the retry-timing
+                # difference already pinned by the failure-routing tests.
+                tm = TransitionMessage.objects.get(instance_id=str(widget.pk),
+                                                   transition_name=action)
+                for _ in range(2):
+                    with self.assertRaises(ValueError):
+                        run_background_transition(tm.pk)
+            widget.refresh_from_db()
+            self.assertEqual(widget.status, 'failed', action)
+            results[action] = list(ORDER)
+
+        for action, order in results.items():
+            self.assertEqual(order, [('failure_side_effect', 'failed'),
+                                     ('failure_callback', 'failed')], action)
+        FAIL['on'] = False
+
+    def test_next_transition_chains_equivalently_across_all_four_classes(self):
+        # The parent's class must not change WHAT the follow-up receives:
+        # the same background follow-up runs with the same typed kwargs and
+        # a live user, and request never reaches it — stripped by
+        # NextTransition for a sync parent (#129), dropped at the parent's
+        # own phase 1 for a background parent. The one declared difference:
+        # a sync Action never runs next_transition (see the divergence note
+        # on Action), while a BackgroundAction's phase 2 does.
+        chains = {'sync_transition_chain': True, 'sync_action_chain': False,
+                  'bg_transition_chain': True, 'bg_action_chain': True}
+        for parent in CHAIN_PARENTS:
+            HOP_SEEN.clear()
+            widget = self._fresh()
+            _drive(widget, parent, user=self.user, request=object(),
+                   **dict(TYPED_KWARGS))
+            widget.refresh_from_db()
+            if not chains[parent]:
+                self.assertEqual(HOP_SEEN, {}, parent)
+                self.assertEqual(widget.status, 'draft', parent)
+                continue
+            self.assertEqual(widget.status, 'chained', parent)
+            hop_kwargs = {k: v for k, v in HOP_SEEN.items()
+                          if k not in _ENGINE_KEYS}
+            self.assertEqual(hop_kwargs, TYPED_KWARGS, parent)
+            for key, value in TYPED_KWARGS.items():
+                self.assertIs(type(hop_kwargs[key]), type(value),
+                              f'{parent}.{key}')
+            self.assertEqual(HOP_SEEN['user'].pk, self.user.pk, parent)
+            self.assertNotIn('request', HOP_SEEN, parent)
 
     def test_sync_failure_raises_and_routes_failed_state_immediately(self):
         FAIL['on'] = True

--- a/tests/background/test_safety_net.py
+++ b/tests/background/test_safety_net.py
@@ -197,6 +197,27 @@ class DetectStuckTests(TestCase):
         )
         self.assertEqual(detect_stuck_transitions(), 0)
 
+    def test_undecodable_kwargs_row_still_finalized(self):
+        """A stuck row whose kwargs no longer decode must still be forced
+        terminal (failed_state + completed) with empty kwargs — a decode
+        failure must not block the safety net and re-wedge the retry loop."""
+        widget = Widget.objects.create(status='fulfilling')
+        TransitionMessage.objects.create(
+            app_label='bg_tests',
+            model_name='widget',
+            instance_id=widget.pk,
+            process_name='process',
+            transition_name='fulfil',
+            queue_name='q',
+            kwargs={'user_id': ['not', 'a', 'pk']},
+            errors_count=3,
+        )
+        self.assertEqual(detect_stuck_transitions(), 1)
+        tm = TransitionMessage.objects.get(instance_id=widget.pk)
+        self.assertTrue(tm.is_completed)
+        widget.refresh_from_db()
+        self.assertEqual(widget.status, 'fulfilment_failed')
+
     def test_unrestorable_row_still_marked_completed(self):
         """A stuck row pointing at a non-existent transition still gets
         terminated so the retry loop stops."""

--- a/tests/background/test_serializers.py
+++ b/tests/background/test_serializers.py
@@ -85,6 +85,38 @@ class SerializeKwargsTests(SimpleTestCase):
         with self.assertLogs('django-logic.transition', level='WARNING'):
             self.assertEqual(decode_value(dict(row)), row)
 
+    def test_malformed_scalar_payload_passes_through_with_a_warning(self):
+        # A KNOWN tag whose payload no longer decodes (hand-edited row,
+        # cross-version writer bug) must not crash phase 2 — same
+        # passthrough contract as an unknown tag.
+        row = {'when': {'__dl_type__': 'datetime', 'value': 'not-a-datetime'}}
+        with self.assertLogs('django-logic.transition', level='WARNING') as logs:
+            self.assertEqual(decode_value(dict(row)), row)
+        self.assertIn('malformed payload', logs.output[0])
+        self.assertIn("'datetime'", logs.output[0])
+
+    def test_missing_payload_for_known_tag_passes_through(self):
+        # Tagged dict without its 'value' key: the inner payload is None.
+        row = {'when': {'__dl_type__': 'datetime'}}
+        with self.assertLogs('django-logic.transition', level='WARNING'):
+            self.assertEqual(decode_value(dict(row)), row)
+
+    def test_malformed_container_payload_passes_through(self):
+        for tag in ('dict', 'tuple', 'set', 'frozenset'):
+            row = {'v': {'__dl_type__': tag, 'value': None}}
+            with self.assertLogs('django-logic.transition', level='WARNING'):
+                self.assertEqual(decode_value(dict(row)), row, tag)
+
+    def test_well_formed_neighbours_of_a_malformed_payload_still_decode(self):
+        row = {
+            'bad': {'__dl_type__': 'uuid', 'value': 'not-a-uuid'},
+            'good': {'__dl_type__': 'decimal', 'value': '1.5'},
+        }
+        with self.assertLogs('django-logic.transition', level='WARNING'):
+            out = decode_value(dict(row))
+        self.assertEqual(out['bad'], row['bad'])
+        self.assertEqual(out['good'], Decimal('1.5'))
+
     def test_tr_ids_stringified_when_uuid(self):
         tr_id = UUID(int=99)
         out = serialize_kwargs({
@@ -100,6 +132,29 @@ class SerializeKwargsTests(SimpleTestCase):
 
         with self.assertRaises(TypeError):
             serialize_kwargs({'blob': Unserializable()})
+
+    def test_nan_rejected_naming_the_offending_value(self):
+        # float('nan') passes Python's json.dumps (non-standard NaN token)
+        # but is not valid JSON — the failure would otherwise surface
+        # backend-dependently at the row write.
+        with self.assertRaisesMessage(TypeError, "kwargs['rate']=nan"):
+            serialize_kwargs({'rate': float('nan')})
+
+    def test_infinity_rejected_naming_the_offending_value(self):
+        with self.assertRaisesMessage(TypeError, "kwargs['rate']=inf"):
+            serialize_kwargs({'rate': float('inf')})
+
+    def test_negative_infinity_rejected(self):
+        with self.assertRaisesMessage(TypeError, "kwargs['rate']=-inf"):
+            serialize_kwargs({'rate': float('-inf')})
+
+    def test_nested_non_finite_float_rejected_with_its_path(self):
+        with self.assertRaisesMessage(
+                TypeError, "kwargs['stats']['values'][]=nan"):
+            serialize_kwargs({'stats': {'values': [1.0, float('nan')]}})
+
+    def test_finite_floats_still_pass(self):
+        self.assertEqual(serialize_kwargs({'rate': 1.5}), {'rate': 1.5})
 
     def test_context_kwarg_stripped(self):
         out = serialize_kwargs({'context': {'x': 1}, 'keep': 2})

--- a/tests/test_assert_idempotent.py
+++ b/tests/test_assert_idempotent.py
@@ -1,0 +1,96 @@
+"""Tests for ``django_logic.testing.assert_idempotent`` (issue #106).
+
+Background side-effects re-run from scratch on every retry, so they must be
+idempotent. The helper applies a side-effect twice and asserts the second
+application changes nothing observable — via instance fields and/or a
+``capture(instance)`` callable for off-instance effects.
+"""
+from django.test import TestCase
+
+from django_logic.testing import assert_idempotent
+from tests.background.models import Widget
+
+
+def set_status_done(instance, **kwargs):
+    instance.status = 'done'
+    instance.save(update_fields=['status'])
+
+
+def set_status_to(instance, value=None, **kwargs):
+    instance.status = value
+    instance.save(update_fields=['status'])
+
+
+def append_to_log(instance, **kwargs):
+    instance.se_log = (instance.se_log or '') + 'ran,'
+    instance.save(update_fields=['se_log'])
+
+
+def create_sibling(instance, **kwargs):
+    Widget.objects.create(status='sibling')
+
+
+def get_or_create_sibling(instance, **kwargs):
+    Widget.objects.get_or_create(status='sibling')
+
+
+def append_in_memory(instance, **kwargs):
+    instance.kwargs_seen.append('x')
+
+
+class AssertIdempotentTests(TestCase):
+
+    def test_idempotent_side_effect_passes(self):
+        widget = Widget.objects.create()
+        assert_idempotent(set_status_done, widget, fields=['status'])
+        self.assertEqual(widget.status, 'done')
+
+    def test_non_idempotent_side_effect_fails_with_diff(self):
+        widget = Widget.objects.create()
+        with self.assertRaises(AssertionError) as ctx:
+            assert_idempotent(append_to_log, widget, fields=['se_log'])
+        message = str(ctx.exception)
+        self.assertIn('append_to_log is not idempotent', message)
+        self.assertIn("se_log: 'ran,' -> 'ran,ran,'", message)
+        self.assertIn('retry', message)
+
+    def test_capture_catches_off_instance_effect(self):
+        widget = Widget.objects.create()
+        siblings = Widget.objects.filter(status='sibling')
+        with self.assertRaises(AssertionError) as ctx:
+            assert_idempotent(create_sibling, widget,
+                              capture=lambda i: siblings.count())
+        self.assertIn('capture(): 1 -> 2', str(ctx.exception))
+
+    def test_capture_passes_for_guarded_off_instance_effect(self):
+        widget = Widget.objects.create()
+        siblings = Widget.objects.filter(status='sibling')
+        assert_idempotent(get_or_create_sibling, widget,
+                          capture=lambda i: siblings.count())
+        self.assertEqual(siblings.count(), 1)
+
+    def test_requires_fields_or_capture(self):
+        widget = Widget.objects.create()
+        with self.assertRaises(TypeError) as ctx:
+            assert_idempotent(set_status_done, widget)
+        self.assertIn('fields', str(ctx.exception))
+        self.assertIn('capture', str(ctx.exception))
+        # An empty fields list is the same vacuous no-op observation.
+        with self.assertRaises(TypeError):
+            assert_idempotent(set_status_done, widget, fields=[])
+
+    def test_kwargs_are_forwarded_to_fn(self):
+        widget = Widget.objects.create()
+        assert_idempotent(set_status_to, widget, fields=['status'],
+                          value='shipped')
+        self.assertEqual(widget.status, 'shipped')
+
+    def test_in_place_mutation_caught_without_refresh(self):
+        # refresh_from_db=False observes in-memory state; the deep copy at
+        # observation time keeps an in-place list mutation from aliasing the
+        # first observation into a vacuous pass.
+        widget = Widget.objects.create()
+        with self.assertRaises(AssertionError) as ctx:
+            assert_idempotent(append_in_memory, widget,
+                              fields=['kwargs_seen'], refresh_from_db=False)
+        self.assertIn("kwargs_seen: ['x'] -> ['x', 'x']", str(ctx.exception))


### PR DESCRIPTION
Release prep for 0.7.0, integrating:

- #130 (merged): NextTransition stops forwarding request into background follow-ups (#129)
- #117: phase-2 decode hardening — malformed tag payloads pass through with a warning; residual decode failures route through attempt error bookkeeping instead of re-dispatching forever
- #118: NaN/Infinity rejected loudly at phase 1; ZoneInfo/fold fidelity limits documented
- #106: django_logic.testing.assert_idempotent helper
- #127: parity matrix extended with hook ordering + next_transition chaining (also fixes the Transition docstring's backwards failure order)
- #120: docs/PLAN.md updated to the typed kwargs contract

Suite: 389 tests OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 0827e45ac371e7ad9f946e8cd2221f8e15015eeb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->