### PR TITLE
consumer-gv workflow polish (#119 items 2-4)

### DIFF
--- a/.github/workflows/consumer-gv.yml
+++ b/.github/workflows/consumer-gv.yml
@@ -17,6 +17,7 @@ on:
     paths:
       - 'django_logic/**'
       - 'pyproject.toml'
+      - '.github/workflows/consumer-gv.yml'
 
 jobs:
   gv-contract:
@@ -71,6 +72,10 @@ jobs:
           token: ${{ secrets.GV_REPO_TOKEN }}
           ref: staging
           path: gv
+          # Don't leave the token on disk while gv-controlled code
+          # (its test suite) executes; nothing after checkout needs git
+          # credentials.
+          persist-credentials: false
 
       - uses: astral-sh/setup-uv@v5
         if: steps.token.outputs.have == 'true'

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -33,10 +33,17 @@ Everything runs through [`uv`](https://github.com/astral-sh/uv) (build) and
 5. **Check the consumer contract job is green**: the `Consumer contract (gv)`
    workflow (nightly + `workflow_dispatch`) runs gv's FSM test subset against
    django-logic@master. Trigger it manually for the release candidate and do
-   not publish while it is red:
+   not publish while it is red. (`gh run watch` with no argument prompts
+   interactively and may pick the wrong run — resolve the id of the run you
+   just dispatched first.)
    ```bash
-   gh workflow run consumer-gv.yml && gh run watch
+   gh workflow run consumer-gv.yml
+   sleep 5   # give the dispatch a moment to register
+   gh run watch "$(gh run list --workflow=consumer-gv.yml --limit 1 --json databaseId -q '.[0].databaseId')" --exit-status
    ```
+   NB: while the `GV_REPO_TOKEN` secret is not configured the job **skips
+   with a warning and comes up green without testing anything** — a green
+   run only means something once the secret exists (issue #119).
 6. **Build + validate the artifacts**:
    ```bash
    make dist          # rm -rf dist/ build/ *.egg-info && uv build && twine check dist/*


### PR DESCRIPTION
The three actionable items from #119: trigger PR runs on workflow-file edits, `persist-credentials: false` on the gv checkout, and a reliable release-gate watch command in RELEASING.md (plus an explicit note that the gate is vacuous until `GV_REPO_TOKEN` exists). Leaves #119 open for item 1 (the secret), which needs a repo admin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI configuration and release documentation; no runtime or library behavior is modified.
> 
> **Overview**
> Polishes the **Consumer contract (gv)** GitHub Actions workflow and release checklist from issue #119 (items 2–4).
> 
> **Workflow:** PR runs now also trigger when `.github/workflows/consumer-gv.yml` changes (alongside `django_logic/**` and `pyproject.toml`). The private **gv** checkout sets `persist-credentials: false` so the `GV_REPO_TOKEN` is not left on disk while gv’s test suite runs.
> 
> **RELEASING.md:** Step 5 documents a deterministic manual gate: dispatch `consumer-gv.yml`, wait briefly, then `gh run watch` the latest run by database id (avoids interactive `gh run watch` picking the wrong run). It also warns that without `GV_REPO_TOKEN` the job skips with a warning and a green run does not prove the consumer contract passed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d3daad95423c7bf25137a54c532f8877a34a7c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->