### PR TITLE
release: django-logic 0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.1] — 2026-07-24
+
 ### Fixed
 
 - **`RedisState` lock refresh is atomic on django-redis** (#151). The
@@ -12,7 +14,11 @@
   re-plant a stale holder's token over a successor's lock — closing the
   residual window #139 documented. Off django-redis (the single-process
   test fake / LocMemCache) the plain read-write is unchanged; it cannot
-  race there.
+  race there. The CAS runs on the raw django-redis connection, so a Redis
+  connection error during the refresh now surfaces to the caller
+  regardless of django-redis `IGNORE_EXCEPTIONS` (0.9.0 swallowed it on
+  the cache-wrapped path and still committed the DB write) — the lock
+  backend fails loud on an outage instead of proceeding without exclusion.
 
 - **Savepoint unlock cleanup is exception-contained.** When a hook
   savepoint rollback releases the deferred unlocks it discarded (#141 ×

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-logic"
-version = "0.9.0"
+version = "0.9.1"
 description = "Declarative business logic & state machines for Django — sync and durable background transitions"
 readme = "README.md"
 license = { text = "MIT License" }


### PR DESCRIPTION
Patch release consolidating the two bugfix PRs merged after 0.9.0 (#155, #153).

## Contents

- **#155 (#151)** — `RedisState.set_state` lock refresh is now a single server-side compare-and-set (Lua `EVAL`) on django-redis, closing the read→write token-misplacement window #139 documented. Off django-redis the plain read-write is unchanged.
- **#153** — three post-#137 hardening fixes:
  - savepoint deferred-unlock cleanup is exception-contained (a cache blip on one release no longer skips siblings or masks the hook's original exception);
  - coverage keys carry a conditions fingerprint so per-courier condition-only namesakes stop collapsing — with backward-compat so persisted 0.9.0-format coverage logs don't read as all-uncovered after upgrade;
  - the missing-`failed_state` warn-once key includes `in_progress_state` so distinct parked backlogs each warn.

## Release mechanics

- `pyproject.toml` version `0.9.0` → `0.9.1`.
- CHANGELOG `[Unreleased]` Fixed entries consolidated into a dated `[0.9.1] — 2026-07-24` section.
- Notes disclose the one behavior nuance surfaced in review: the CAS runs on the raw django-redis connection, so a Redis error during `set_state` now surfaces regardless of `IGNORE_EXCEPTIONS` (0.9.0 swallowed it and still committed the DB write) — fail-loud on a lock-backend outage.

## Validation

- Full engine suite: 540 tests OK (sqlite; +2 coverage regressions added on #153 for the backward-compat shim, verified to fail without it).
- `tests.test_metadata` drift check: green.
- django-logic-test Heroku rig (real Redis/PG/CloudAMQP) validated against this candidate — evidence to follow on this PR before publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-metadata-only PR (version + CHANGELOG); runtime changes ship via prior merged PRs, with a documented fail-loud Redis error behavior on upgrade.
> 
> **Overview**
> **Release 0.9.1** — bumps `pyproject.toml` from `0.9.0` to `0.9.1` and moves the unreleased **Fixed** notes into a dated `[0.9.1] — 2026-07-24` section (no application code in this diff).
> 
> The changelog documents bugfixes already merged after 0.9.0: **atomic `RedisState.set_state` lock refresh** via server-side CAS on django-redis (#151), **exception-contained savepoint deferred-unlock cleanup**, **coverage keys that include a conditions fingerprint** (with backward-compat for 0.9.0 log lines), and **warn-once keys for missing `failed_state` that include `in_progress_state`**.
> 
> It also calls out a **behavior nuance**: CAS uses the raw django-redis connection, so Redis errors during refresh **propagate even when `IGNORE_EXCEPTIONS` is set** — 0.9.0 could swallow them and still commit the DB write; 0.9.1 fails loud on lock-backend outages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9786c89afa1925c4fcf78fc17ba40b627feda53c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->