### PR TITLE
release: django-logic 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+## [0.8.0] — 2026-07-20
+
+Transition-execution coverage (#132): initiation observers on the resolver
+plus a coverage report that answers "which transitions did the test suite
+never drive?" exactly. A new top-level `django_logic` AppConfig activates
+system checks and coverage recording for sync-only installs (closing the
+W001 registration gap noted on #126), and the consumer-contract workflow
+got the #119 polish (PR-runs on workflow edits, no persisted token,
+reliable release-gate watch).
+
 ### Added
 
 - **Transition-execution coverage** (#132). The resolver now notifies
@@ -17,7 +27,22 @@
   fork/spawn-safe parallel test runs), and `coverage_report()`. Static
   test-tree analysis cannot see transitive or dynamically-dispatched
   drives; the engine can — this answers "which transitions did the suite
-  never drive?" exactly.
+  never drive?" exactly. The log is append-only (fresh path per run);
+  `coverage_report` treats a never-written log as all-uncovered.
+- **Top-level `django_logic` AppConfig.** System checks (`django_logic.W001`)
+  and coverage-log activation now bootstrap for sync-only consumers that
+  install just `'django_logic'` — previously both required the optional
+  `django_logic.background` app (gap noted on #126). Idempotent with the
+  background app's own `ready()`.
+
+### Changed
+
+- **consumer-gv workflow polish** (#119, items 2–4): PR runs trigger on
+  edits to the workflow file itself, the gv checkout no longer persists
+  `GV_REPO_TOKEN` on disk while gv-controlled code executes, and
+  RELEASING.md's release gate resolves the dispatched run id instead of
+  the unreliable bare `gh run watch` (and documents that the gate is
+  vacuous until the secret is configured).
 
 ## [0.7.0] — 2026-07-17
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-logic"
-version = "0.7.0"
+version = "0.8.0"
 description = "Declarative business logic & state machines for Django — sync and durable background transitions"
 readme = "README.md"
 license = { text = "MIT License" }


### PR DESCRIPTION
Release prep for 0.8.0: transition-execution coverage (#132, PR #133 with review fixes), top-level AppConfig bootstrap, consumer-gv polish (#119 items 2-4, PR #134). Version bump + CHANGELOG section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version and changelog update; no runtime code changes in this diff.
> 
> **Overview**
> **Release prep for 0.8.0** — bumps `pyproject.toml` from `0.7.0` to `0.8.0` and adds a dated `[0.8.0]` section to `CHANGELOG.md` (the `[Unreleased]` block is left empty).
> 
> The changelog entry summarizes work already merged for this release: **transition-execution coverage** (#132) with resolver initiation observers and `django_logic.coverage` / `coverage_report()`; a **top-level `django_logic` AppConfig** so sync-only installs get `django_logic.W001` and coverage-log bootstrap without `django_logic.background` (#126 gap); and **consumer-gv workflow** polish (#119) for PR workflow triggers, token handling, and release-gate `gh run` resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd9ede9b7b8c4f1f9f835124ef9e0bd3daa43b15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->