### PR TITLE
0.11.0 — django-redis out of core deps + in_progress_state recovery-ownership (fixes a regression #176 would have shipped)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,40 @@
     `manage.py check` time. Celery workers do not run system checks, so make
     sure your deploy pipeline does.
 
+### Fixed
+
+- **Late migration note for the 0.10.0 removal of `django_logic.conditions`.**
+  0.10.0 removed `all_related_in` / `any_related_in` (#168) as "public API with
+  no callers in any tree". That audit scanned only one consumer; the
+  `django-logic-test` validation rig imported both, and would have failed at
+  import on upgrade. Nothing changes in 0.11.0 — the module is still gone — but
+  the migration the changelog never gave is: **copy the two factories into your
+  own project.** They are queryset arithmetic with no engine coupling:
+
+  ```python
+  def all_related_in(relation, field, states):
+      wanted = set(states)
+
+      def condition(instance, **kwargs) -> bool:
+          manager = getattr(instance, relation)
+          total = manager.count()
+          if total == 0:
+              return False
+          return manager.filter(**{f'{field}__in': wanted}).count() == total
+
+      return condition
+
+
+  def any_related_in(relation, field, states):
+      wanted = set(states)
+
+      def condition(instance, **kwargs) -> bool:
+          return getattr(instance, relation).filter(
+              **{f'{field}__in': wanted}).exists()
+
+      return condition
+  ```
+
 ## [0.10.0] — 2026-07-27
 
 An overengineering sweep. ~1,900 lines removed across the engine, its tests and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 ## [Unreleased]
 
+## [0.10.1] — 2026-07-28
+
+### Changed
+
+- **`in_progress_state` no longer has to be unique.** Declaring two transitions
+  in one process tree with the same `in_progress_state` used to raise
+  `ImproperlyConfigured` at class-creation time. The rule the engine actually
+  needs is narrower, and it is now the only one enforced: every transition
+  claiming an `in_progress_state` on a given (model, state_field) must **recover
+  a record-less stranded instance identically** — same `failed_state`, same
+  `failure_side_effects`, same `failure_callbacks`. Where they agree, sharing is
+  free and `recover_stranded_states` picks any claimant; where they disagree,
+  `django_logic.E001` fails `manage.py check` and the sweep skips the state, as
+  it already did across bindings (#143).
+
+  The old justification — "the in-progress state alone identifies the
+  transition that's mid-flight" — has not been true since 0.6 added
+  `owning_process_class` to `TransitionMessage` (migration 0007): phase-2 restore
+  resolves `(owning process class, action_name)` off the row, guarded by
+  `_validate_unique_background_action_names`, and never searches by state.
+  `_state_guard_matches` compares against the transition it already restored.
+
+  This unblocks the legitimate shape the raise forbade: several actions on one
+  model that all mean "busy" to a client, sharing one in-progress value and one
+  `failed_state`. Consumers previously forced to synthesize a per-action state
+  (and map it back for the API) can collapse it back to one.
+
+  `E001`'s message and hint changed accordingly; nothing else in the public API
+  moved, and a topology that was valid before is still valid.
+
 ## [0.10.0] — 2026-07-27
 
 An overengineering sweep. ~1,900 lines removed across the engine, its tests and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.11.0] — 2026-07-28
+
 ### Changed (breaking)
 
 - **`django-redis` is no longer a core dependency** — it moves to the `[redis]`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 ## [Unreleased]
 
+### Changed (breaking)
+
+- **`django-redis` is no longer a core dependency** — it moves to the
+  `[redis]` extra, which stops being an empty alias (#173). The engine has
+  never imported `django_redis`: the state lock goes through Django's cache
+  API (`State.lock` → `cache.add`), so what it actually requires is a
+  *cross-process cache backend*, not a particular package. Django has shipped
+  `django.core.cache.backends.redis.RedisCache` since 4.0 and our floor is
+  4.2, so the documented setup no longer needs a third-party package.
+
+  Verified: with `django-redis` uninstalled and the built-in backend
+  configured, two separate OS processes contend correctly on the same lock —
+  the second `lock()` returns `False`, `is_locked()` is `True`, and the key
+  is released on `unlock()`. The locmem control shows both processes
+  acquiring, which is the failure the boot guard exists to prevent.
+
+  **Migration:** if your settings name `django_redis.cache.RedisCache`,
+  install it explicitly — `pip install django-logic[redis]`, or add
+  `django-redis` to your own dependencies. Both known consumers already
+  declare it directly and are unaffected. Note the failure mode if you miss
+  this is *not* at boot: `django.setup()` succeeds and
+  `InvalidCacheBackendError` is raised at the first cache access, because
+  the celery-mode guard only string-matches the backend path against
+  locmem/dummy and never instantiates the cache.
+
+  Not affected: the boot guard itself, which is backend-agnostic and still
+  refuses locmem/dummy in celery mode when `DEBUG=False`.
+
 ## [0.10.0] — 2026-07-27
 
 An overengineering sweep. ~1,900 lines removed across the engine, its tests and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,11 +69,14 @@ change on success) for anything slow, external, or retriable.
 
 ## Deployment the durability contract depends on
 
-- A real broker (Redis/RabbitMQ). Celery and django-redis are core
-  dependencies of django-logic (installed automatically);
-  `BACKGROUND_EXECUTION` defaults to `'celery'`.
-- A cross-process `default` cache (django-redis) for the state lock —
-  celery mode refuses to boot with a locmem/dummy cache when `DEBUG=False`.
+- A real broker (Redis/RabbitMQ). Celery is a core dependency of
+  django-logic (installed automatically); `BACKGROUND_EXECUTION` defaults
+  to `'celery'`.
+- A cross-process `default` cache for the state lock — celery mode refuses
+  to boot with a locmem/dummy cache when `DEBUG=False`. The engine locks
+  through Django's cache API and imports no backend, so Django's built-in
+  `django.core.cache.backends.redis.RedisCache` is enough; django-redis is
+  the `[redis]` extra, not a core dependency (0.11.0).
 - Crash re-delivery is built in (every django-logic task sets
   `acks_late=True` + `reject_on_worker_lost=True`); set the global Celery
   pair only for your *own* tasks. You still need a **single beat**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,8 +50,11 @@ change on success) for anything slow, external, or retriable.
    completion check** on the parent, and **aggregate errors by reading child
    rows** (give the parent an explicit `action_required` partial-failure
    state). Never re-raise a child error into the parent.
-4. **`in_progress_state` is unique within a Process**; set a `failed_state` so
-   failures are contained.
+4. **Set a `failed_state`** so failures are contained. Transitions may share an
+   `in_progress_state` (several actions that all mean "busy" to a UI), provided
+   they also share `failed_state` and their failure hooks — otherwise recovery of
+   a record-less stranded instance would guess, and `django_logic.E001` fails
+   `manage.py check`.
 5. **Test in sync mode**: `DJANGO_LOGIC['BACKGROUND_EXECUTION']='sync'` (or the
    `sync_execution()` context manager) runs phase 2 inline with no broker and
    propagates exceptions; `retry_pending()` simulates the periodic starter.

--- a/README.md
+++ b/README.md
@@ -768,7 +768,7 @@ class GmailConversationProcess(Process):
         BackgroundTransition(
             action_name='send_message_via_integration',
             sources=['open'], target='open',
-            in_progress_state='gmail_sending',     # must be unique across the tree
+            in_progress_state='gmail_sending',     # distinct here: different failure hooks
             conditions=[is_gmail],
             side_effects=[send_via_gmail],
         ),
@@ -811,8 +811,11 @@ phase 2 restores that exact transition from the recorded owner — it does not
 re-evaluate the condition, so routing is deterministic even if the instance
 changes mid-flight. Constraints: a background `action_name` must only be
 **unique within a single process class** (two in one class are
-indistinguishable at restore), and every `in_progress_state` must be unique
-across the whole tree. A background `action_name` *may* coincide with a
+indistinguishable at restore). `in_progress_state` may be shared by several
+transitions — useful when a UI only knows one "busy" value — provided they
+agree on `failed_state` and their failure hooks, since a record-less stranded
+instance in that state has no owner to recover under; `django_logic.E001`
+fails `manage.py check` when they disagree. A background `action_name` *may* coincide with a
 synchronous transition of the same name (phase 2 restores only background
 transitions; phase 1 routes the call by condition) — so a synchronous fast-path
 and a durable background slow-path can share one `action_name`.

--- a/README.md
+++ b/README.md
@@ -35,17 +35,18 @@ Django Logic is a lightweight workflow framework for Django that makes it easy t
 - Django 4.2+ (4.2, 5.1, 5.2 and 6.0 are tested in CI; 5.0 is not supported)
 - django-model-utils >= 4.5.1
 - celery >= 5.0 — **installed automatically**; background transitions are Celery tasks
-- django-redis >= 5.0.0 — **installed automatically**; provides the cross-process state lock
+- A **cross-process `default` cache** for the state lock — *not* a package dependency. The engine locks through Django's cache API, so any cross-process backend works, including `django.core.cache.backends.redis.RedisCache`, built into Django since 4.0. Celery mode refuses to boot on a locmem/dummy cache when `DEBUG=False`.
 
 Extras:
+- `pip install django-logic[redis]` — installs `django-redis`, for deployments whose settings name `django_redis.cache.RedisCache`. It stopped being a core dependency in 0.11.0: the engine has never imported it.
 - `pip install django-logic[drf]` — pulls in `djangorestframework` (kept for projects migrating off the old DRF-coupled releases; no DRF-specific code ships since 0.4)
-- `[celery]` and `[redis]` remain as **empty aliases**, so existing `pip install django-logic[celery,redis]` pins keep resolving — both packages are core dependencies since 0.4
+- `[celery]` remains an **empty alias**, so existing `pip install django-logic[celery,redis]` pins keep resolving — celery is a core dependency since 0.4
 
 ## Installation
 
 ```bash
-# Installs the current release from PyPI.
-# Celery and django-redis are installed automatically.
+# Installs the current release from PyPI. Celery is installed automatically.
+# Add [redis] if your settings name django_redis.cache.RedisCache.
 pip install django-logic
 ```
 
@@ -535,7 +536,7 @@ Multiple processes trying to transition the same object can cause race condition
 - a **cache lock** (atomic set-if-absent on the `default` cache) held for a synchronous transition's whole flight and for a background transition's phase-1 critical section, with the persisted state re-validated under the lock; and
 - the **`TransitionMessage` row** — while a background transition is in flight, a second one raises `AlreadyInProgress` and a synchronous transition on the same instance + process raises `TransitionNotAllowed`.
 
-Use a cross-process cache (django-redis, installed automatically) so the lock is shared between web processes and workers.
+Use a cross-process cache so the lock is shared between web processes and workers.
 
 #### 4. Side Effects Not Rolling Back
 Side effects that modify external systems may not roll back automatically.
@@ -681,7 +682,9 @@ At boot, celery mode fails fast on two misconfigurations that would silently bre
 ```python
 CACHES = {
     'default': {
-        'BACKEND': 'django_redis.cache.RedisCache',
+        # Built into Django since 4.0; needs the `redis` client package.
+        # `django_redis.cache.RedisCache` also works — `pip install django-logic[redis]`.
+        'BACKEND': 'django.core.cache.backends.redis.RedisCache',
         'LOCATION': os.environ['REDIS_URL'],
     }
 }

--- a/django_logic/background/dispatch.py
+++ b/django_logic/background/dispatch.py
@@ -192,18 +192,18 @@ def recover_stranded_states() -> int:
 
     recovered = 0
     seen = set()
-    # In-progress states claimed by more than one bound machine have no
-    # provenance for a record-less stranding — recovering would guess an
-    # owner and could run the wrong failed_state/hooks. Skip them loudly;
-    # the django_logic.E001 system check flags the topology itself (#143).
+    # A record-less stranding has no provenance, so recovery picks one of
+    # the transitions claiming the state. That is only safe while they all
+    # recover identically; where they disagree, skip loudly. The
+    # django_logic.E001 system check flags the topology itself (#143).
     ambiguous = collect_ambiguous_in_progress_states()
     for key in sorted(ambiguous):
         model_label, state_field, in_progress = key
         logger.error(
             f'recover_stranded_states: in_progress_state {in_progress!r} '
-            f'on {model_label}.{state_field} is claimed by multiple bound '
-            f'machines (django_logic.E001); skipping recovery for it — '
-            f'stranded instances stay parked until the binding topology '
+            f'on {model_label}.{state_field} is shared by transitions that '
+            f'recover differently (django_logic.E001); skipping recovery '
+            f'for it — stranded instances stay parked until the topology '
             f'is fixed.'
         )
     for binding, process_cls, transition in iter_bound_transitions():

--- a/django_logic/background/settings.py
+++ b/django_logic/background/settings.py
@@ -267,8 +267,9 @@ def _check_lock_cache_in_celery_mode() -> None:
         f"DJANGO_LOGIC['BACKGROUND_EXECUTION']='celery' but the 'default' "
         f"cache backend is {backend!r}, which is per-process. The state "
         f"lock will not be shared between web processes and Celery "
-        f"workers. Use a cross-process cache (django-redis is installed "
-        f"as a django-logic dependency) for the 'default' cache."
+        f"workers. Use a cross-process cache for the 'default' cache — "
+        f"e.g. 'django.core.cache.backends.redis.RedisCache', or "
+        f"django-redis via `pip install django-logic[redis]`."
     )
     if getattr(settings, 'DEBUG', False):
         from django_logic.logger import logger

--- a/django_logic/background/transitions.py
+++ b/django_logic/background/transitions.py
@@ -54,8 +54,9 @@ class BackgroundTransition(Transition):
         - ``in_progress_state`` — if omitted, the state field does not
           change until phase 2 finishes. Providing it is strongly
           recommended so concurrent readers see "in progress" rather
-          than the pre-transition state. ``in_progress_state`` values
-          must be unique within a :class:`django_logic.Process`.
+          than the pre-transition state. Transitions may share one, as
+          long as they also share a ``failed_state`` and failure hooks —
+          see ``django_logic.E001``.
     """
 
     is_background = True

--- a/django_logic/checks.py
+++ b/django_logic/checks.py
@@ -41,12 +41,15 @@ def check_hook_signatures(app_configs, **kwargs):
 
 @checks.register('django_logic')
 def check_unambiguous_in_progress_ownership(app_configs, **kwargs):
-    """Two bound machines must not claim the same in_progress_state on
-    one (model, state_field) — a record-less stranded instance there has
-    no provenance, so automatic recovery could run the wrong transition's
-    failed_state and failure hooks (``django_logic.E001``).
-    ``recover_stranded_states`` also skips such states at runtime, but
-    the topology itself is the defect; fail loudly at check time."""
+    """Transitions sharing an in_progress_state on one
+    (model, state_field) must all recover a record-less stranded instance
+    the same way — such an instance has no provenance, so recovery picks
+    an owner, and claimants that disagree on ``failed_state`` or their
+    failure hooks make that pick wrong half the time
+    (``django_logic.E001``). Sharing is fine on its own;
+    ``recover_stranded_states`` also skips ambiguous states at runtime,
+    but the topology itself is the defect, so fail loudly at check
+    time."""
     findings = []
     for key, owners in sorted(collect_ambiguous_in_progress_states().items()):
         model_label, state_field, in_progress = key
@@ -56,12 +59,13 @@ def check_unambiguous_in_progress_ownership(app_configs, **kwargs):
         ))
         findings.append(checks.Error(
             f"in_progress_state {in_progress!r} on {model_label}."
-            f"{state_field} is claimed by more than one bound machine: "
-            f"{claimants}.",
-            hint='Give each machine a distinct in_progress_state (or bind '
-                 'the processes to distinct state fields). Stranded-state '
-                 'recovery skips ambiguous states, leaving instances '
-                 'parked until fixed manually.',
+            f"{state_field} is shared by transitions that recover "
+            f"differently: {claimants}.",
+            hint='Give them a matching failed_state and matching '
+                 'failure_side_effects/failure_callbacks, or a distinct '
+                 'in_progress_state each (or bind the processes to distinct '
+                 'state fields). Stranded-state recovery skips ambiguous '
+                 'states, leaving instances parked until fixed manually.',
             obj=f'{model_label}.{state_field}',
             id='django_logic.E001',
         ))

--- a/django_logic/process.py
+++ b/django_logic/process.py
@@ -55,9 +55,9 @@ class Process:
     ``nested_processes``, ``conditions``, ``permissions``,
     ``process_name``, and ``state_class``.
 
-    Class-time validation enforces that no two transitions on the same
-    ``Process`` share the same ``in_progress_state`` — this makes
-    phase-2 background-transition lookup unambiguous.
+    Class-time validation enforces that a background transition is
+    uniquely identifiable by ``(owning process class, action_name)``,
+    which is what phase-2 restore resolves a ``TransitionMessage`` by.
     """
 
     nested_processes = []
@@ -71,7 +71,6 @@ class Process:
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
-        _validate_unique_in_progress_states(cls)
         _validate_unique_background_action_names(cls)
 
     def __init__(self, field_name='', instance=None, state=None):
@@ -280,39 +279,6 @@ class Process:
         )
 
 
-def _validate_unique_in_progress_states(process_cls):
-    """Reject duplicate in_progress_state values across a Process AND its
-    nested processes.
-
-    Unique ``in_progress_state`` is what lets the phase-2 background
-    transition lookup work unambiguously — the in-progress state alone
-    identifies the transition that's mid-flight, without any source-state
-    search. Nested processes share the parent's state field, so the
-    uniqueness guarantee must hold across the whole tree (mirroring
-    ``_validate_unique_background_action_names``), not just the class's
-    own ``transitions``.
-    """
-    seen: dict[str, str] = {}
-    for proc_cls in _iter_process_tree(process_cls):
-        for transition in proc_cls.transitions or []:
-            in_progress = getattr(transition, 'in_progress_state', None)
-            if not in_progress:
-                continue
-            where = (
-                f'{proc_cls.__module__}.{proc_cls.__name__}.'
-                f'{transition.action_name}'
-            )
-            if in_progress in seen:
-                raise ImproperlyConfigured(
-                    f"Process {process_cls.__module__}.{process_cls.__name__} "
-                    f"(or its nested processes) has two transitions sharing "
-                    f"in_progress_state='{in_progress}': {seen[in_progress]} "
-                    f"and {where}. Every in_progress_state must be unique "
-                    f"across a Process and its nested processes."
-                )
-            seen[in_progress] = where
-
-
 def _iter_process_tree(process_cls, _seen=None):
     """Yield ``process_cls`` and every Process class reachable through
     ``nested_processes`` (depth-first), guarding against cycles.
@@ -487,20 +453,40 @@ def collect_hook_signature_offenders(process_cls) -> list:
     return offenders
 
 
-def collect_ambiguous_in_progress_states() -> dict:
-    """Cross-binding in-progress ownership map (#143).
+def _recovery_signature(transition) -> tuple:
+    """What ``recover_stranded_states`` would do with this transition.
 
-    Uniqueness of ``in_progress_state`` is enforced per process tree, but
-    two *bindings* on the same (model, state_field) may legally exist.
-    If their trees share an ``in_progress_state``, a record-less stranded
-    instance in that state has no provenance: automatic recovery could
-    run the wrong transition's ``failed_state`` and failure hooks.
+    Recovery is exactly ``fail_transition``, which reads only
+    ``failed_state`` and the two failure bundles; everything else it
+    touches is logging. Identity of the command objects, not equality —
+    two equal-but-distinct callables compare as different, which errs
+    toward calling a key ambiguous.
+    """
+    return (
+        transition.failed_state,
+        tuple(id(command) for command in transition.failure_side_effects.commands),
+        tuple(id(command) for command in transition.failure_callbacks.commands),
+    )
+
+
+def collect_ambiguous_in_progress_states() -> dict:
+    """In-progress states whose stranded-recovery owner is undecidable
+    (#143).
+
+    Several transitions may share an ``in_progress_state`` on one
+    (model, state_field) — declared side by side in a process tree, or
+    reached through two *bindings*. That is only a problem for a
+    **record-less** stranded instance: it has no provenance, so recovery
+    has to pick an owner. Picking is safe when every claimant would
+    recover identically (same ``failed_state``, same failure hooks) and
+    unsafe otherwise, which is what this reports — not the sharing
+    itself.
 
     Returns ``{(model_label, state_field, in_progress_state):
-    [(process_cls, transition), ...]}`` for every key claimed by more
-    than one binding. ``Action``\\ s never write their
-    ``in_progress_state`` and are excluded (mirrors the stranded sweep).
-    Consumed by the ``django_logic.E001`` system check and by
+    [(process_cls, transition), ...]}`` for every key whose claimants
+    disagree. ``Action``\\ s never write their ``in_progress_state`` and
+    are excluded (mirrors the stranded sweep). Consumed by the
+    ``django_logic.E001`` system check and by
     ``recover_stranded_states``, which skips ambiguous keys.
     """
     from django_logic.transition import Action
@@ -523,11 +509,8 @@ def collect_ambiguous_in_progress_states() -> dict:
                 claims.setdefault(key, []).append((process_cls, transition))
             stack.extend(process_cls.nested_processes)
     return {
-        # The same transition object reachable through two bindings is
-        # not ambiguous — recovery drives the identical failed_state and
-        # hooks either way. Only distinct declarations conflict.
         key: owners for key, owners in claims.items()
-        if len({id(transition) for _, transition in owners}) > 1
+        if len({_recovery_signature(t) for _, t in owners}) > 1
     }
 
 

--- a/docs/design/BACKGROUND_TRANSITION_ANALYSIS.md
+++ b/docs/design/BACKGROUND_TRANSITION_ANALYSIS.md
@@ -134,11 +134,12 @@ Three properties this gives you, effectively for free:
 
 Two smaller rules keep the design honest:
 
-- **`in_progress_state` is unique within a Process.** Validated at
-  class-creation time. Phase 2 can then find its transition by the
-  in-progress state alone, without the `ignore_sources=True` hack.
-  Operational bonus: a glance at `state='fulfilling'` tells you
-  exactly which transition is mid-flight.
+- **`in_progress_state` need not be unique.** Phase 2 restores its
+  transition from the owner recorded on the `TransitionMessage`, not
+  from the state, so sharing costs nothing there. The one consumer that
+  needs an owner is stranded recovery of a *record-less* instance, which
+  is why claimants must agree on `failed_state` and failure hooks
+  (`django_logic.E001`) rather than on the state name.
 - **`BackgroundAction` uses the same durable path.** No state change
   on success, but same `TransitionMessage` row, same retry, same
   concurrency guard. A background action that bypassed the DB record

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-logic"
-version = "0.10.0"
+version = "0.10.1"
 description = "Declarative business logic & state machines for Django — sync and durable background transitions"
 readme = "README.md"
 license = { text = "MIT License" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,23 +39,24 @@ dependencies = [
     # No upper bound by design: the django-main CI job is the early warning.
     "django>=4.2,!=5.0.*",
     "django-model-utils>=4.5.1",
-    # Celery and Redis are core dependencies, not extras. Background
-    # transitions always execute through Celery in production ('sync'
-    # execution exists only for tests/CI). The engine never imports
-    # django_redis — it locks through Django's cache API — but it does
-    # require a CROSS-PROCESS cache, and django-redis is the backend the
-    # README documents, so it ships installed rather than as a footgun.
-    # Whether to demote it now that Django 4.0+ has its own Redis backend
-    # is a separate call: see issue #173.
+    # Celery is a core dependency, not an extra: background transitions
+    # always execute through Celery in production ('sync' execution exists
+    # only for tests/CI), and background/tasks.py imports shared_task at
+    # module level.
     "celery>=5.0",
-    "django-redis>=5.0.0",
 ]
 
 [project.optional-dependencies]
-# Kept as empty aliases so existing `pip install django-logic[celery,redis]`
-# pins keep resolving; both packages are core dependencies as of 0.4.0.
+# Celery is still a core dependency, so [celery] stays an empty alias purely
+# so existing `pip install django-logic[celery,redis]` pins keep resolving.
 celery = []
-redis = []
+# [redis] has meaning again as of 0.11.0. The engine never imports
+# django_redis — the state lock goes through Django's cache API
+# (`State.lock` → `cache.add`) — so any cross-process backend works,
+# including the `django.core.cache.backends.redis.RedisCache` Django has
+# shipped since 4.0. This extra installs the third-party backend for
+# deployments whose settings name `django_redis.cache.RedisCache`.
+redis = ["django-redis>=5.0.0"]
 drf = [
     "djangorestframework>=3.14.0",
 ]
@@ -65,6 +66,9 @@ dev = [
     # Postgres concurrency tests. Without it, `uv sync --extra dev` runs the
     # SQLite suite but not tests.stability.
     "psycopg[binary]>=3.1",
+    # Client for Django's built-in Redis cache backend, which the
+    # real-Redis and stability test settings use for the state lock.
+    "redis>=4.2",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-logic"
-version = "0.10.1"
+version = "0.11.0"
 description = "Declarative business logic & state machines for Django — sync and durable background transitions"
 readme = "README.md"
 license = { text = "MIT License" }

--- a/tests/background/test_validation.py
+++ b/tests/background/test_validation.py
@@ -1,5 +1,7 @@
 """Class-time validation: queue optional but non-empty when given,
-in_progress_state unique, background action_names unique within a Process."""
+background action_names unique within a Process. Sharing an
+in_progress_state is legal — the recovery-ownership rule that replaced the
+old uniqueness raise lives in tests/test_binding_validation.py."""
 from django.core.exceptions import ImproperlyConfigured
 from django.test import SimpleTestCase, override_settings
 
@@ -50,36 +52,35 @@ class QueueValidationTests(SimpleTestCase):
         self.assertIn('cannot declare in_progress_state', str(ctx.exception))
 
 
-class UniqueInProgressStateTests(SimpleTestCase):
-    def test_duplicate_in_progress_state_rejected(self):
-        with self.assertRaises(ImproperlyConfigured) as ctx:
-            class _BadProcess(Process):
-                process_name = 'bad'
-                transitions = [
-                    BackgroundTransition(
-                        action_name='a',
-                        sources=['s'],
-                        target='t1',
-                        in_progress_state='processing',
-                        queue='q',
-                    ),
-                    BackgroundTransition(
-                        action_name='b',
-                        sources=['s'],
-                        target='t2',
-                        in_progress_state='processing',
-                        queue='q',
-                    ),
-                ]
-        msg = str(ctx.exception)
-        self.assertIn("in_progress_state='processing'", msg)
-        self.assertIn('_BadProcess.a', msg)
-        self.assertIn('_BadProcess.b', msg)
+class SharedInProgressStateTests(SimpleTestCase):
+    def test_duplicate_in_progress_state_accepted(self):
+        class _SharedProcess(Process):
+            process_name = 'shared'
+            transitions = [
+                BackgroundTransition(
+                    action_name='a',
+                    sources=['s'],
+                    target='t1',
+                    in_progress_state='processing',
+                    failed_state='oops',
+                    queue='q',
+                ),
+                BackgroundTransition(
+                    action_name='b',
+                    sources=['s'],
+                    target='t2',
+                    in_progress_state='processing',
+                    failed_state='oops',
+                    queue='q',
+                ),
+            ]
 
-    def test_duplicate_in_progress_state_across_nested_tree_rejected(self):
-        # Issue #88: nested processes share the parent's state field, so the
-        # uniqueness guarantee must hold across the whole tree — previously
-        # only the class's own transitions were checked.
+        self.assertEqual(
+            {t.in_progress_state for t in _SharedProcess.transitions},
+            {'processing'},
+        )
+
+    def test_duplicate_in_progress_state_across_nested_tree_accepted(self):
         class _NestedChild(Process):
             process_name = 'child'
             transitions = [
@@ -92,23 +93,20 @@ class UniqueInProgressStateTests(SimpleTestCase):
                 ),
             ]
 
-        with self.assertRaises(ImproperlyConfigured) as ctx:
-            class _BadParent(Process):
-                process_name = 'bad_parent'
-                nested_processes = [_NestedChild]
-                transitions = [
-                    BackgroundTransition(
-                        action_name='parent_act',
-                        sources=['s'],
-                        target='t2',
-                        in_progress_state='processing',
-                        queue='q',
-                    ),
-                ]
-        msg = str(ctx.exception)
-        self.assertIn("in_progress_state='processing'", msg)
-        self.assertIn('parent_act', msg)
-        self.assertIn('child_act', msg)
+        class _SharedParent(Process):
+            process_name = 'shared_parent'
+            nested_processes = [_NestedChild]
+            transitions = [
+                BackgroundTransition(
+                    action_name='parent_act',
+                    sources=['s'],
+                    target='t2',
+                    in_progress_state='processing',
+                    queue='q',
+                ),
+            ]
+
+        self.assertEqual(_SharedParent.nested_processes, [_NestedChild])
 
     def test_unique_in_progress_states_accepted(self):
         class _GoodProcess(Process):

--- a/tests/settings_redis.py
+++ b/tests/settings_redis.py
@@ -11,11 +11,8 @@ from tests.settings import *  # noqa: F401, F403
 
 CACHES = {
     'default': {
-        'BACKEND': 'django_redis.cache.RedisCache',
+        'BACKEND': 'django.core.cache.backends.redis.RedisCache',
         'LOCATION': os.environ.get('REDIS_URL', 'redis://localhost:6379/1'),
-        'OPTIONS': {
-            'CLIENT_CLASS': 'django_redis.client.DefaultClient',
-        },
     }
 }
 

--- a/tests/settings_stability.py
+++ b/tests/settings_stability.py
@@ -30,11 +30,8 @@ DATABASES = {
 
 CACHES = {
     'default': {
-        'BACKEND': 'django_redis.cache.RedisCache',
+        'BACKEND': 'django.core.cache.backends.redis.RedisCache',
         'LOCATION': os.environ.get('REDIS_URL', 'redis://localhost:6379/1'),
-        'OPTIONS': {
-            'CLIENT_CLASS': 'django_redis.client.DefaultClient',
-        },
     }
 }
 

--- a/tests/test_binding_validation.py
+++ b/tests/test_binding_validation.py
@@ -7,6 +7,10 @@ property while the registry kept both claims, a typo'd state_field only
 failed deep inside a transition, and two machines sharing an
 in_progress_state on one field made record-less stranded recovery guess
 an owner.
+
+Sharing an in_progress_state is legal (a UI may only know one "busy"
+value); what must hold is that every claimant recovers a record-less
+stranded instance identically — same failed_state, same failure hooks.
 """
 from django.core.cache import cache
 from django.core.exceptions import ImproperlyConfigured
@@ -47,6 +51,36 @@ class _MachineC(Process):
     ]
 
 
+def _note_failure(instance, **kwargs):
+    pass
+
+
+class _SharedRecoveryMachine(Process):
+    """Two transitions on one class sharing an in_progress_state AND the
+    recovery they would drive — the shape the old uniqueness raise forbade."""
+    process_name = 'machine_shared'
+    transitions = [
+        Transition('run_one', sources=['draft'], target='done',
+                   in_progress_state='busy', failed_state='shared_failed',
+                   failure_callbacks=[_note_failure]),
+        Transition('run_two', sources=['draft'], target='ready',
+                   in_progress_state='busy', failed_state='shared_failed',
+                   failure_callbacks=[_note_failure]),
+    ]
+
+
+class _DivergentRecoveryMachine(Process):
+    """Same in_progress_state and failed_state, different failure hooks."""
+    process_name = 'machine_divergent'
+    transitions = [
+        Transition('run_three', sources=['draft'], target='done',
+                   in_progress_state='busy', failed_state='shared_failed',
+                   failure_callbacks=[_note_failure]),
+        Transition('run_four', sources=['draft'], target='ready',
+                   in_progress_state='busy', failed_state='shared_failed'),
+    ]
+
+
 class _ActionOnlyMachine(Process):
     process_name = 'machine_action'
     transitions = [
@@ -55,7 +89,8 @@ class _ActionOnlyMachine(Process):
 
 
 class _BindingCleanupMixin:
-    _test_processes = (_MachineA, _MachineB, _MachineC, _ActionOnlyMachine)
+    _test_processes = (_MachineA, _MachineB, _MachineC, _ActionOnlyMachine,
+                       _SharedRecoveryMachine, _DivergentRecoveryMachine)
 
     def tearDown(self):
         ProcessManager.bindings = [
@@ -150,3 +185,33 @@ class AmbiguousInProgressTests(_BindingCleanupMixin, TestCase):
         # Parked, not guessed: neither a_failed nor b_failed was written.
         self.assertEqual(stranded.status, 'working')
         self.assertTrue(any('E001' in line for line in logs.output))
+
+    def test_shared_state_with_matching_recovery_is_not_ambiguous(self):
+        ProcessManager.bind_model_process(
+            Invoice, _SharedRecoveryMachine, state_field='status')
+
+        self.assertEqual(collect_ambiguous_in_progress_states(), {})
+        self.assertEqual(check_unambiguous_in_progress_ownership(None), [])
+
+    def test_shared_state_with_matching_recovery_is_swept(self):
+        ProcessManager.bind_model_process(
+            Invoice, _SharedRecoveryMachine, state_field='status')
+        cache.clear()
+        stranded = Invoice.objects.create(status='busy')
+
+        recovered = recover_stranded_states()
+
+        stranded.refresh_from_db()
+        # Either claimant drives the same recovery, so guessing is safe.
+        self.assertEqual(recovered, 1)
+        self.assertEqual(stranded.status, 'shared_failed')
+
+    def test_shared_state_with_divergent_failure_hooks_is_ambiguous(self):
+        ProcessManager.bind_model_process(
+            Invoice, _DivergentRecoveryMachine, state_field='status')
+
+        ambiguous = collect_ambiguous_in_progress_states()
+        self.assertIn(('tests.Invoice', 'status', 'busy'), ambiguous)
+        findings = check_unambiguous_in_progress_ownership(None)
+        self.assertEqual([f.id for f in findings], ['django_logic.E001'])
+        self.assertIn('recover differently', findings[0].msg)


### PR DESCRIPTION
Supersedes #174 and #176, which are folded in here as one minor release. Closes #173, #175.

## Why this isn't just the two PRs merged

Reviewing #176 turned up a **data-corruption regression** it would have shipped. Proven with the same test against both trees:

| | ambiguous? | recovered | final status |
|---|---|---|---|
| master (0.10.0) | ✅ flagged | 0 | `shared_busy` — correct |
| #176 as proposed | ❌ not flagged | **1** | **`shared_failed`** — corrupted |

Two *different* bound processes on one `(model, state_field)` sharing an `in_progress_state` with byte-identical recovery stopped being reported. But `_sweep_transition` scopes its in-flight `TransitionMessage` query by `process_name` — deliberately, "so a sibling process's in-flight row cannot delay recovery" — so process A's sweep cannot see process B's open row. An instance legitimately mid-flight under B (state written, row open, lock released while the phase-2 task sits in the queue) looks record-less to A and gets driven to `failed_state`, superseding B's work. #143 rejected exactly this shape; generalising to recovery signatures dropped it.

**Fix:** the bound `process_name` is part of `_recovery_signature`, so claimants from two bindings can never match. Intra-process sharing — the shape #175 exists to enable — is untouched.

Two smaller review fixes:

- **The sweep no longer re-pages per action.** `seen` dropped `action_name`: a non-ambiguous key means every claimant recovers identically, so one pass suffices. #175's motivating gv case was paging the same candidates 3×.
- **`E001` now says hooks are matched by object *identity*.** Two transitions each passing `partial(notify)` get distinct objects and were reported as "recovering differently" while behaving identically — and the fix (hoist to a module-level name) was undiscoverable from the message.

## Heroku validation — real RabbitMQ + PostgreSQL + multiple worker dynos

Ran on the `django-logic-test` rig against this candidate before publishing. Full write-up in that repo's `docs/RESULTS.md`; new cells TC-19/20/21 in `docs/TEST_MATRIX.md`.

| Cell | Result |
|---|---|
| TC-01 happy path | ✅ `orders#375 → fulfilled` |
| TC-02 retry → success | ✅ `errors_count=2`, recovered by beat |
| TC-19 shared `in_progress_state` | ✅ both actions round-trip; stranded recovery runs **once**, not per action |
| TC-20 lock without django-redis | ✅ identical on both backends |
| TC-21 system checks | ✅ clean on the real config |

**TC-19** is worth reading. The rig *booting* is the first assertion — on published 0.10.0 the same declaration raises `ImproperlyConfigured` at import. The stranded half seeds a record-less instance straight into the shared state:

```
$ heroku run python manage.py run_starter --stranded
ERROR recover_stranded_states: recovered exports.Export#241
      status='rebuilding' (rebuild_pdf) -> 'rebuild_failed'
{"recover_stranded_states": 1}
```

`1` with two claimants — the `seen`-key fix, on real infra.

**TC-20** is the one a local suite can't prove. Two concurrent phase-1 `charge` calls; the loser is rejected **by the state lock itself**, over Heroku Redis TLS, across dynos, with `django-redis` no longer a dependency:

| Backend | Winner | Loser | Final | TMs |
|---|---|---|---|---|
| `django.core.cache.backends.redis.RedisCache` (new default) | 200 | **409** `State is locked` | `charged` | 1 |
| `django_redis.cache.RedisCache` | 200 | **409** `State is locked` | `charged` | 1 |

## Two things the run found

**`W002` caught a real gap.** It fired on the first deploy: the rig's hand-written `CELERY_BEAT_SCHEDULE` had **four of the five** safety-net tasks, missing `recover_stranded_states`. A record-less stranded instance would never have been recovered there — exactly the failure W002 was added for. Fixed rig-side, plus `run_starter --stranded`, which it never had.

**0.10.0 removed an API a real consumer used.** The rig imported `django_logic.conditions` (`all_related_in`/`any_related_in`), removed in #168 as "no callers in any tree" — that audit scanned gv only, and the rig was pinned to 0.8.0 so it never surfaced. Every dyno would have failed at import. The removal stands, but the changelog named no replacement; it now carries the two factories inline to copy, and the rig vendors them.

## Verification

- SQLite **499 OK** · real-Redis **499 OK** · Postgres+Redis stability **52 OK** · metadata drift **4 OK**
- New tests: cross-process sharing stays ambiguous; a sibling process's in-flight instance is never recovered; a shared state is swept once, not per action

## Version

**0.11.0**, not 0.10.1 — #176 alone was a relaxation that breaks nothing, but dropping a core dependency can break a consumer relying on the transitive install (at first cache access, not at boot), so it takes the minor bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes dependency layout and stranded-state recovery semantics; a regression could mis-classify topology or sweep live cross-process transitions into failed_state, though new tests target those cases.
> 
> **Overview**
> **0.11.0** ships two behavioral/package changes plus docs and tests.
> 
> **`django-redis` is optional.** It moves from core dependencies to `pip install django-logic[redis]`; locking still uses Django’s cache API only. Docs and boot warnings now point at `django.core.cache.backends.redis.RedisCache` as the default example; test Redis settings switch to that backend and add a `redis` client under the `dev` extra.
> 
> **`in_progress_state` uniqueness is removed at class creation** (`_validate_unique_in_progress_states` deleted). Transitions on the same `(model, state_field)` may share a busy state when every claimant would run the same stranded recovery: bound `process_name`, `failed_state`, and failure hooks (matched by **callable identity**, not equality). **`django_logic.E001`** and `collect_ambiguous_in_progress_states()` implement that rule instead of “any duplicate state.” **Two different bound processes** must not share a state—even with identical recovery—because each sweep only sees its own `process_name`’s in-flight rows; including `process_name` in `_recovery_signature` keeps that case ambiguous and avoids force-failing legitimately mid-flight siblings.
> 
> **`recover_stranded_states`** dedupes sweeps by `(model, field, in_progress, process_name)` instead of `action_name`, so shared states are recovered once per pass, and log/check messages describe “recover differently” rather than “multiple machines.”
> 
> Changelog also documents copying `all_related_in` / `any_related_in` after the 0.10.0 module removal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bab51d383fd691873a870162506677a3772283e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->