### PR TITLE
deps: drop django-redis from core, give the [redis] extra meaning again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 ## [Unreleased]
 
+### Changed (breaking)
+
+- **`django-redis` is no longer a core dependency** — it moves to the
+  `[redis]` extra, which stops being an empty alias (#173). The engine has
+  never imported `django_redis`: the state lock goes through Django's cache
+  API (`State.lock` → `cache.add`), so what it actually requires is a
+  *cross-process cache backend*, not a particular package. Django has shipped
+  `django.core.cache.backends.redis.RedisCache` since 4.0 and our floor is
+  4.2, so the documented setup no longer needs a third-party package.
+
+  Verified: with `django-redis` uninstalled and the built-in backend
+  configured, two separate OS processes contend correctly on the same lock —
+  the second `lock()` returns `False`, `is_locked()` is `True`, and the key
+  is released on `unlock()`. The locmem control shows both processes
+  acquiring, which is the failure the boot guard exists to prevent.
+
+  **Migration:** if your settings name `django_redis.cache.RedisCache`,
+  install it explicitly — `pip install django-logic[redis]`, or add
+  `django-redis` to your own dependencies. Both known consumers already
+  declare it directly and are unaffected. Note the failure mode if you miss
+  this is *not* at boot: `django.setup()` succeeds and
+  `InvalidCacheBackendError` is raised at the first cache access, because
+  the celery-mode guard only string-matches the backend path against
+  locmem/dummy and never instantiates the cache.
+
+  Not affected: the boot guard itself, which is backend-agnostic and still
+  refuses locmem/dummy in celery mode when `DEBUG=False`.
+
 ## [0.10.0] — 2026-07-27
 
 An overengineering sweep. ~1,900 lines removed across the engine, its tests and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,11 +69,14 @@ change on success) for anything slow, external, or retriable.
 
 ## Deployment the durability contract depends on
 
-- A real broker (Redis/RabbitMQ). Celery and django-redis are core
-  dependencies of django-logic (installed automatically);
-  `BACKGROUND_EXECUTION` defaults to `'celery'`.
-- A cross-process `default` cache (django-redis) for the state lock —
-  celery mode refuses to boot with a locmem/dummy cache when `DEBUG=False`.
+- A real broker (Redis/RabbitMQ). Celery is a core dependency of
+  django-logic (installed automatically); `BACKGROUND_EXECUTION` defaults
+  to `'celery'`.
+- A cross-process `default` cache for the state lock — celery mode refuses
+  to boot with a locmem/dummy cache when `DEBUG=False`. The engine locks
+  through Django's cache API and imports no backend, so Django's built-in
+  `django.core.cache.backends.redis.RedisCache` is enough; django-redis is
+  the `[redis]` extra, not a core dependency (0.11.0).
 - Crash re-delivery is built in (every django-logic task sets
   `acks_late=True` + `reject_on_worker_lost=True`); set the global Celery
   pair only for your *own* tasks. You still need a **single beat**

--- a/README.md
+++ b/README.md
@@ -35,17 +35,18 @@ Django Logic is a lightweight workflow framework for Django that makes it easy t
 - Django 4.2+ (4.2, 5.1, 5.2 and 6.0 are tested in CI; 5.0 is not supported)
 - django-model-utils >= 4.5.1
 - celery >= 5.0 — **installed automatically**; background transitions are Celery tasks
-- django-redis >= 5.0.0 — **installed automatically**; provides the cross-process state lock
+- A **cross-process `default` cache** for the state lock — *not* a package dependency. The engine locks through Django's cache API, so any cross-process backend works, including `django.core.cache.backends.redis.RedisCache`, built into Django since 4.0. Celery mode refuses to boot on a locmem/dummy cache when `DEBUG=False`.
 
 Extras:
+- `pip install django-logic[redis]` — installs `django-redis`, for deployments whose settings name `django_redis.cache.RedisCache`. It stopped being a core dependency in 0.11.0: the engine has never imported it.
 - `pip install django-logic[drf]` — pulls in `djangorestframework` (kept for projects migrating off the old DRF-coupled releases; no DRF-specific code ships since 0.4)
-- `[celery]` and `[redis]` remain as **empty aliases**, so existing `pip install django-logic[celery,redis]` pins keep resolving — both packages are core dependencies since 0.4
+- `[celery]` remains an **empty alias**, so existing `pip install django-logic[celery,redis]` pins keep resolving — celery is a core dependency since 0.4
 
 ## Installation
 
 ```bash
-# Installs the current release from PyPI.
-# Celery and django-redis are installed automatically.
+# Installs the current release from PyPI. Celery is installed automatically.
+# Add [redis] if your settings name django_redis.cache.RedisCache.
 pip install django-logic
 ```
 
@@ -535,7 +536,7 @@ Multiple processes trying to transition the same object can cause race condition
 - a **cache lock** (atomic set-if-absent on the `default` cache) held for a synchronous transition's whole flight and for a background transition's phase-1 critical section, with the persisted state re-validated under the lock; and
 - the **`TransitionMessage` row** — while a background transition is in flight, a second one raises `AlreadyInProgress` and a synchronous transition on the same instance + process raises `TransitionNotAllowed`.
 
-Use a cross-process cache (django-redis, installed automatically) so the lock is shared between web processes and workers.
+Use a cross-process cache so the lock is shared between web processes and workers.
 
 #### 4. Side Effects Not Rolling Back
 Side effects that modify external systems may not roll back automatically.
@@ -681,7 +682,9 @@ At boot, celery mode fails fast on two misconfigurations that would silently bre
 ```python
 CACHES = {
     'default': {
-        'BACKEND': 'django_redis.cache.RedisCache',
+        # Built into Django since 4.0; needs the `redis` client package.
+        # `django_redis.cache.RedisCache` also works — `pip install django-logic[redis]`.
+        'BACKEND': 'django.core.cache.backends.redis.RedisCache',
         'LOCATION': os.environ['REDIS_URL'],
     }
 }

--- a/django_logic/background/settings.py
+++ b/django_logic/background/settings.py
@@ -267,8 +267,9 @@ def _check_lock_cache_in_celery_mode() -> None:
         f"DJANGO_LOGIC['BACKGROUND_EXECUTION']='celery' but the 'default' "
         f"cache backend is {backend!r}, which is per-process. The state "
         f"lock will not be shared between web processes and Celery "
-        f"workers. Use a cross-process cache (django-redis is installed "
-        f"as a django-logic dependency) for the 'default' cache."
+        f"workers. Use a cross-process cache for the 'default' cache — "
+        f"e.g. 'django.core.cache.backends.redis.RedisCache', or "
+        f"django-redis via `pip install django-logic[redis]`."
     )
     if getattr(settings, 'DEBUG', False):
         from django_logic.logger import logger

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,23 +39,24 @@ dependencies = [
     # No upper bound by design: the django-main CI job is the early warning.
     "django>=4.2,!=5.0.*",
     "django-model-utils>=4.5.1",
-    # Celery and Redis are core dependencies, not extras. Background
-    # transitions always execute through Celery in production ('sync'
-    # execution exists only for tests/CI). The engine never imports
-    # django_redis — it locks through Django's cache API — but it does
-    # require a CROSS-PROCESS cache, and django-redis is the backend the
-    # README documents, so it ships installed rather than as a footgun.
-    # Whether to demote it now that Django 4.0+ has its own Redis backend
-    # is a separate call: see issue #173.
+    # Celery is a core dependency, not an extra: background transitions
+    # always execute through Celery in production ('sync' execution exists
+    # only for tests/CI), and background/tasks.py imports shared_task at
+    # module level.
     "celery>=5.0",
-    "django-redis>=5.0.0",
 ]
 
 [project.optional-dependencies]
-# Kept as empty aliases so existing `pip install django-logic[celery,redis]`
-# pins keep resolving; both packages are core dependencies as of 0.4.0.
+# Celery is still a core dependency, so [celery] stays an empty alias purely
+# so existing `pip install django-logic[celery,redis]` pins keep resolving.
 celery = []
-redis = []
+# [redis] has meaning again as of 0.11.0. The engine never imports
+# django_redis — the state lock goes through Django's cache API
+# (`State.lock` → `cache.add`) — so any cross-process backend works,
+# including the `django.core.cache.backends.redis.RedisCache` Django has
+# shipped since 4.0. This extra installs the third-party backend for
+# deployments whose settings name `django_redis.cache.RedisCache`.
+redis = ["django-redis>=5.0.0"]
 drf = [
     "djangorestframework>=3.14.0",
 ]
@@ -65,6 +66,9 @@ dev = [
     # Postgres concurrency tests. Without it, `uv sync --extra dev` runs the
     # SQLite suite but not tests.stability.
     "psycopg[binary]>=3.1",
+    # Client for Django's built-in Redis cache backend, which the
+    # real-Redis and stability test settings use for the state lock.
+    "redis>=4.2",
 ]
 
 [project.urls]

--- a/tests/settings_redis.py
+++ b/tests/settings_redis.py
@@ -11,11 +11,8 @@ from tests.settings import *  # noqa: F401, F403
 
 CACHES = {
     'default': {
-        'BACKEND': 'django_redis.cache.RedisCache',
+        'BACKEND': 'django.core.cache.backends.redis.RedisCache',
         'LOCATION': os.environ.get('REDIS_URL', 'redis://localhost:6379/1'),
-        'OPTIONS': {
-            'CLIENT_CLASS': 'django_redis.client.DefaultClient',
-        },
     }
 }
 

--- a/tests/settings_stability.py
+++ b/tests/settings_stability.py
@@ -30,11 +30,8 @@ DATABASES = {
 
 CACHES = {
     'default': {
-        'BACKEND': 'django_redis.cache.RedisCache',
+        'BACKEND': 'django.core.cache.backends.redis.RedisCache',
         'LOCATION': os.environ.get('REDIS_URL', 'redis://localhost:6379/1'),
-        'OPTIONS': {
-            'CLIENT_CLASS': 'django_redis.client.DefaultClient',
-        },
     }
 }
 


### PR DESCRIPTION
Closes #173.

Audited every declared dependency for whether the engine actually needs it. One core dependency doesn't survive the audit; the rest do, and I've recorded why so this isn't re-litigated.

## `django-redis` — removed from core, `[redis]` extra given meaning again

**The engine has never imported `django_redis`.** The state lock goes through Django's cache API — `cache.add()` to acquire, `cache.get()`/`cache.delete()` for the compare-and-delete release ([state.py:58-100](../blob/master/django_logic/state.py#L58-L100)). So what it requires is a **cross-process cache backend**, not a particular package. Django has shipped `django.core.cache.backends.redis.RedisCache` since 4.0, comfortably under our `>=4.2` floor.

### Locking is proven intact, not argued

Clean venv, `django-redis` uninstalled, Django's built-in backend, two separate OS processes on one key:

```
### Django built-in RedisCache (django-redis NOT installed)
proc1 acquire : ACQUIRED
proc2 acquire : BLOCKED
proc3 islocked: LOCKED
proc4 unlock  : RELEASED
proc5 acquire : ACQUIRED

### LocMemCache control (expected: no cross-process locking)
proc1 acquire : ACQUIRED
proc2 acquire : ACQUIRED
```

The locmem control is the point: it shows both processes acquiring, which is exactly the failure `_check_lock_cache_in_celery_mode()` exists to prevent. **That guard is unchanged and always was backend-agnostic** — it string-matches the `BACKEND` path against locmem/dummy. It never mentioned a package except in its error text, which this PR corrects.

### Consumer impact: none

Both known consumers already declare `django-redis` themselves rather than relying on the transitive install — gv (`pyproject.toml:47`, `django-redis >= 5.4.0, < 6`) and the `django-logic-test` rig (`requirements.txt:23`). Anyone naming `django_redis.cache.RedisCache` in settings keeps working.

`[redis]` stops being an empty alias and installs `django-redis`, so that pin does what its name says again. Verified against the built wheel:

| install | `django-redis` |
|---|---|
| `django_logic-0.10.0.whl` | absent ✅ |
| `…whl[redis]` | 7.0.0 + `redis` 8.0.1 ✅ |
| `…whl[celery,redis]` (legacy pin) | resolves, installs it ✅ |

**One sharp edge worth reading before merge:** a consumer who *did* rely on the transitive dep does **not** fail at boot. `django.setup()` succeeds and `InvalidCacheBackendError` fires at the first cache access — inside a request or a worker — because the guard never instantiates the cache. That's in the CHANGELOG migration note.

## Deliberately kept — with reasons

- **`celery`** — technically demotable, but I recommend against it and did not do it. `background/tasks.py:28` imports `shared_task` at module level and `dispatch.py:134` (`retry_pending`) imports from it unconditionally. Worse, `BACKGROUND_EXECUTION` defaults to `'celery'` and W002's `ImportError` guard means `manage.py check` would report **no issues** with celery absent — so a consumer who forgot the extra boots clean and silently strands their first background transition. Trading a hard `ImportError` for that is a bad deal.
- **`django-model-utils`** — genuinely used (`TimeStampedModel`), and `background/migrations/0001_initial.py:2` imports `model_utils.fields` at module level, so uninstalling breaks `migrate` before any model is touched. Removing it means either vendoring the field classes or rewriting an applied migration. Not worth it for one small, stable dependency.
- **`[dev]`** — `psycopg[binary]` is required by `stability.yml`, `coverage` by `make coverage`. Added `redis>=4.2` here, since the test settings now use Django's built-in backend.

## One open question for you

The **`drf` extra** installs `djangorestframework` and **nothing in the repo references `rest_framework`** — zero hits across code, tests and docs. I left it alone rather than deleting it, because [README.md:42](../blob/master/README.md#L42) documents it as an intentional shim ("kept for projects migrating off the old DRF-coupled releases") and `TODO.md:9` lists "Admin + DRF integration modules" as planned work. It's opt-in, so it costs nothing by default. Say the word and it's a two-line deletion.

## Changes

- `pyproject.toml` — `django-redis` out of core; `redis = ["django-redis>=5.0.0"]`; `redis>=4.2` into `[dev]`; comments rewritten
- `tests/settings_redis.py`, `tests/settings_stability.py` — Django's built-in Redis backend, so the suites no longer need the third-party package
- `django_logic/background/settings.py:270` — the guard message no longer claims django-redis ships as a dependency
- `README.md`, `CLAUDE.md` — install/deployment docs
- `CHANGELOG.md` — `[Unreleased]`, breaking, with the migration note

Version left at 0.10.0 — this is breaking for anyone relying on the transitive install, so it wants a 0.11.0 release PR rather than a version bump smuggled in here.

## Verification

- SQLite suite **493 OK**
- real-Redis suite on the built-in backend **493 OK**
- Postgres + Redis stability **52 OK**
- metadata drift **4 OK**
- wheel builds; all three install modes verified above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking for installs that relied on transitive django-redis without declaring it; misconfigured cache backends may fail at first cache use rather than at install time.
> 
> **Overview**
> **Breaking dependency change (0.11.0):** `django-redis` is removed from core `dependencies` and moved to the optional `[redis]` extra (`pip install django-logic[redis]`). Celery stays required; only the Redis cache *client package* is no longer pulled in by default.
> 
> The library still locks only through Django’s cache API, so deployments can use **`django.core.cache.backends.redis.RedisCache`** with a `redis` client instead of `django_redis.cache.RedisCache`. Docs (`README`, `CLAUDE.md`, `CHANGELOG`) and the celery-mode locmem guard message in `django_logic/background/settings.py` are updated to say that. **Test settings** (`settings_redis.py`, `settings_stability.py`) now use the built-in Redis backend; **`redis>=4.2`** is added under the `dev` extra for those suites.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0de1131812d7ccf30f49cc6cb03ca11433a19255. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->