### PR TITLE
0.10.1 — enforce recovery-ownership instead of in_progress_state uniqueness (#175)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 ## [Unreleased]
 
+## [0.10.1] — 2026-07-28
+
+### Changed
+
+- **`in_progress_state` no longer has to be unique.** Declaring two transitions
+  in one process tree with the same `in_progress_state` used to raise
+  `ImproperlyConfigured` at class-creation time. The rule the engine actually
+  needs is narrower, and it is now the only one enforced: every transition
+  claiming an `in_progress_state` on a given (model, state_field) must **recover
+  a record-less stranded instance identically** — same `failed_state`, same
+  `failure_side_effects`, same `failure_callbacks`. Where they agree, sharing is
+  free and `recover_stranded_states` picks any claimant; where they disagree,
+  `django_logic.E001` fails `manage.py check` and the sweep skips the state, as
+  it already did across bindings (#143).
+
+  The old justification — "the in-progress state alone identifies the
+  transition that's mid-flight" — has not been true since 0.6 added
+  `owning_process_class` to `TransitionMessage` (migration 0007): phase-2 restore
+  resolves `(owning process class, action_name)` off the row, guarded by
+  `_validate_unique_background_action_names`, and never searches by state.
+  `_state_guard_matches` compares against the transition it already restored.
+
+  This unblocks the legitimate shape the raise forbade: several actions on one
+  model that all mean "busy" to a client, sharing one in-progress value and one
+  `failed_state`. Consumers previously forced to synthesize a per-action state
+  (and map it back for the API) can collapse it back to one.
+
+  `E001`'s message and hint changed accordingly; nothing else in the public API
+  moved, and a topology that was valid before is still valid.
+
 ## [0.10.0] — 2026-07-27
 
 An overengineering sweep. ~1,900 lines removed across the engine, its tests and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,8 +50,11 @@ change on success) for anything slow, external, or retriable.
    completion check** on the parent, and **aggregate errors by reading child
    rows** (give the parent an explicit `action_required` partial-failure
    state). Never re-raise a child error into the parent.
-4. **`in_progress_state` is unique within a Process**; set a `failed_state` so
-   failures are contained.
+4. **Set a `failed_state`** so failures are contained. Transitions may share an
+   `in_progress_state` (several actions that all mean "busy" to a UI), provided
+   they also share `failed_state` and their failure hooks — otherwise recovery of
+   a record-less stranded instance would guess, and `django_logic.E001` fails
+   `manage.py check`.
 5. **Test in sync mode**: `DJANGO_LOGIC['BACKGROUND_EXECUTION']='sync'` (or the
    `sync_execution()` context manager) runs phase 2 inline with no broker and
    propagates exceptions; `retry_pending()` simulates the periodic starter.

--- a/README.md
+++ b/README.md
@@ -768,7 +768,7 @@ class GmailConversationProcess(Process):
         BackgroundTransition(
             action_name='send_message_via_integration',
             sources=['open'], target='open',
-            in_progress_state='gmail_sending',     # must be unique across the tree
+            in_progress_state='gmail_sending',     # distinct here: different failure hooks
             conditions=[is_gmail],
             side_effects=[send_via_gmail],
         ),
@@ -811,8 +811,11 @@ phase 2 restores that exact transition from the recorded owner — it does not
 re-evaluate the condition, so routing is deterministic even if the instance
 changes mid-flight. Constraints: a background `action_name` must only be
 **unique within a single process class** (two in one class are
-indistinguishable at restore), and every `in_progress_state` must be unique
-across the whole tree. A background `action_name` *may* coincide with a
+indistinguishable at restore). `in_progress_state` may be shared by several
+transitions — useful when a UI only knows one "busy" value — provided they
+agree on `failed_state` and their failure hooks, since a record-less stranded
+instance in that state has no owner to recover under; `django_logic.E001`
+fails `manage.py check` when they disagree. A background `action_name` *may* coincide with a
 synchronous transition of the same name (phase 2 restores only background
 transitions; phase 1 routes the call by condition) — so a synchronous fast-path
 and a durable background slow-path can share one `action_name`.

--- a/django_logic/background/dispatch.py
+++ b/django_logic/background/dispatch.py
@@ -192,18 +192,18 @@ def recover_stranded_states() -> int:
 
     recovered = 0
     seen = set()
-    # In-progress states claimed by more than one bound machine have no
-    # provenance for a record-less stranding — recovering would guess an
-    # owner and could run the wrong failed_state/hooks. Skip them loudly;
-    # the django_logic.E001 system check flags the topology itself (#143).
+    # A record-less stranding has no provenance, so recovery picks one of
+    # the transitions claiming the state. That is only safe while they all
+    # recover identically; where they disagree, skip loudly. The
+    # django_logic.E001 system check flags the topology itself (#143).
     ambiguous = collect_ambiguous_in_progress_states()
     for key in sorted(ambiguous):
         model_label, state_field, in_progress = key
         logger.error(
             f'recover_stranded_states: in_progress_state {in_progress!r} '
-            f'on {model_label}.{state_field} is claimed by multiple bound '
-            f'machines (django_logic.E001); skipping recovery for it — '
-            f'stranded instances stay parked until the binding topology '
+            f'on {model_label}.{state_field} is shared by transitions that '
+            f'recover differently (django_logic.E001); skipping recovery '
+            f'for it — stranded instances stay parked until the topology '
             f'is fixed.'
         )
     for binding, process_cls, transition in iter_bound_transitions():

--- a/django_logic/background/transitions.py
+++ b/django_logic/background/transitions.py
@@ -54,8 +54,9 @@ class BackgroundTransition(Transition):
         - ``in_progress_state`` — if omitted, the state field does not
           change until phase 2 finishes. Providing it is strongly
           recommended so concurrent readers see "in progress" rather
-          than the pre-transition state. ``in_progress_state`` values
-          must be unique within a :class:`django_logic.Process`.
+          than the pre-transition state. Transitions may share one, as
+          long as they also share a ``failed_state`` and failure hooks —
+          see ``django_logic.E001``.
     """
 
     is_background = True

--- a/django_logic/checks.py
+++ b/django_logic/checks.py
@@ -41,12 +41,15 @@ def check_hook_signatures(app_configs, **kwargs):
 
 @checks.register('django_logic')
 def check_unambiguous_in_progress_ownership(app_configs, **kwargs):
-    """Two bound machines must not claim the same in_progress_state on
-    one (model, state_field) — a record-less stranded instance there has
-    no provenance, so automatic recovery could run the wrong transition's
-    failed_state and failure hooks (``django_logic.E001``).
-    ``recover_stranded_states`` also skips such states at runtime, but
-    the topology itself is the defect; fail loudly at check time."""
+    """Transitions sharing an in_progress_state on one
+    (model, state_field) must all recover a record-less stranded instance
+    the same way — such an instance has no provenance, so recovery picks
+    an owner, and claimants that disagree on ``failed_state`` or their
+    failure hooks make that pick wrong half the time
+    (``django_logic.E001``). Sharing is fine on its own;
+    ``recover_stranded_states`` also skips ambiguous states at runtime,
+    but the topology itself is the defect, so fail loudly at check
+    time."""
     findings = []
     for key, owners in sorted(collect_ambiguous_in_progress_states().items()):
         model_label, state_field, in_progress = key
@@ -56,12 +59,13 @@ def check_unambiguous_in_progress_ownership(app_configs, **kwargs):
         ))
         findings.append(checks.Error(
             f"in_progress_state {in_progress!r} on {model_label}."
-            f"{state_field} is claimed by more than one bound machine: "
-            f"{claimants}.",
-            hint='Give each machine a distinct in_progress_state (or bind '
-                 'the processes to distinct state fields). Stranded-state '
-                 'recovery skips ambiguous states, leaving instances '
-                 'parked until fixed manually.',
+            f"{state_field} is shared by transitions that recover "
+            f"differently: {claimants}.",
+            hint='Give them a matching failed_state and matching '
+                 'failure_side_effects/failure_callbacks, or a distinct '
+                 'in_progress_state each (or bind the processes to distinct '
+                 'state fields). Stranded-state recovery skips ambiguous '
+                 'states, leaving instances parked until fixed manually.',
             obj=f'{model_label}.{state_field}',
             id='django_logic.E001',
         ))

--- a/django_logic/process.py
+++ b/django_logic/process.py
@@ -55,9 +55,9 @@ class Process:
     ``nested_processes``, ``conditions``, ``permissions``,
     ``process_name``, and ``state_class``.
 
-    Class-time validation enforces that no two transitions on the same
-    ``Process`` share the same ``in_progress_state`` — this makes
-    phase-2 background-transition lookup unambiguous.
+    Class-time validation enforces that a background transition is
+    uniquely identifiable by ``(owning process class, action_name)``,
+    which is what phase-2 restore resolves a ``TransitionMessage`` by.
     """
 
     nested_processes = []
@@ -71,7 +71,6 @@ class Process:
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
-        _validate_unique_in_progress_states(cls)
         _validate_unique_background_action_names(cls)
 
     def __init__(self, field_name='', instance=None, state=None):
@@ -280,39 +279,6 @@ class Process:
         )
 
 
-def _validate_unique_in_progress_states(process_cls):
-    """Reject duplicate in_progress_state values across a Process AND its
-    nested processes.
-
-    Unique ``in_progress_state`` is what lets the phase-2 background
-    transition lookup work unambiguously — the in-progress state alone
-    identifies the transition that's mid-flight, without any source-state
-    search. Nested processes share the parent's state field, so the
-    uniqueness guarantee must hold across the whole tree (mirroring
-    ``_validate_unique_background_action_names``), not just the class's
-    own ``transitions``.
-    """
-    seen: dict[str, str] = {}
-    for proc_cls in _iter_process_tree(process_cls):
-        for transition in proc_cls.transitions or []:
-            in_progress = getattr(transition, 'in_progress_state', None)
-            if not in_progress:
-                continue
-            where = (
-                f'{proc_cls.__module__}.{proc_cls.__name__}.'
-                f'{transition.action_name}'
-            )
-            if in_progress in seen:
-                raise ImproperlyConfigured(
-                    f"Process {process_cls.__module__}.{process_cls.__name__} "
-                    f"(or its nested processes) has two transitions sharing "
-                    f"in_progress_state='{in_progress}': {seen[in_progress]} "
-                    f"and {where}. Every in_progress_state must be unique "
-                    f"across a Process and its nested processes."
-                )
-            seen[in_progress] = where
-
-
 def _iter_process_tree(process_cls, _seen=None):
     """Yield ``process_cls`` and every Process class reachable through
     ``nested_processes`` (depth-first), guarding against cycles.
@@ -487,20 +453,40 @@ def collect_hook_signature_offenders(process_cls) -> list:
     return offenders
 
 
-def collect_ambiguous_in_progress_states() -> dict:
-    """Cross-binding in-progress ownership map (#143).
+def _recovery_signature(transition) -> tuple:
+    """What ``recover_stranded_states`` would do with this transition.
 
-    Uniqueness of ``in_progress_state`` is enforced per process tree, but
-    two *bindings* on the same (model, state_field) may legally exist.
-    If their trees share an ``in_progress_state``, a record-less stranded
-    instance in that state has no provenance: automatic recovery could
-    run the wrong transition's ``failed_state`` and failure hooks.
+    Recovery is exactly ``fail_transition``, which reads only
+    ``failed_state`` and the two failure bundles; everything else it
+    touches is logging. Identity of the command objects, not equality —
+    two equal-but-distinct callables compare as different, which errs
+    toward calling a key ambiguous.
+    """
+    return (
+        transition.failed_state,
+        tuple(id(command) for command in transition.failure_side_effects.commands),
+        tuple(id(command) for command in transition.failure_callbacks.commands),
+    )
+
+
+def collect_ambiguous_in_progress_states() -> dict:
+    """In-progress states whose stranded-recovery owner is undecidable
+    (#143).
+
+    Several transitions may share an ``in_progress_state`` on one
+    (model, state_field) — declared side by side in a process tree, or
+    reached through two *bindings*. That is only a problem for a
+    **record-less** stranded instance: it has no provenance, so recovery
+    has to pick an owner. Picking is safe when every claimant would
+    recover identically (same ``failed_state``, same failure hooks) and
+    unsafe otherwise, which is what this reports — not the sharing
+    itself.
 
     Returns ``{(model_label, state_field, in_progress_state):
-    [(process_cls, transition), ...]}`` for every key claimed by more
-    than one binding. ``Action``\\ s never write their
-    ``in_progress_state`` and are excluded (mirrors the stranded sweep).
-    Consumed by the ``django_logic.E001`` system check and by
+    [(process_cls, transition), ...]}`` for every key whose claimants
+    disagree. ``Action``\\ s never write their ``in_progress_state`` and
+    are excluded (mirrors the stranded sweep). Consumed by the
+    ``django_logic.E001`` system check and by
     ``recover_stranded_states``, which skips ambiguous keys.
     """
     from django_logic.transition import Action
@@ -523,11 +509,8 @@ def collect_ambiguous_in_progress_states() -> dict:
                 claims.setdefault(key, []).append((process_cls, transition))
             stack.extend(process_cls.nested_processes)
     return {
-        # The same transition object reachable through two bindings is
-        # not ambiguous — recovery drives the identical failed_state and
-        # hooks either way. Only distinct declarations conflict.
         key: owners for key, owners in claims.items()
-        if len({id(transition) for _, transition in owners}) > 1
+        if len({_recovery_signature(t) for _, t in owners}) > 1
     }
 
 

--- a/docs/design/BACKGROUND_TRANSITION_ANALYSIS.md
+++ b/docs/design/BACKGROUND_TRANSITION_ANALYSIS.md
@@ -134,11 +134,12 @@ Three properties this gives you, effectively for free:
 
 Two smaller rules keep the design honest:
 
-- **`in_progress_state` is unique within a Process.** Validated at
-  class-creation time. Phase 2 can then find its transition by the
-  in-progress state alone, without the `ignore_sources=True` hack.
-  Operational bonus: a glance at `state='fulfilling'` tells you
-  exactly which transition is mid-flight.
+- **`in_progress_state` need not be unique.** Phase 2 restores its
+  transition from the owner recorded on the `TransitionMessage`, not
+  from the state, so sharing costs nothing there. The one consumer that
+  needs an owner is stranded recovery of a *record-less* instance, which
+  is why claimants must agree on `failed_state` and failure hooks
+  (`django_logic.E001`) rather than on the state name.
 - **`BackgroundAction` uses the same durable path.** No state change
   on success, but same `TransitionMessage` row, same retry, same
   concurrency guard. A background action that bypassed the DB record

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-logic"
-version = "0.10.0"
+version = "0.10.1"
 description = "Declarative business logic & state machines for Django — sync and durable background transitions"
 readme = "README.md"
 license = { text = "MIT License" }

--- a/tests/background/test_validation.py
+++ b/tests/background/test_validation.py
@@ -1,5 +1,7 @@
 """Class-time validation: queue optional but non-empty when given,
-in_progress_state unique, background action_names unique within a Process."""
+background action_names unique within a Process. Sharing an
+in_progress_state is legal — the recovery-ownership rule that replaced the
+old uniqueness raise lives in tests/test_binding_validation.py."""
 from django.core.exceptions import ImproperlyConfigured
 from django.test import SimpleTestCase, override_settings
 
@@ -50,36 +52,35 @@ class QueueValidationTests(SimpleTestCase):
         self.assertIn('cannot declare in_progress_state', str(ctx.exception))
 
 
-class UniqueInProgressStateTests(SimpleTestCase):
-    def test_duplicate_in_progress_state_rejected(self):
-        with self.assertRaises(ImproperlyConfigured) as ctx:
-            class _BadProcess(Process):
-                process_name = 'bad'
-                transitions = [
-                    BackgroundTransition(
-                        action_name='a',
-                        sources=['s'],
-                        target='t1',
-                        in_progress_state='processing',
-                        queue='q',
-                    ),
-                    BackgroundTransition(
-                        action_name='b',
-                        sources=['s'],
-                        target='t2',
-                        in_progress_state='processing',
-                        queue='q',
-                    ),
-                ]
-        msg = str(ctx.exception)
-        self.assertIn("in_progress_state='processing'", msg)
-        self.assertIn('_BadProcess.a', msg)
-        self.assertIn('_BadProcess.b', msg)
+class SharedInProgressStateTests(SimpleTestCase):
+    def test_duplicate_in_progress_state_accepted(self):
+        class _SharedProcess(Process):
+            process_name = 'shared'
+            transitions = [
+                BackgroundTransition(
+                    action_name='a',
+                    sources=['s'],
+                    target='t1',
+                    in_progress_state='processing',
+                    failed_state='oops',
+                    queue='q',
+                ),
+                BackgroundTransition(
+                    action_name='b',
+                    sources=['s'],
+                    target='t2',
+                    in_progress_state='processing',
+                    failed_state='oops',
+                    queue='q',
+                ),
+            ]
 
-    def test_duplicate_in_progress_state_across_nested_tree_rejected(self):
-        # Issue #88: nested processes share the parent's state field, so the
-        # uniqueness guarantee must hold across the whole tree — previously
-        # only the class's own transitions were checked.
+        self.assertEqual(
+            {t.in_progress_state for t in _SharedProcess.transitions},
+            {'processing'},
+        )
+
+    def test_duplicate_in_progress_state_across_nested_tree_accepted(self):
         class _NestedChild(Process):
             process_name = 'child'
             transitions = [
@@ -92,23 +93,20 @@ class UniqueInProgressStateTests(SimpleTestCase):
                 ),
             ]
 
-        with self.assertRaises(ImproperlyConfigured) as ctx:
-            class _BadParent(Process):
-                process_name = 'bad_parent'
-                nested_processes = [_NestedChild]
-                transitions = [
-                    BackgroundTransition(
-                        action_name='parent_act',
-                        sources=['s'],
-                        target='t2',
-                        in_progress_state='processing',
-                        queue='q',
-                    ),
-                ]
-        msg = str(ctx.exception)
-        self.assertIn("in_progress_state='processing'", msg)
-        self.assertIn('parent_act', msg)
-        self.assertIn('child_act', msg)
+        class _SharedParent(Process):
+            process_name = 'shared_parent'
+            nested_processes = [_NestedChild]
+            transitions = [
+                BackgroundTransition(
+                    action_name='parent_act',
+                    sources=['s'],
+                    target='t2',
+                    in_progress_state='processing',
+                    queue='q',
+                ),
+            ]
+
+        self.assertEqual(_SharedParent.nested_processes, [_NestedChild])
 
     def test_unique_in_progress_states_accepted(self):
         class _GoodProcess(Process):

--- a/tests/test_binding_validation.py
+++ b/tests/test_binding_validation.py
@@ -7,6 +7,10 @@ property while the registry kept both claims, a typo'd state_field only
 failed deep inside a transition, and two machines sharing an
 in_progress_state on one field made record-less stranded recovery guess
 an owner.
+
+Sharing an in_progress_state is legal (a UI may only know one "busy"
+value); what must hold is that every claimant recovers a record-less
+stranded instance identically — same failed_state, same failure hooks.
 """
 from django.core.cache import cache
 from django.core.exceptions import ImproperlyConfigured
@@ -47,6 +51,36 @@ class _MachineC(Process):
     ]
 
 
+def _note_failure(instance, **kwargs):
+    pass
+
+
+class _SharedRecoveryMachine(Process):
+    """Two transitions on one class sharing an in_progress_state AND the
+    recovery they would drive — the shape the old uniqueness raise forbade."""
+    process_name = 'machine_shared'
+    transitions = [
+        Transition('run_one', sources=['draft'], target='done',
+                   in_progress_state='busy', failed_state='shared_failed',
+                   failure_callbacks=[_note_failure]),
+        Transition('run_two', sources=['draft'], target='ready',
+                   in_progress_state='busy', failed_state='shared_failed',
+                   failure_callbacks=[_note_failure]),
+    ]
+
+
+class _DivergentRecoveryMachine(Process):
+    """Same in_progress_state and failed_state, different failure hooks."""
+    process_name = 'machine_divergent'
+    transitions = [
+        Transition('run_three', sources=['draft'], target='done',
+                   in_progress_state='busy', failed_state='shared_failed',
+                   failure_callbacks=[_note_failure]),
+        Transition('run_four', sources=['draft'], target='ready',
+                   in_progress_state='busy', failed_state='shared_failed'),
+    ]
+
+
 class _ActionOnlyMachine(Process):
     process_name = 'machine_action'
     transitions = [
@@ -55,7 +89,8 @@ class _ActionOnlyMachine(Process):
 
 
 class _BindingCleanupMixin:
-    _test_processes = (_MachineA, _MachineB, _MachineC, _ActionOnlyMachine)
+    _test_processes = (_MachineA, _MachineB, _MachineC, _ActionOnlyMachine,
+                       _SharedRecoveryMachine, _DivergentRecoveryMachine)
 
     def tearDown(self):
         ProcessManager.bindings = [
@@ -150,3 +185,33 @@ class AmbiguousInProgressTests(_BindingCleanupMixin, TestCase):
         # Parked, not guessed: neither a_failed nor b_failed was written.
         self.assertEqual(stranded.status, 'working')
         self.assertTrue(any('E001' in line for line in logs.output))
+
+    def test_shared_state_with_matching_recovery_is_not_ambiguous(self):
+        ProcessManager.bind_model_process(
+            Invoice, _SharedRecoveryMachine, state_field='status')
+
+        self.assertEqual(collect_ambiguous_in_progress_states(), {})
+        self.assertEqual(check_unambiguous_in_progress_ownership(None), [])
+
+    def test_shared_state_with_matching_recovery_is_swept(self):
+        ProcessManager.bind_model_process(
+            Invoice, _SharedRecoveryMachine, state_field='status')
+        cache.clear()
+        stranded = Invoice.objects.create(status='busy')
+
+        recovered = recover_stranded_states()
+
+        stranded.refresh_from_db()
+        # Either claimant drives the same recovery, so guessing is safe.
+        self.assertEqual(recovered, 1)
+        self.assertEqual(stranded.status, 'shared_failed')
+
+    def test_shared_state_with_divergent_failure_hooks_is_ambiguous(self):
+        ProcessManager.bind_model_process(
+            Invoice, _DivergentRecoveryMachine, state_field='status')
+
+        ambiguous = collect_ambiguous_in_progress_states()
+        self.assertIn(('tests.Invoice', 'status', 'busy'), ambiguous)
+        findings = check_unambiguous_in_progress_ownership(None)
+        self.assertEqual([f.id for f in findings], ['django_logic.E001'])
+        self.assertIn('recover differently', findings[0].msg)


### PR DESCRIPTION
Closes #175. Releases **0.10.1**.

## What changed

`in_progress_state` no longer has to be unique. `_validate_unique_in_progress_states` is deleted, and the rule the engine actually needs is the only one enforced:

> Every transition claiming an `in_progress_state` on a given (model, state_field) must recover a record-less stranded instance identically — same `failed_state`, same `failure_side_effects`, same `failure_callbacks`.

`collect_ambiguous_in_progress_states` now keys ambiguity on that recovery signature instead of transition identity. Where claimants agree, sharing is free and the sweep picks any of them; where they disagree, `django_logic.E001` fails `manage.py check` and `recover_stranded_states` skips the state — exactly what it already did across bindings (#143).

## Why the old rule was wrong

Its docstring claimed "the in-progress state alone identifies the transition that's mid-flight, without any source-state search". That has not been true since `owning_process_class` landed on `TransitionMessage` (migration `0007`):

- phase-2 restore resolves `(owning process class, action_name)` off the row (`_restore` → `_find_background_transition_in_owner`), guarded by `_validate_unique_background_action_names`;
- `_state_guard_matches` compares the persisted state against the `in_progress_state` of the transition it has **already** restored;
- `_ensure_no_background_in_flight` keys on the TM row.

The single consumer that needs an owner is `recover_stranded_states`, and only for a **record-less** stranded instance. It drives `fail_transition`, which reads `failed_state` + the two failure bundles and nothing else — everything else it touches is logging. Hence the signature.

## Why this is a strict generalization, not a relaxation of #143

`len({id(transition) …}) > 1` → `len({_recovery_signature(t) …}) > 1`. The same transition object reached through two bindings yields one signature, so #143's "not ambiguous" case is preserved verbatim; and two *different* transitions that disagree still trip. What newly passes is only the case where disagreement is impossible. `_recovery_signature` compares command **identity**, so two equal-but-distinct callables read as different — erring toward calling a key ambiguous.

## What this unblocks

Several actions on one model that all mean "busy" to a client. Borderless360/gv#9039 has three background transitions on `BatchAction` (`charge_order_estimates`, `create_sales_invoices`, `create_credit_notes`) that share one `failed_state` and identical failure hooks, against a frontend that knows exactly one in-progress value. Under the old rule that consumer needed three invented `updating_<action>` states, a schema migration, an import-time guard, a `Process`-level accessor to collect them back, and an API-layer collapse. All of that goes away.

## Tests

`Ran 496 tests … OK` (was 493).

- `tests/background/test_validation.py` — the two tests that pinned the raise now pin acceptance (same class, and across a nested tree).
- `tests/test_binding_validation.py` — three new: shared state + matching recovery is not ambiguous and passes `E001`; shared state + matching recovery **is** swept (a stranded instance reaches `shared_failed`); shared state + divergent `failure_callbacks` is ambiguous and reports `E001` with "recover differently".
- The existing #143 fixtures (`_MachineA`/`_MachineB`, differing `failed_state`) are unchanged and still ambiguous, which is the regression guard for the generalization.

`ruff` error count is identical before and after (58, all pre-existing). `tests.test_metadata` green after the version bump.

## Docs

`E001`'s message + hint, the sweep's skip log, `BackgroundTransition`'s docstring, `Process`'s docstring, `CLAUDE.md` rule 4, the README nested-processes constraints paragraph, and `docs/design/BACKGROUND_TRANSITION_ANALYSIS.md`'s "two smaller rules" bullet.

## Upgrade note

Nothing to do. Every topology that was valid before is still valid; this only stops rejecting ones that were always safe. If you had worked around the raise with per-action in-progress states, you can collapse them — keep the old values in your model's `choices` until no rows hold them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches stranded-state recovery and `manage.py check` topology rules for background/sync machines; behavior change is a generalization (previously valid configs stay valid) but misconfigured shared states can still park rows until E001 is fixed.
> 
> **Overview**
> **Release 0.10.1** drops class-time **`ImproperlyConfigured`** for duplicate `in_progress_state` within a process tree (`_validate_unique_in_progress_states` removed). Sharing one “busy” value across several transitions is allowed when every claimant on the same `(model, state_field)` would recover a **record-less** stranded instance the same way.
> 
> **`collect_ambiguous_in_progress_states`** now treats ambiguity as disagreeing **recovery signatures** (`failed_state` plus identity of `failure_side_effects` / `failure_callbacks` commands), not duplicate transition objects. **`django_logic.E001`**, **`recover_stranded_states`** skip logging, and docs (`README`, `CLAUDE.md`, `BackgroundTransition` / `Process` docstrings) describe this rule instead of global uniqueness.
> 
> Tests flip from expecting the old raise to accepting shared states with matching recovery, and add coverage for sweep + divergent failure hooks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf931d3296276cd30500da0e02f7cff1da1f2470. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->