### PR TITLE
release: django-logic 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 ## [0.9.0] — 2026-07-23
 
+Stranded-state recovery (#136): `recover_stranded_states`, the fifth
+safety-net task, actively recovers instances that a hard-killed
+*synchronous* transition left parked in an `in_progress_state`, driving
+each through the owning transition's normal failure path. Per-transition
+`lock_timeout` lets legitimately long side-effects declare their own lock
+budget. Plus the #138–#150 hardening batch: lock ownership tokens, opt-in
+`DEFER_UNLOCK_UNTIL_COMMIT`, per-hook savepoints, fail-closed restore of
+unimportable process classes, binding validation, the `E001`/`E002` system
+checks, and boot-time validation of every safety setting.
+
 ### Changed (breaking)
 
 - **Transition observers receive the resolved declaration** (#146).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.0] — 2026-07-23
+
 ### Changed (breaking)
 
 - **Transition observers receive the resolved declaration** (#146).

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Extras:
 ## Installation
 
 ```bash
-# Installs the current release from PyPI (0.8.0 at the time of writing).
+# Installs the current release from PyPI (0.9.0 at the time of writing).
 # Celery and django-redis are installed automatically.
 pip install django-logic
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-logic"
-version = "0.8.0"
+version = "0.9.0"
 description = "Declarative business logic & state machines for Django — sync and durable background transitions"
 readme = "README.md"
 license = { text = "MIT License" }


### PR DESCRIPTION
Release prep for 0.9.0: stranded-state recovery (#136), per-transition `lock_timeout`, and the #138–#150 hardening batch (PR #137). Version bump + dated CHANGELOG section; the `[Unreleased]` block is left empty.

Breaking changes on the 0.x line (hence the minor bump): four-argument transition-observer signature (#146), `RedisState` storage format (lock ownership tokens, #139), and startup-failing binding validation (#143).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only release prep (version and docs); no library code changes in this PR.
> 
> **Overview**
> **Release packaging for 0.9.0** — bumps `version` in `pyproject.toml`, updates the README PyPI install comment to **0.9.0**, and adds a dated **`[0.9.0] — 2026-07-23`** section to `CHANGELOG.md` (with `[Unreleased]` left empty).
> 
> The new changelog section documents what ships on this line (implemented in prior PRs): **`recover_stranded_states`**, per-transition **`lock_timeout`**, and hardening from **#138–#150** (lock ownership tokens, opt-in **`DEFER_UNLOCK_UNTIL_COMMIT`**, per-hook savepoints, fail-closed unrestorable process classes, binding validation, **`E001`/`E002`**, boot-time safety-setting validation), plus breaking notes (four-arg transition observers **#146**, **`RedisState`** format **#139**, binding validation **#143**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c01116caadf13f112cf715cfb8a3e4cef8bb25a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->