### PR TITLE
Atomic RedisState lock refresh via compare-and-set (#151)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **`RedisState` lock refresh is atomic on django-redis** (#151). The
+  value+lock key's refresh in `set_state` is now a single server-side
+  compare-and-set (Lua): the new state is written only if the key still
+  holds exactly the bytes the ownership decision was based on, so a
+  takeover landing strictly between the read and the write can no longer
+  re-plant a stale holder's token over a successor's lock — closing the
+  residual window #139 documented. Off django-redis (the single-process
+  test fake / LocMemCache) the plain read-write is unchanged; it cannot
+  race there.
+
 ## [0.9.0] — 2026-07-23
 
 Stranded-state recovery (#136): `recover_stranded_states`, the fifth

--- a/django_logic/state.py
+++ b/django_logic/state.py
@@ -158,6 +158,36 @@ class RedisState(State):
     _STATE_KEY = '__dl_state__'
     _TOKEN_KEY = '__dl_token__'
 
+    # Atomic refresh (#151): rewrite the live key's value with a new TTL
+    # only if it still holds exactly the bytes ``set_state`` based its
+    # ownership decision on. A takeover (value changed) or TTL expiry
+    # (value gone) since the read makes the GET mismatch, so the write is
+    # skipped — a stale holder can never re-plant its token over a
+    # successor's lock, and an unlocked writer can never recreate an
+    # expired key (xx semantics). Runs server-side on django-redis.
+    _REFRESH_CAS = (
+        "if redis.call('GET', KEYS[1]) == ARGV[1] then "
+        "redis.call('SET', KEYS[1], ARGV[2], 'PX', ARGV[3]) return 1 "
+        "end return 0"
+    )
+
+    @staticmethod
+    def _redis_conn():
+        """The raw django-redis connection used for the atomic refresh, or
+        ``None`` when the backend is not django-redis — the single-process
+        test fake / LocMemCache, where the read-compare-write below cannot
+        race and needs no server-side CAS."""
+        if getattr(cache, 'client', None) is None:
+            return None
+        try:
+            from django_redis import get_redis_connection
+        except ImportError:
+            return None
+        try:
+            return get_redis_connection('default')
+        except Exception:
+            return None
+
     @property
     def lock_timeout(self):
         # Prefer the TTL this instance locked with (per-transition
@@ -213,28 +243,59 @@ class RedisState(State):
         return cache.get(self._get_hash()) is not None
 
     def set_state(self, state):
-        # xx=True: refresh the key's value/TTL only when it exists (i.e. the
-        # state is locked). A state write outside a lock()/unlock() pair —
-        # background phase 2's target/failed writes, Action.failed_state —
-        # must not implicitly create a lock nobody will release. (Background
-        # phase 1's in_progress write happens UNDER its critical-section
-        # lock, so there the xx write refreshes the live key's value.)
-        #
-        # Preserve the ownership token already stored on the key: a state
-        # write must not clobber the holder's token. Token-gated for
-        # holders: if this object holds a token but the key now carries a
-        # DIFFERENT one, our lock TTL-expired and a successor owns the
-        # key — skip the cache refresh entirely, or we would re-plant our
-        # own token over theirs and our later unlock would delete their
-        # lock (the dual-entry hazard #139 closes). The DB write below
-        # still happens; the phase-2 state guard / under-lock revalidation
+        # Refresh the key's value/TTL only when it exists (xx semantics): a
+        # state write outside a lock()/unlock() pair — background phase 2's
+        # target/failed writes, Action.failed_state — must not implicitly
+        # create a lock nobody will release. (Background phase 1's
+        # in_progress write happens UNDER its critical-section lock, so
+        # there it refreshes the live key.) The stored ownership token is
+        # preserved: a state write must not clobber the holder's token, and
+        # a stale holder whose key now carries a successor's token must not
+        # re-plant its own (the dual-entry hazard #139 closes). The DB write
+        # always lands; the phase-2 state guard / under-lock revalidation
         # arbitrate the outcome.
         #
-        # The get→compare→set is still not multi-process atomic: a
-        # takeover strictly between the read and the write can leave a
-        # stale token behind. For tokenless writers that degrades to a
-        # TTL-bounded leak; for a holder it remains a narrow wrong-unlock
-        # window — fully closing it needs an atomic refresh (issue #151).
+        # On django-redis the read → decide → write is a single server-side
+        # compare-and-set (#151): the write applies only if the key still
+        # holds exactly the bytes the token decision was based on, so a
+        # takeover landing strictly between read and write can no longer
+        # misplace a token. Off django-redis (the single-process test fake /
+        # LocMemCache) there is no concurrency, so the plain read-write is
+        # already race-free.
+        conn = self._redis_conn()
+        if conn is None:
+            self._set_state_fallback(state)
+            return
+
+        full_key = cache.client.make_key(self._get_hash())
+        current_raw = conn.get(full_key)
+        if current_raw is None:
+            # No live key: an unlocked write must not recreate the lock.
+            super().set_state(state)
+            return
+
+        current_token = self._stored_token(cache.client.decode(current_raw))
+        own_token = getattr(self, '_lock_token', None)
+        if (
+            own_token is not None
+            and current_token is not None
+            and current_token != own_token
+        ):
+            # A successor already owns the key; leave it untouched.
+            super().set_state(state)
+            return
+
+        new_raw = cache.client.encode(self._store_value(state, current_token))
+        conn.eval(
+            self._REFRESH_CAS, 1, full_key,
+            current_raw, new_raw, int(self.lock_timeout * 1000),
+        )
+        super().set_state(state)
+
+    def _set_state_fallback(self, state):
+        """Non-atomic token-gated refresh for a single-process cache (the
+        test fake / LocMemCache). Correct there because nothing can take
+        the lock over between the read and the write."""
         current_token = self._stored_token(cache.get(self._get_hash()))
         own_token = getattr(self, '_lock_token', None)
         if (

--- a/tests/stability/test_atomic_refresh.py
+++ b/tests/stability/test_atomic_refresh.py
@@ -1,0 +1,96 @@
+"""Atomic RedisState lock refresh under TTL overrun (#151).
+
+`RedisState.set_state` refreshes the single value+lock key. The token
+gate (#139) already skips the refresh when the key *already* carries a
+successor's token at read time. The residual #151 window is a takeover
+landing **strictly between** the read and the write: a stale holder that
+still saw its own token when it read could, with a plain read-write,
+re-plant that token over the successor's lock — and its later `unlock()`
+would then compare-and-delete the successor's live lock.
+
+On django-redis the refresh is a single server-side compare-and-set: the
+write applies only if the key still holds exactly the bytes the token
+decision was based on. This test drives a takeover into that exact window
+and asserts the successor's lock is left intact. It needs a real Redis
+(the CAS runs a Lua `EVAL`); LocMemCache / the single-process fake cannot
+exhibit the race and take the non-atomic fallback.
+"""
+from unittest.mock import patch
+
+from django.core.cache import cache
+from django.test import tag
+
+from django_logic.state import RedisState
+
+from tests.models import Invoice
+from tests.stability.base import StabilityTestCase, requires_real_redis
+
+
+class _TakeoverBetweenReadAndWrite:
+    """Wraps the real connection so the first ``get`` — set_state's read —
+    fires a one-shot takeover before returning the pre-takeover bytes,
+    reproducing a successor acquiring the lock in the read→write window."""
+
+    def __init__(self, real, takeover):
+        self._real = real
+        self._takeover = takeover
+        self._fired = False
+
+    def get(self, key):
+        raw = self._real.get(key)
+        if not self._fired:
+            self._fired = True
+            self._takeover()
+        return raw
+
+    def eval(self, *args, **kwargs):
+        return self._real.eval(*args, **kwargs)
+
+
+@tag('stability')
+@requires_real_redis
+class RedisStateAtomicRefreshTests(StabilityTestCase):
+    def setUp(self):
+        super().setUp()
+        cache.clear()
+        self.invoice = Invoice.objects.create(status='draft')
+
+    def _state(self):
+        return RedisState(Invoice.objects.get(pk=self.invoice.pk), 'status')
+
+    def test_takeover_between_read_and_write_cannot_replant_token(self):
+        from django_redis import get_redis_connection
+
+        t1 = self._state()
+        self.assertTrue(t1.lock())
+
+        t2 = self._state()
+
+        def takeover():
+            # T1's TTL expires and T2 acquires the lock with a fresh token,
+            # all after T1's set_state has read the old value.
+            cache.delete(t1._get_hash())
+            self.assertTrue(t2.lock())
+
+        wrapper = _TakeoverBetweenReadAndWrite(
+            get_redis_connection('default'), takeover)
+
+        with patch.object(RedisState, '_redis_conn', staticmethod(lambda: wrapper)):
+            t1.set_state('late_write')
+
+        # The CAS saw the key change under it and skipped the write, so
+        # T2's token — not T1's — still owns the key.
+        stored = cache.get(t2._get_hash())
+        self.assertEqual(t2._stored_token(stored), t2._lock_token)
+        self.assertNotEqual(t2._stored_token(stored), t1._lock_token)
+
+        # The DB write still landed (the state guard arbitrates the value).
+        self.assertEqual(
+            Invoice.objects.get(pk=self.invoice.pk).status, 'late_write')
+
+        # T1's late unlock therefore cannot release T2's lock.
+        t1.unlock()
+        self.assertTrue(t2.is_locked())
+
+        t2.unlock()
+        self.assertFalse(t2.is_locked())


### PR DESCRIPTION
Closes the residual window in #151 (follow-up to #139 lock ownership tokens).

## Problem

`RedisState.set_state` refreshes the single value+lock key with a non-atomic **get → decide → write**. The #139 token gate already skips the refresh when the key *already* carries a successor's token at read time, but a takeover landing **strictly between** the read and the write survives: a stale holder that still saw its own token when it read would re-plant that token over the successor's lock, and its later `unlock()` would then compare-and-delete the successor's live lock.

## Fix

On django-redis the refresh is now a single **server-side compare-and-set** (Lua `EVAL` via the raw `get_redis_connection` client): the new state is written only if the key still holds exactly the bytes the ownership decision was based on. A takeover (value changed) or TTL expiry (value gone) since the read makes the `GET` mismatch, so the write is a no-op — a stale holder can never re-plant its token, and an unlocked writer can never recreate an expired key (xx semantics preserved).

Off django-redis (the single-process test fake / `LocMemCache`) `set_state` takes an unchanged read-write fallback — there is no concurrency there to race, so no server-side CAS is needed. All existing single-process behavior (holder-preserve, non-holder-preserve, post-takeover skip, legacy raw values, None sentinel) is untouched.

## Tests

- `tests/stability/test_atomic_refresh.py` (real Redis, `@requires_real_redis`) drives a takeover into the exact read→write window and asserts the successor's token survives and the stale holder's late `unlock()` cannot release it. **This fails on the old non-atomic code and passes on the CAS.** It runs in the stability CI job (real `redis:7-alpine`); it skips under LocMemCache.
- Full engine suite green (534 OK) on the single-process fallback.

## Notes

- Scope is the `set_state` refresh (#151's stated residual). `unlock()`'s own get-compare-delete remains the base-class behavior; fixing the refresh removes the only mechanism that re-planted a stale token, which was the wrong-unlock hazard.
- Bugfix-only, no API/behavior change off django-redis → targets the 0.9.1 patch line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches distributed lock correctness on the hot `set_state` path for production django-redis deployments; scope is narrow and off-django-redis behavior is preserved.
> 
> **Overview**
> **`RedisState.set_state`** on django-redis no longer uses a non-atomic get → compare → write for cache refresh. It runs a **server-side Lua compare-and-set**: the value+lock key is updated only if Redis still holds the exact bytes used for the ownership decision, so a successor takeover in the read→write gap cannot be overwritten by a stale holder’s token.
> 
> Non–django-redis backends keep the prior token-gated **`xx`** refresh via **`_set_state_fallback`** (LocMem / test fakes). **`_redis_conn()`** resolves the raw connection for the CAS path.
> 
> Adds **`tests/stability/test_atomic_refresh.py`** (real Redis) to force a takeover between read and write and assert the successor’s lock survives and a late **`unlock()`** from the stale holder does not drop it. **CHANGELOG** documents the fix for #151.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd38dff6e185ba574ec6f8da60b17df58bb009f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->