### PR TITLE
Transition-execution coverage: observers + coverage report (#132)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Transition-execution coverage** (#132). The resolver now notifies
+  `django_logic.process.transition_observers` with
+  `(owning_process_cls, action_name, instance)` on every transition
+  initiation (direct calls, `next_transition` follow-ups, background
+  phase 1; phase-2 restore does not re-notify). A raising observer is
+  logged and never breaks the transition. On top of it,
+  `django_logic.coverage` records executed `(process, action)` pairs and
+  diffs them against every transition declared by `ProcessManager.bindings`
+  (nested processes included): `TransitionCoverage` (in-memory context
+  manager), `DJANGO_LOGIC['TRANSITION_COVERAGE_LOG'] = path` (file-backed,
+  fork/spawn-safe parallel test runs), and `coverage_report()`. Static
+  test-tree analysis cannot see transitive or dynamically-dispatched
+  drives; the engine can — this answers "which transitions did the suite
+  never drive?" exactly.
+
 ### Fixed
 
 - **NextTransition no longer forwards `request` into background

--- a/README.md
+++ b/README.md
@@ -681,6 +681,7 @@ DJANGO_LOGIC = {
     'SENTRY_TRANSACTION_NAMING': True,  # per-transition Sentry naming (no-op without sentry-sdk)
     'STRICT_KWARGS_SERIALIZATION': False,  # True: raise (not warn) on dropped 'request' / non-string dict keys
     'STRICT_HOOK_SIGNATURES': False,    # True: refuse to bind hooks without a named instance-first parameter
+    # 'TRANSITION_COVERAGE_LOG': '...',  # opt-in: record driven transitions to a file (see "Transition-execution coverage")
 }
 ```
 
@@ -1195,6 +1196,10 @@ Diffing `report['uncovered']` in CI catches transitions that silently stop
 being exercised. The observer list is public — consumers can register their
 own hooks (metrics, tracing); a raising observer is logged and never breaks a
 transition.
+
+The log is **append-only and never truncated** — point each run at a fresh
+path (or delete the old file first), or stale pairs from earlier runs count
+as covered.
 
 ## Contributing
 Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.

--- a/README.md
+++ b/README.md
@@ -1157,6 +1157,45 @@ class TestStuckOrder(ProcessScenario):
 
 **The full guide — [docs/TESTING_GUIDE.md](docs/TESTING_GUIDE.md)** — documents every test scenario for a process (happy paths, gating, failures, retries, terminal failures, one-in-flight conflicts, superseded rows, nested processes, snapshot replay) with copy-pasteable examples, and explains the philosophy: **you test your process; the library guarantees the background machinery** (validated by its own regression suite and a production-style Heroku matrix), so your tests never need a Celery broker.
 
+### Transition-execution coverage
+
+Which transitions does your test suite actually drive? Static analysis of the
+test tree can't tell — a test that exercises a view or Celery task which calls
+`instance.process.action()` looks uncovered, and dynamically-dispatched drives
+(`getattr(process, name)()`) can't be attributed at all. The engine can answer
+exactly: every initiation resolves the transition and its declaring (possibly
+nested) process in one place, and notifies
+`django_logic.process.transition_observers`.
+
+```python
+from django_logic.coverage import TransitionCoverage
+
+with TransitionCoverage() as cov:
+    ...  # drive processes / run tests
+report = cov.report()
+report['uncovered']  # [{'process': ..., 'action': ..., 'background': ..., 'models': [...]}]
+```
+
+For parallel test runs (fork or spawn), record to a file instead — every
+worker appends unique `(process, action)` pairs:
+
+```python
+# settings used for the coverage run
+DJANGO_LOGIC = {..., 'TRANSITION_COVERAGE_LOG': '/tmp/fsm_coverage.log'}
+```
+
+```python
+from django_logic.coverage import coverage_report
+report = coverage_report(log_path='/tmp/fsm_coverage.log')
+```
+
+A pair is recorded at *initiation* (direct calls, `next_transition`
+follow-ups, background phase 1); phase-2 restore and retries don't re-notify.
+Diffing `report['uncovered']` in CI catches transitions that silently stop
+being exercised. The observer list is public — consumers can register their
+own hooks (metrics, tracing); a raising observer is logged and never breaks a
+transition.
+
 ## Contributing
 Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.
 

--- a/django_logic/apps.py
+++ b/django_logic/apps.py
@@ -1,0 +1,26 @@
+from django.apps import AppConfig
+
+
+class DjangoLogicConfig(AppConfig):
+    """App-level bootstrap for the base ``django_logic`` app.
+
+    The background app (``django_logic.background``) performs the same
+    bootstrap in its own ``ready()`` — both are idempotent — but a
+    sync-only consumer that installs just ``django_logic`` must still get
+    the system checks and coverage recording, so they live here too.
+    """
+    name = 'django_logic'
+
+    def ready(self) -> None:
+        from django.conf import settings
+
+        from django_logic import checks  # noqa: F401 — registers system checks
+
+        # Transition-coverage recording (#132). Activated in ready() so
+        # spawn-based parallel test workers, which re-run it, self-activate;
+        # fork-based workers inherit the parent's recorder.
+        conf = getattr(settings, 'DJANGO_LOGIC', {}) or {}
+        coverage_log = conf.get('TRANSITION_COVERAGE_LOG')
+        if coverage_log:
+            from django_logic.coverage import start_file_recording
+            start_file_recording(coverage_log)

--- a/django_logic/background/apps.py
+++ b/django_logic/background/apps.py
@@ -8,6 +8,17 @@ class BackgroundConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
 
     def ready(self) -> None:
+        from django.conf import settings
+
         from django_logic.background.settings import validate_on_ready
         validate_on_ready()
         from django_logic import checks  # noqa: F401 — registers system checks
+
+        # Transition-coverage recording (#132). Activated here (not in the
+        # recorder module) so spawn-based parallel test workers, which re-run
+        # ready(), self-activate; fork-based workers inherit the parent's.
+        conf = getattr(settings, 'DJANGO_LOGIC', {}) or {}
+        coverage_log = conf.get('TRANSITION_COVERAGE_LOG')
+        if coverage_log:
+            from django_logic.coverage import start_file_recording
+            start_file_recording(coverage_log)

--- a/django_logic/coverage.py
+++ b/django_logic/coverage.py
@@ -25,9 +25,19 @@ Two front-ends:
   worker appends unique pairs (activated in ``AppConfig.ready``); afterwards
   ``coverage_report(log_path=...)`` merges and diffs.
 
-Initiation semantics: a pair is recorded when a transition is resolved and
-about to execute. Phase-2 background restore and retries do not re-notify —
-phase 1 already recorded the pair.
+Initiation semantics: a pair is recorded when a transition is *resolved* —
+an initiation refused later (lock contention, under-lock revalidation,
+``AlreadyInProgress``) still counts as driven. Phase-2 background restore
+and retries do not re-notify — phase 1 already recorded the pair.
+
+Two footguns worth knowing:
+
+* The log file is append-only and never truncated — point each run at a
+  fresh path (or delete the old file first), or stale pairs from earlier
+  runs silently count as covered.
+* Pairs are keyed on ``(owning process class, action_name)``: a synchronous
+  and a background transition sharing an ``action_name`` within one class
+  (courier-style polymorphism) collapse into a single entry.
 
 No test-framework imports here: activation happens in ``AppConfig.ready``,
 which also runs in production processes.
@@ -73,8 +83,15 @@ def coverage_report(executed=None, log_path=None) -> dict:
     """
     executed_keys = set(executed or ())
     if log_path:
-        with open(log_path) as fh:
-            executed_keys.update(line.rstrip('\n') for line in fh if line.strip())
+        try:
+            with open(log_path) as fh:
+                executed_keys.update(
+                    line.rstrip('\n') for line in fh if line.strip())
+        except FileNotFoundError:
+            # The recorder only creates the file on the first pair — a run
+            # that drove no transitions is a valid (all-uncovered) report,
+            # not a crash.
+            pass
 
     declared = {}
     for binding, process_cls, transition in iter_bound_transitions():
@@ -138,9 +155,12 @@ class _FileRecorder:
         key = _key(owning_process_cls, action_name)
         if key in self.seen:
             return
-        self.seen.add(key)
         with open(self.path, 'a') as fh:
             fh.write(key + '\n')
+        # Marked seen only after the append succeeds — a transient write
+        # failure (disk full, permissions) retries on the next initiation
+        # instead of permanently dropping the pair.
+        self.seen.add(key)
 
 
 _file_recorder = None

--- a/django_logic/coverage.py
+++ b/django_logic/coverage.py
@@ -1,0 +1,169 @@
+"""Transition-execution coverage (#132).
+
+Static analysis of a consumer's test tree cannot see transitive execution
+(a test drives a view/task which calls ``instance.process.action()``) or
+dynamic dispatch (``getattr(process, action_name)()``). The engine can:
+every initiation resolves ``(transition, owning_process)`` in one place and
+notifies ``django_logic.process.transition_observers``.
+
+This module records those notifications as ``(owning process class, action)``
+pairs and diffs them against every transition declared by every bound
+process (``ProcessManager.bindings``, nested processes included), so a test
+run can answer "which transitions did the suite never drive?" exactly.
+
+Two front-ends:
+
+* :class:`TransitionCoverage` — in-memory context manager for
+  single-process runs::
+
+      with TransitionCoverage() as cov:
+          ...  # run tests / drive processes
+      report = cov.report()
+
+* File-backed recording for parallel test runners (fork or spawn): set
+  ``DJANGO_LOGIC['TRANSITION_COVERAGE_LOG'] = '/path/to/file.log'`` and every
+  worker appends unique pairs (activated in ``AppConfig.ready``); afterwards
+  ``coverage_report(log_path=...)`` merges and diffs.
+
+Initiation semantics: a pair is recorded when a transition is resolved and
+about to execute. Phase-2 background restore and retries do not re-notify —
+phase 1 already recorded the pair.
+
+No test-framework imports here: activation happens in ``AppConfig.ready``,
+which also runs in production processes.
+"""
+from django_logic.process import ProcessManager, transition_observers
+
+
+def _key(process_cls, action_name: str) -> str:
+    return f'{process_cls.__module__}.{process_cls.__qualname__}\t{action_name}'
+
+
+def iter_bound_transitions():
+    """Yield ``(binding, owning_process_cls, transition)`` for every
+    transition declared by every bound process, walking nested processes.
+
+    A process class nested under several bindings is yielded once per
+    binding — key on ``(owning class, action_name)`` to deduplicate.
+    """
+    for binding in ProcessManager.bindings:
+        stack = [binding.process_class]
+        seen = set()
+        while stack:
+            process_cls = stack.pop()
+            if process_cls in seen:
+                continue
+            seen.add(process_cls)
+            for transition in process_cls.transitions:
+                yield binding, process_cls, transition
+            stack.extend(process_cls.nested_processes)
+
+
+def coverage_report(executed=None, log_path=None) -> dict:
+    """Diff executed pairs against every bound transition.
+
+    :param executed: iterable of recorder keys (see :func:`_key`), e.g.
+        ``TransitionCoverage.executed``.
+    :param log_path: path to a file-backed recording (merged with
+        ``executed`` if both are given).
+    :return: dict with ``total`` / ``executed`` / ``uncovered`` where
+        ``uncovered`` is a sorted list of
+        ``{'process': dotted_class, 'action': name, 'background': bool,
+        'models': [model labels]}``.
+    """
+    executed_keys = set(executed or ())
+    if log_path:
+        with open(log_path) as fh:
+            executed_keys.update(line.rstrip('\n') for line in fh if line.strip())
+
+    declared = {}
+    for binding, process_cls, transition in iter_bound_transitions():
+        entry = declared.setdefault(_key(process_cls, transition.action_name), {
+            'process': f'{process_cls.__module__}.{process_cls.__qualname__}',
+            'action': transition.action_name,
+            'background': bool(getattr(transition, 'is_background', False)),
+            'models': set(),
+        })
+        entry['models'].add(binding.model._meta.label)
+
+    uncovered = [
+        {**entry, 'models': sorted(entry['models'])}
+        for key, entry in sorted(declared.items())
+        if key not in executed_keys
+    ]
+    return {
+        'total': len(declared),
+        'executed': len(declared) - len(uncovered),
+        'uncovered': uncovered,
+    }
+
+
+class TransitionCoverage:
+    """In-memory recorder; use as a context manager or ``start()``/``stop()``."""
+
+    def __init__(self):
+        self.executed = set()
+
+    def _observe(self, owning_process_cls, action_name, instance):
+        self.executed.add(_key(owning_process_cls, action_name))
+
+    def start(self):
+        if self._observe not in transition_observers:
+            transition_observers.append(self._observe)
+        return self
+
+    def stop(self):
+        if self._observe in transition_observers:
+            transition_observers.remove(self._observe)
+
+    def report(self) -> dict:
+        return coverage_report(self.executed)
+
+    __enter__ = start
+
+    def __exit__(self, *exc_info):
+        self.stop()
+
+
+class _FileRecorder:
+    """Appends each newly-seen pair to ``path``. Per-process dedup only:
+    parallel workers may write duplicate lines — ``coverage_report`` merges
+    via a set, so duplicates are harmless."""
+
+    def __init__(self, path):
+        self.path = path
+        self.seen = set()
+
+    def __call__(self, owning_process_cls, action_name, instance):
+        key = _key(owning_process_cls, action_name)
+        if key in self.seen:
+            return
+        self.seen.add(key)
+        with open(self.path, 'a') as fh:
+            fh.write(key + '\n')
+
+
+_file_recorder = None
+
+
+def start_file_recording(path) -> None:
+    """Idempotently register a file-backed recorder (one per process).
+
+    Called from ``AppConfig.ready`` when
+    ``DJANGO_LOGIC['TRANSITION_COVERAGE_LOG']`` is set, so spawn-based
+    parallel workers self-activate; fork-based workers inherit the parent's
+    recorder."""
+    global _file_recorder
+    if _file_recorder is not None and _file_recorder.path == path:
+        return
+    stop_file_recording()
+    _file_recorder = _FileRecorder(path)
+    transition_observers.append(_file_recorder)
+
+
+def stop_file_recording() -> None:
+    global _file_recorder
+    if _file_recorder is not None:
+        if _file_recorder in transition_observers:
+            transition_observers.remove(_file_recorder)
+        _file_recorder = None

--- a/django_logic/process.py
+++ b/django_logic/process.py
@@ -24,6 +24,25 @@ _transition_context: ContextVar[dict | None] = ContextVar(
     '_transition_context', default=None
 )
 
+#: Transition-initiation observers. Each callable is invoked as
+#: ``observer(owning_process_cls, action_name, instance)`` after a
+#: transition resolves, before it executes — for every initiation path
+#: (direct calls, next_transition follow-ups, background phase 1; phase-2
+#: restore does not re-notify). Observers must never break a transition:
+#: exceptions are logged and swallowed. Registered by
+#: ``django_logic.coverage``; open to consumer metrics/tracing hooks.
+transition_observers: list = []
+
+
+def _notify_transition_observers(owning_process, action_name, instance):
+    for observer in tuple(transition_observers):
+        try:
+            observer(type(owning_process), action_name, instance)
+        except Exception:
+            transition_logger.exception(
+                f'transition observer {observer!r} raised; ignored'
+            )
+
 
 class Process:
     """Declarative container of transitions and nested processes.
@@ -113,6 +132,10 @@ class Process:
         transition, owning_process = self._resolve_transition_with_owner(
             action_name, user
         )
+        if transition_observers:
+            _notify_transition_observers(
+                owning_process, action_name, self.state.instance
+            )
 
         tr_id = uuid.uuid4()
         transition_logger.info(

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -1,0 +1,159 @@
+"""Transition-initiation observers + transition-execution coverage (#132).
+
+Static test-tree analysis cannot see transitive or dynamically-dispatched
+drives; the resolver can. These tests pin the observer contract (fires on
+every initiation path, never breaks a transition) and the coverage report
+(executed vs declared, nested owner attribution, file-backed merging).
+"""
+import tempfile
+
+from django.test import TestCase
+
+from django_logic.coverage import (
+    TransitionCoverage,
+    coverage_report,
+    iter_bound_transitions,
+    start_file_recording,
+    stop_file_recording,
+)
+from django_logic.process import Process, ProcessManager, transition_observers
+from django_logic.transition import Transition
+from tests.models import Invoice
+
+
+def is_never_available(instance):
+    return False
+
+
+class _NestedCoverageProcess(Process):
+    process_name = 'coverage_process'
+    transitions = [
+        Transition('archive', sources=['approved'], target='archived'),
+    ]
+
+
+class _CoverageProcess(Process):
+    process_name = 'coverage_process'
+    nested_processes = [_NestedCoverageProcess]
+    transitions = [
+        Transition('approve', sources=['draft'], target='approved'),
+        Transition('reject', sources=['draft'], target='rejected'),
+        Transition('purge', sources=['archived'], target='purged',
+                   conditions=[is_never_available]),
+    ]
+
+
+class TransitionObserverAndCoverageTests(TestCase):
+    def setUp(self):
+        super().setUp()
+        ProcessManager.bind_model_process(
+            Invoice, _CoverageProcess, state_field='status')
+
+    def tearDown(self):
+        stop_file_recording()
+        ProcessManager.bindings = [
+            b for b in ProcessManager.bindings
+            if b.process_class is not _CoverageProcess
+        ]
+        if 'coverage_process' in vars(Invoice):
+            delattr(Invoice, 'coverage_process')
+        super().tearDown()
+
+    # --- observer contract ------------------------------------------------
+
+    def test_observer_receives_owner_action_and_instance(self):
+        invoice = Invoice.objects.create(status='draft')
+        seen = []
+        observer = lambda cls, action, instance: seen.append((cls, action, instance.pk))  # noqa: E731
+        transition_observers.append(observer)
+        try:
+            invoice.coverage_process.approve()
+        finally:
+            transition_observers.remove(observer)
+        self.assertEqual(seen, [(_CoverageProcess, 'approve', invoice.pk)])
+
+    def test_observer_attributes_nested_transition_to_declaring_process(self):
+        invoice = Invoice.objects.create(status='approved')
+        seen = []
+        observer = lambda cls, action, instance: seen.append((cls, action))  # noqa: E731
+        transition_observers.append(observer)
+        try:
+            invoice.coverage_process.archive()
+        finally:
+            transition_observers.remove(observer)
+        self.assertEqual(seen, [(_NestedCoverageProcess, 'archive')])
+
+    def test_raising_observer_does_not_break_the_transition(self):
+        invoice = Invoice.objects.create(status='draft')
+
+        def broken(cls, action, instance):
+            raise RuntimeError('observer bug')
+
+        transition_observers.append(broken)
+        try:
+            with self.assertLogs('django-logic.transition', level='ERROR'):
+                invoice.coverage_process.approve()
+        finally:
+            transition_observers.remove(broken)
+        invoice.refresh_from_db()
+        self.assertEqual(invoice.status, 'approved')
+
+    # --- declared-transition walk ------------------------------------------
+
+    def test_iter_bound_transitions_includes_nested(self):
+        pairs = {
+            (proc.__name__, t.action_name)
+            for _, proc, t in iter_bound_transitions()
+            if proc in (_CoverageProcess, _NestedCoverageProcess)
+        }
+        self.assertEqual(pairs, {
+            ('_CoverageProcess', 'approve'),
+            ('_CoverageProcess', 'reject'),
+            ('_CoverageProcess', 'purge'),
+            ('_NestedCoverageProcess', 'archive'),
+        })
+
+    # --- in-memory recorder -------------------------------------------------
+
+    def test_coverage_report_splits_executed_and_uncovered(self):
+        invoice = Invoice.objects.create(status='draft')
+        with TransitionCoverage() as cov:
+            invoice.coverage_process.approve()
+            invoice.coverage_process.archive()
+        self.assertNotIn(cov._observe, transition_observers)
+
+        report = cov.report()
+        ours = [u for u in report['uncovered']
+                if u['process'].endswith(('_CoverageProcess', '_NestedCoverageProcess'))]
+        self.assertEqual({u['action'] for u in ours}, {'reject', 'purge'})
+        self.assertTrue(all(u['models'] == ['tests.Invoice'] for u in ours))
+        self.assertTrue(all(u['background'] is False for u in ours))
+
+    # --- file-backed recorder -----------------------------------------------
+
+    def test_file_recording_appends_unique_pairs_and_report_merges(self):
+        invoice = Invoice.objects.create(status='draft')
+        with tempfile.NamedTemporaryFile(mode='r', suffix='.log') as log:
+            start_file_recording(log.name)
+            invoice.coverage_process.approve()
+            invoice.coverage_process.archive()
+            Invoice.objects.filter(pk=invoice.pk).update(status='draft')
+            invoice.refresh_from_db()
+            invoice.coverage_process.approve()  # dedup: no second line
+            stop_file_recording()
+
+            lines = [line for line in log.read().splitlines() if line]
+            self.assertEqual(len(lines), 2)
+
+            report = coverage_report(log_path=log.name)
+            ours = [u for u in report['uncovered']
+                    if u['process'].endswith(('_CoverageProcess', '_NestedCoverageProcess'))]
+            self.assertEqual({u['action'] for u in ours}, {'reject', 'purge'})
+
+    def test_start_file_recording_is_idempotent_per_path(self):
+        with tempfile.NamedTemporaryFile(suffix='.log') as log:
+            start_file_recording(log.name)
+            start_file_recording(log.name)
+            recorders = [o for o in transition_observers
+                         if o.__class__.__name__ == '_FileRecorder']
+            self.assertEqual(len(recorders), 1)

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -7,7 +7,7 @@ every initiation path, never breaks a transition) and the coverage report
 """
 import tempfile
 
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from django_logic.coverage import (
     TransitionCoverage,
@@ -157,3 +157,142 @@ class TransitionObserverAndCoverageTests(TestCase):
             recorders = [o for o in transition_observers
                          if o.__class__.__name__ == '_FileRecorder']
             self.assertEqual(len(recorders), 1)
+
+    def test_coverage_report_tolerates_a_never_written_log(self):
+        # The recorder creates the file on the first pair — a run that drove
+        # nothing is a valid all-uncovered report, not a crash.
+        report = coverage_report(log_path='/nonexistent/dir/coverage.log')
+        self.assertEqual(report['executed'], 0)
+
+    # --- observer isolation / cleanup ---------------------------------------
+
+    def test_dirty_with_block_exit_still_unregisters_the_observer(self):
+        cov = TransitionCoverage()
+        with self.assertRaises(RuntimeError):
+            with cov:
+                raise RuntimeError('test body blew up')
+        self.assertNotIn(cov._observe, transition_observers)
+
+    def test_raising_observer_does_not_block_later_observers(self):
+        invoice = Invoice.objects.create(status='draft')
+        seen = []
+
+        def broken(cls, action, instance):
+            raise RuntimeError('observer bug')
+
+        def working(cls, action, instance):
+            seen.append(action)
+
+        transition_observers.extend([broken, working])
+        try:
+            with self.assertLogs('django-logic.transition', level='ERROR'):
+                invoice.coverage_process.approve()
+        finally:
+            transition_observers.remove(broken)
+            transition_observers.remove(working)
+        self.assertEqual(seen, ['approve'])
+
+
+_SYNC_SETTINGS = {
+    'LOCK_TIMEOUT': 7200,
+    'BACKGROUND_EXECUTION': 'sync',
+    'STARTER_QUEUE': 'django_logic.starter',
+    'TRANSITION_MESSAGE_MAX_ERRORS': 3,
+    'TRANSITION_MESSAGE_RETRY_MINUTES': 2,
+    'TRANSITION_MESSAGE_CLEANUP_DAYS': 7,
+}
+
+_BG_FAIL = {'on': False}
+
+
+def _bg_side_effect(instance, **kwargs):
+    if _BG_FAIL['on']:
+        raise ValueError('injected failure')
+
+
+@override_settings(DJANGO_LOGIC=_SYNC_SETTINGS)
+class BackgroundObserverSemanticsTests(TestCase):
+    """The headline claims: background phase 1 notifies exactly once;
+    phase-2 execution and retries never re-notify; a next_transition
+    follow-up notifies once more, attributed to the follow-up's owner."""
+
+    @classmethod
+    def setUpClass(cls):
+        from django_logic.background import BackgroundTransition
+        from tests.background.models import Widget
+
+        super().setUpClass()
+
+        class ObserverBgProcess(Process):
+            process_name = 'observer_bg_process'
+            transitions = [
+                BackgroundTransition('bg_go', sources=['draft'], target='done',
+                                     failed_state='failed',
+                                     side_effects=[_bg_side_effect]),
+                Transition('kick', sources=['draft'], target='kicked',
+                           next_transition='bg_finish'),
+                BackgroundTransition('bg_finish', sources=['kicked'],
+                                     target='done',
+                                     side_effects=[_bg_side_effect]),
+            ]
+
+        cls.process_class = ObserverBgProcess
+        cls.Widget = Widget
+        ProcessManager.bind_model_process(Widget, ObserverBgProcess,
+                                          state_field='status')
+
+    @classmethod
+    def tearDownClass(cls):
+        if 'observer_bg_process' in vars(cls.Widget):
+            delattr(cls.Widget, 'observer_bg_process')
+        ProcessManager.bindings = [
+            b for b in ProcessManager.bindings
+            if b.process_class is not cls.process_class
+        ]
+        super().tearDownClass()
+
+    def setUp(self):
+        _BG_FAIL['on'] = False
+        self.seen = []
+        self._observer = lambda cls_, action, instance: self.seen.append(
+            (cls_.__name__, action))
+        transition_observers.append(self._observer)
+        self.widget = self.Widget.objects.create(status='draft')
+
+    def tearDown(self):
+        transition_observers.remove(self._observer)
+        super().tearDown()
+
+    def test_background_initiation_notifies_exactly_once(self):
+        # Sync execution mode runs phase 1 AND phase 2 inline — phase 2
+        # (restore + side-effect execution) must not add a second record.
+        self.widget.observer_bg_process.bg_go()
+        self.widget.refresh_from_db()
+        self.assertEqual(self.widget.status, 'done')
+        self.assertEqual(self.seen, [('ObserverBgProcess', 'bg_go')])
+
+    def test_retries_do_not_renotify(self):
+        from django_logic.background.models import TransitionMessage
+        from django_logic.background.runner import run_background_transition
+
+        _BG_FAIL['on'] = True
+        with self.assertRaises(ValueError):
+            self.widget.observer_bg_process.bg_go()
+        tm = TransitionMessage.objects.get(instance_id=str(self.widget.pk),
+                                           transition_name='bg_go')
+        for _ in range(2):  # drive the remaining attempts as the worker would
+            try:
+                run_background_transition(tm.pk)
+            except ValueError:
+                pass
+        self.widget.refresh_from_db()
+        self.assertEqual(self.widget.status, 'failed')
+        # Three attempts, one initiation, one record.
+        self.assertEqual(self.seen, [('ObserverBgProcess', 'bg_go')])
+
+    def test_next_transition_follow_up_notifies_with_its_own_initiation(self):
+        self.widget.observer_bg_process.kick()
+        self.widget.refresh_from_db()
+        self.assertEqual(self.widget.status, 'done')
+        self.assertEqual(self.seen, [('ObserverBgProcess', 'kick'),
+                                     ('ObserverBgProcess', 'bg_finish')])


### PR DESCRIPTION
Closes #132.

## What

1. **Core: transition-initiation observers.** `django_logic.process.transition_observers` — a public list of callables invoked as `observer(owning_process_cls, action_name, instance)` after `_get_transition_method` resolves a transition, before it executes. Covers every initiation path: direct calls, `next_transition` follow-ups (they re-enter through the Process entrypoint), background phase 1. Phase-2 restore/retries do **not** re-notify — phase 1 already recorded the initiation. Zero overhead when the list is empty; a raising observer is logged and never breaks a transition.

2. **`django_logic/coverage.py`** (top-level module, no test-framework imports — safe to import from `AppConfig.ready`):
   - `iter_bound_transitions()` — walks `ProcessManager.bindings` (#125) including nested processes, yielding every declared transition with its owning class.
   - `TransitionCoverage` — in-memory context-manager recorder for single-process runs.
   - File-backed recording via `DJANGO_LOGIC['TRANSITION_COVERAGE_LOG'] = <path>`, activated in the existing `BackgroundConfig.ready()` beside the checks import — spawn-based parallel workers self-activate, fork-based workers inherit the parent's recorder; workers append unique pairs, duplicates across workers are merged at report time.
   - `coverage_report(executed=None, log_path=None)` — totals + sorted `uncovered` entries (`process`, `action`, `background`, `models`), ready for a CI gate that fails when a previously-driven transition goes silent.

## Why

Consumers auditing FSM coverage statically hit two blind spots (both found during the gv #8577 migration audit): transitive execution (test → view/task → `process.action()`) counts as uncovered, and dynamic dispatch (`getattr(process, name)()`) can't be attributed at all. Prototyping this exact hook against the gv suite showed ~150 of 167 statically-"uncovered" pairs actually execute at runtime — and produced the exact short list that doesn't.

## Tests

7 new tests in `tests/test_coverage.py`: observer payload + **nested owner attribution** (the declaring process class, not the bound root), raising-observer isolation, nested walk of declared transitions, executed/uncovered split, file-backed dedup + merge, idempotent activation. Full suite: **373 OK** (was 366).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observers run on every initiation when registered but are isolated from transition success; file recording is opt-in via settings.
> 
> **Overview**
> Adds **runtime transition-execution coverage** so test suites can see which declared FSM transitions were actually initiated, including transitive and dynamic drives that static analysis misses.
> 
> The engine now exposes **`transition_observers`** and fires **`(owning_process_cls, action_name, instance)`** after a transition resolves in **`_get_transition_method`** (direct calls, **`next_transition`**, background phase 1 only). Raising observers are logged and do not block the transition; there is no work when the list is empty.
> 
> **`django_logic.coverage`** compares recorded **`(process, action)`** pairs to all transitions from **`ProcessManager.bindings`** (nested processes included): **`TransitionCoverage`** for in-memory runs, optional **`DJANGO_LOGIC['TRANSITION_COVERAGE_LOG']`** with **`coverage_report()`** for parallel tests, activated idempotently from **`AppConfig.ready()`** on both **`django_logic`** and **`django_logic.background`**.
> 
> Docs and changelog describe CI usage and the append-only log footgun.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9b019c7f3ae870a0ba20a782f479d61746c21c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

