### PR TITLE
release: django-logic 0.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@
 
 Five fixes from the 0.13.0 adoption review (raised by the gv consumer as
 #194–#197) plus #192, the sync analog the 0.13.0 review deliberately deferred.
-One is a 0.13.0 regression; the rest harden the release's new surfaces. Every
+One is a 0.13.0 regression; the rest harden the release's new surfaces. An
+adversarial review pass over this release's own diff then confirmed nine gaps
+in the first cut — the largest being that the staleness horizon used the
+wrong liveness signal — all fixed and folded into the bullets below. Every
 fix is mutation-pinned: reverting it makes its tests fail.
 
 ### Fixed
@@ -20,15 +23,24 @@ fix is mutation-pinned: reverting it makes its tests fail.
   logs, skips the `failed_state` write (unknown means don't write), and lets
   the original exception re-raise with both hook bundles running.
 
-- **The sync gate's transient typing is bounded by the retry horizon**
-  (#195). An uncompleted `TransitionMessage` untouched for longer than
-  `max(RETRY_MINUTES × (MAX_ERRORS + 1), 15)` minutes is stranded, not busy —
-  a lost broker message with the safety-net beat tasks unscheduled leaves it
-  uncompleted forever, and 0.13.0's `TransitionTemporarilyUnavailable` then
-  told generic handlers to retry forever while hook-path logging sat demoted
-  at WARNING. A stale row now raises plain `TransitionNotAllowed` again (and
-  pages at ERROR), with the row's age and a pointer to `django_logic.W002` in
-  the message. A live row keeps the transient type.
+- **The transient typing is bounded by one shared liveness classification**
+  (#195, `TransitionMessage.in_flight_liveness`). A stranded row — one
+  nothing is driving — used to keep answering "retry shortly" forever:
+  0.13.0's `TransitionTemporarilyUnavailable` told generic handlers to retry
+  while hook-path logging sat demoted at WARNING. Liveness now reads the
+  watchdog's own signals first: an attempt inside its declared
+  `started_at + timeout_seconds` budget (plus slack) is LIVE however old
+  `modified` is — a healthy 40-minute declared-budget attempt is never
+  called stranded at minute 16. Otherwise a row whose newest activity is
+  within `max(RETRY_MINUTES × (MAX_ERRORS + 1), 15)` minutes is live; past
+  that it is stranded and raises plain `TransitionNotAllowed` (paging at
+  ERROR), with likely causes in the message — unscheduled beats
+  (`django_logic.W002`), a queue backlog or worker outage longer than the
+  horizon, or a lost broker message. The classification covers **both entry
+  points**: the sync gate and phase 1's constraint rejection (a stranded row
+  no longer raises `AlreadyInProgress` on a background re-drive — the most
+  likely consumer retry path). A row that completed in the race window keeps
+  the transient answer: it just finished, so retrying is exactly right.
 
 - **The sync `failed_state` writers get the #189 treatment** (#192). Both
   sync savepoints — `Transition.fail_transition` and the Action's
@@ -36,27 +48,36 @@ fix is mutation-pinned: reverting it makes its tests fail.
   write (the receiver-authored suppressed-database-error idiom at the one
   spot with no query after it) takes the honest except-branch instead of
   logging a false `SET_STATE`. The original exception still re-raises
-  unchanged.
+  unchanged. The except-branches (all four terminal writers) also restore
+  the in-memory state attribute the discarded savepoint left refreshed, so
+  failure hooks and the sync caller never observe a state the database
+  never had.
 
 - **The `LEGACY_EXCEPTION_BASE` smoke probe is airtight** (#196). It now
-  verifies the bridged class preserves the denial message (`args` and
-  `str()` survive the new MRO — a message-eating fork `__init__` used to boot
-  green and blank every denial, breaking pickling too), and the `__bases__`
-  unwind runs on `BaseException`, so a fork `__init__` raising
-  `SystemExit`/`KeyboardInterrupt` during boot cannot leave the class
-  half-mutated.
+  verifies the bridged class preserves the denial message — `args` must
+  survive exactly and the message must appear in `str()` (a fork `__str__`
+  that *formats* the preserved message is accepted; a message-eating
+  `__init__` that used to boot green and blank every denial, breaking
+  pickling too, is rejected) — and the `__bases__` unwind runs on
+  `BaseException`, so a fork `__init__` raising `SystemExit`/
+  `KeyboardInterrupt` during boot cannot leave the class half-mutated.
 
 ### Added
 
 - **`django_logic.background.in_flight(instance, process_name='process')`**
-  (#197) — a documented probe of the durable in-flight marker, for shaping
-  "busy, try again shortly" answers at consumer API seams without poking
-  engine internals or duplicating the marker filter. Racy by nature (the
-  engine's own guards stay authoritative), returns `False` when the
-  background app is not installed. The marker filter itself now lives in
-  exactly one place (`TransitionMessage.in_flight_for`) — the sync gate and
-  the Action failure path read through it, so the #184/#186 identity rework
-  will change it once.
+  (#197) — a documented probe for shaping "busy, try again shortly" answers
+  at consumer API seams without poking engine internals or duplicating the
+  marker filter. It answers the *busy* question: `True` only for a LIVE
+  uncompleted row (same classification as the gates), `False` for a
+  stranded one — so a consumer answering 409 on this probe and 400 on plain
+  `TransitionNotAllowed` stays consistent with what the engine raises. Racy
+  by nature (the engine's own guards stay authoritative); `False` when the
+  background app is not installed, without touching the database. The
+  engine's failure-path write-skip deliberately stays bare existence — an
+  Action must never clobber an uncompleted row's instance, stranded or not.
+  The marker filter itself now lives in exactly one place
+  (`TransitionMessage.in_flight_for`), so the #184/#186 identity rework will
+  change it once.
 
 ## [0.13.0] — 2026-08-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,62 @@
 
 ## [Unreleased]
 
+## [0.13.1] — 2026-08-10
+
+Five fixes from the 0.13.0 adoption review (raised by the gv consumer as
+#194–#197) plus #192, the sync analog the 0.13.0 review deliberately deferred.
+One is a 0.13.0 regression; the rest harden the release's new surfaces. Every
+fix is mutation-pinned: reverting it makes its tests fail.
+
+### Fixed
+
+- **Regression: `Action.fail_transition`'s in-flight probe was unguarded**
+  (#194, introduced in 0.13.0). The side-effect that brings the engine to the
+  failure path may have rollback-poisoned the connection (`ATOMIC_REQUESTS`,
+  any caller's `atomic`), in which case the probe itself raised
+  `TransactionManagementError` — replacing the original exception at the
+  caller and silently skipping both failure hook bundles. A probe failure now
+  logs, skips the `failed_state` write (unknown means don't write), and lets
+  the original exception re-raise with both hook bundles running.
+
+- **The sync gate's transient typing is bounded by the retry horizon**
+  (#195). An uncompleted `TransitionMessage` untouched for longer than
+  `max(RETRY_MINUTES × (MAX_ERRORS + 1), 15)` minutes is stranded, not busy —
+  a lost broker message with the safety-net beat tasks unscheduled leaves it
+  uncompleted forever, and 0.13.0's `TransitionTemporarilyUnavailable` then
+  told generic handlers to retry forever while hook-path logging sat demoted
+  at WARNING. A stale row now raises plain `TransitionNotAllowed` again (and
+  pages at ERROR), with the row's age and a pointer to `django_logic.W002` in
+  the message. A live row keeps the transient type.
+
+- **The sync `failed_state` writers get the #189 treatment** (#192). Both
+  sync savepoints — `Transition.fail_transition` and the Action's
+  write-under-lock — now pass `require_commit=True`, so a silently discarded
+  write (the receiver-authored suppressed-database-error idiom at the one
+  spot with no query after it) takes the honest except-branch instead of
+  logging a false `SET_STATE`. The original exception still re-raises
+  unchanged.
+
+- **The `LEGACY_EXCEPTION_BASE` smoke probe is airtight** (#196). It now
+  verifies the bridged class preserves the denial message (`args` and
+  `str()` survive the new MRO — a message-eating fork `__init__` used to boot
+  green and blank every denial, breaking pickling too), and the `__bases__`
+  unwind runs on `BaseException`, so a fork `__init__` raising
+  `SystemExit`/`KeyboardInterrupt` during boot cannot leave the class
+  half-mutated.
+
+### Added
+
+- **`django_logic.background.in_flight(instance, process_name='process')`**
+  (#197) — a documented probe of the durable in-flight marker, for shaping
+  "busy, try again shortly" answers at consumer API seams without poking
+  engine internals or duplicating the marker filter. Racy by nature (the
+  engine's own guards stay authoritative), returns `False` when the
+  background app is not installed. The marker filter itself now lives in
+  exactly one place (`TransitionMessage.in_flight_for`) — the sync gate and
+  the Action failure path read through it, so the #184/#186 identity rework
+  will change it once.
+
 ## [0.13.0] — 2026-08-04
 
 A small, deliberate release triaged from what the 0.12.0 review passes filed

--- a/README.md
+++ b/README.md
@@ -563,9 +563,11 @@ handler should answer them differently:
 from `django_logic.exceptions`): another flight owns the instance right now
 (`AlreadyInProgress`, or the sync gate while a **live** background row is
 uncompleted), or the state moved while phase 1 waited (`SourceStateChanged`).
-A row untouched past the retry horizon is stranded, not busy — the gate then
-raises the plain base again, so "retry shortly" is never a forever answer.
-Catch the transient type **ahead of** the base class:
+A row past its liveness window is stranded, not busy — both the sync gate and
+a background re-drive then raise the plain base again, so "retry shortly" is
+never a forever answer. (A running attempt inside its declared `timeout=`
+budget always counts as live.) Catch the transient type **ahead of** the base
+class:
 
 ```python
 from django_logic.exceptions import (
@@ -1069,7 +1071,7 @@ if in_flight(order, 'process'):
     return Response(status=409, data={'detail': 'Busy — please retry shortly.'})
 ```
 
-The read is racy — a flight can start or complete right after it — so use it for shaping answers, not as a pre-flight gate; the engine's own guards stay authoritative.
+The read is racy — a flight can start or complete right after it — so use it for shaping answers, not as a pre-flight gate; the engine's own guards stay authoritative. It answers the *busy* question: a stranded row (uncompleted but past the retry horizon) is `False`, matching the plain `TransitionNotAllowed` the engine's gates raise for it.
 
 Because the in-flight marker is a database row rather than a held lock, nothing leaks if the caller's surrounding transaction rolls back — the row, the `in_progress_state` write, and the dispatch all disappear together.
 

--- a/README.md
+++ b/README.md
@@ -561,9 +561,11 @@ handler should answer them differently:
 **Transient concurrency** — the action is fine, retry shortly. These raise
 `TransitionTemporarilyUnavailable` (a `TransitionNotAllowed` subclass, importable
 from `django_logic.exceptions`): another flight owns the instance right now
-(`AlreadyInProgress`, or the sync gate while a background row is uncompleted),
-or the state moved while phase 1 waited (`SourceStateChanged`). Catch it
-**ahead of** the base class:
+(`AlreadyInProgress`, or the sync gate while a **live** background row is
+uncompleted), or the state moved while phase 1 waited (`SourceStateChanged`).
+A row untouched past the retry horizon is stranded, not busy — the gate then
+raises the plain base again, so "retry shortly" is never a forever answer.
+Catch the transient type **ahead of** the base class:
 
 ```python
 from django_logic.exceptions import (
@@ -1057,6 +1059,17 @@ Two mechanisms serialize work on a state field, each with a precise scope:
    - synchronous `Action`s still run (they don't change state on success); a failing Action's `failed_state` write is skipped while the row is uncompleted, for the same ownership reason.
 
 The constraint is scoped **per process**: two independent state machines bound to different fields of the same model (say `status` and `payment_status`) can both have background work in flight.
+
+To shape answers at your own API seams ("busy, try again shortly"), read the marker through the documented probe instead of duplicating the filter:
+
+```python
+from django_logic.background import in_flight
+
+if in_flight(order, 'process'):
+    return Response(status=409, data={'detail': 'Busy — please retry shortly.'})
+```
+
+The read is racy — a flight can start or complete right after it — so use it for shaping answers, not as a pre-flight gate; the engine's own guards stay authoritative.
 
 Because the in-flight marker is a database row rather than a held lock, nothing leaks if the caller's surrounding transaction rolls back — the row, the `in_progress_state` write, and the dispatch all disappear together.
 

--- a/django_logic/background/__init__.py
+++ b/django_logic/background/__init__.py
@@ -7,6 +7,8 @@ Public API:
 * :func:`sync_execution` — context manager that forces the current block
   to run phase 2 inline (for tests, management commands, the shell).
 * :func:`retry_pending` — run the periodic safety-net task once inline.
+* :func:`in_flight` — racy read of the durable in-flight marker, for
+  shaping "busy, try again shortly" answers at API seams (#197).
 * :func:`beat_schedule` — ready-made Celery beat entries for the five
   safety-net tasks, routed to ``DJANGO_LOGIC['STARTER_QUEUE']``.
 
@@ -24,6 +26,7 @@ _PUBLIC = {
     'BackgroundAction': ('django_logic.background.transitions', 'BackgroundAction'),
     'sync_execution': ('django_logic.background.dispatch', 'sync_execution'),
     'retry_pending': ('django_logic.background.dispatch', 'retry_pending'),
+    'in_flight': ('django_logic.background.dispatch', 'in_flight'),
     'beat_schedule': ('django_logic.background.settings', 'beat_schedule'),
 }
 

--- a/django_logic/background/dispatch.py
+++ b/django_logic/background/dispatch.py
@@ -133,3 +133,25 @@ def retry_pending() -> int:
     """
     from django_logic.background.tasks import _retry_pending_inline
     return _retry_pending_inline()
+
+
+def in_flight(instance, process_name: str = 'process') -> bool:
+    """Whether a background transition is in flight for ``instance`` +
+    ``process_name`` — i.e. an uncompleted ``TransitionMessage`` exists
+    (#197).
+
+    For shaping answers at API seams ("busy, try again shortly"), NOT as a
+    pre-flight gate: the read is racy — a flight can start or complete
+    between this call and whatever the caller does next. The engine's own
+    guards (phase 1's unique constraint, the sync gate's under-lock check)
+    stay authoritative.
+
+    Returns ``False`` when ``django_logic.background`` is not installed.
+    """
+    from django.apps import apps
+
+    if not apps.is_installed('django_logic.background'):
+        return False
+    from django_logic.background.models import TransitionMessage
+
+    return TransitionMessage.in_flight_for(instance, process_name).exists()

--- a/django_logic/background/dispatch.py
+++ b/django_logic/background/dispatch.py
@@ -136,15 +136,22 @@ def retry_pending() -> int:
 
 
 def in_flight(instance, process_name: str = 'process') -> bool:
-    """Whether a background transition is in flight for ``instance`` +
-    ``process_name`` — i.e. an uncompleted ``TransitionMessage`` exists
-    (#197).
+    """Whether a background transition is LIVE for ``instance`` +
+    ``process_name`` (#197) — an uncompleted ``TransitionMessage`` exists
+    and is inside its liveness window.
 
     For shaping answers at API seams ("busy, try again shortly"), NOT as a
     pre-flight gate: the read is racy — a flight can start or complete
     between this call and whatever the caller does next. The engine's own
     guards (phase 1's unique constraint, the sync gate's under-lock check)
     stay authoritative.
+
+    A STRANDED row (past the retry horizon, #195) answers ``False``: it is
+    not "busy, retry shortly", and the engine's gates raise the plain
+    ``TransitionNotAllowed`` for it — so a consumer answering 409 on this
+    probe and 400 on the plain base stays consistent. The engine's own
+    failure-path write-skip deliberately uses bare existence instead —
+    it must never clobber an uncompleted row's instance, stranded or not.
 
     Returns ``False`` when ``django_logic.background`` is not installed.
     """
@@ -154,4 +161,7 @@ def in_flight(instance, process_name: str = 'process') -> bool:
         return False
     from django_logic.background.models import TransitionMessage
 
-    return TransitionMessage.in_flight_for(instance, process_name).exists()
+    return (
+        TransitionMessage.in_flight_liveness(instance, process_name)
+        == TransitionMessage.LIVENESS_LIVE
+    )

--- a/django_logic/background/models.py
+++ b/django_logic/background/models.py
@@ -14,6 +14,8 @@ flight.
 """
 from __future__ import annotations
 
+from datetime import timedelta
+
 from django.db import OperationalError, models, transaction
 from django.utils import timezone
 from model_utils.models import TimeStampedModel
@@ -167,6 +169,62 @@ class TransitionMessage(TimeStampedModel):
             process_name=process_name,
             is_completed=False,
         )
+
+    LIVENESS_LIVE = 'live'
+    LIVENESS_STRANDED = 'stranded'
+
+    #: Grace between an attempt exhausting its declared budget and the
+    #: watchdog abandoning it (which writes ``modified`` via record_error,
+    #: putting the row back on the horizon clock).
+    LIVENESS_SLACK = timedelta(minutes=5)
+
+    @classmethod
+    def in_flight_liveness(cls, instance, process_name: str):
+        """``None`` (no uncompleted row), ``LIVENESS_LIVE``, or
+        ``LIVENESS_STRANDED`` (#195) — one classification shared by the
+        sync gate, phase 1's constraint rejection, and ``in_flight()``, so
+        they can never disagree about the same row.
+
+        Liveness signals, in order:
+
+        * a running attempt inside its declared per-attempt budget
+          (``started_at + timeout_seconds`` plus slack) is LIVE — the
+          watchdog's own definition, so the gate cannot call an attempt
+          stranded while the watchdog still calls it live;
+        * otherwise a row whose newest activity (``modified``, refreshed at
+          attempt start / on every recorded error, or ``started_at``) is
+          within the retry horizon is LIVE;
+        * past the horizon it is STRANDED: nothing has driven it for longer
+          than the whole retry pipeline's span. This cannot distinguish a
+          truly lost row from a queue backlogged for that long — the
+          stranded message names both causes.
+        """
+        from django_logic.background import settings as bg_settings
+
+        row = (
+            cls.in_flight_for(instance, process_name)
+            .order_by('-modified')
+            .values('modified', 'started_at', 'timeout_seconds')
+            .first()
+        )
+        if row is None:
+            return None
+        now = timezone.now()
+        started, timeout = row['started_at'], row['timeout_seconds']
+        if (
+            started is not None and timeout is not None
+            and now < started + timedelta(seconds=timeout) + cls.LIVENESS_SLACK
+        ):
+            return cls.LIVENESS_LIVE
+        newest = max(t for t in (row['modified'], started) if t is not None)
+        # The whole retry pipeline's span plus slack, floored so short
+        # test/dev retry configs don't classify a fresh row as stale.
+        horizon = max(
+            bg_settings.retry_minutes() * (bg_settings.max_errors() + 1), 15,
+        )
+        if now - newest > timedelta(minutes=horizon):
+            return cls.LIVENESS_STRANDED
+        return cls.LIVENESS_LIVE
 
     @classmethod
     def stamp_attempt_started(cls, tm_id: int) -> bool:

--- a/django_logic/background/models.py
+++ b/django_logic/background/models.py
@@ -151,6 +151,24 @@ class TransitionMessage(TimeStampedModel):
         )
 
     @classmethod
+    def in_flight_for(cls, instance, process_name: str):
+        """The uncompleted rows for ``instance`` + ``process_name`` — the
+        durable in-flight marker (#197).
+
+        The ONE place the marker filter is written. The sync gate, the
+        Action failure path, and the public ``in_flight()`` probe all read
+        through it, so a future change to the marker's keying (the
+        #184/#186 identity rework) changes it exactly once.
+        """
+        return cls.objects.filter(
+            app_label=instance._meta.app_label,
+            model_name=instance._meta.model_name,
+            instance_id=str(instance.pk),
+            process_name=process_name,
+            is_completed=False,
+        )
+
+    @classmethod
     def stamp_attempt_started(cls, tm_id: int) -> bool:
         """Mark an attempt as beginning, in its own committed statement.
 

--- a/django_logic/background/runner.py
+++ b/django_logic/background/runner.py
@@ -459,6 +459,7 @@ def _finalize_terminal_from_watchdog(
         # loop. Opened on the instance's alias (set_state routes there) and
         # through _run_in_savepoint, so a rollback releases any deferred
         # unlock registered inside it instead of leaking it until TTL.
+        previous = state.get_state()
         try:
             # require_commit: the else-branch below logs the write as landed,
             # so a silently discarded savepoint must surface as the failure
@@ -469,6 +470,10 @@ def _finalize_terminal_from_watchdog(
                 require_commit=True,
             )
         except Exception as write_error:
+            # Restore the attribute a discarded savepoint left refreshed —
+            # the failure hooks below must not see a state the database
+            # never had.
+            setattr(state.instance, state.field_name, previous)
             transition_logger.error(
                 f'{source}: could not write failed_state='
                 f'{transition.failed_state!r} on {state.instance_key}: '
@@ -819,6 +824,7 @@ def _handle_failure(
     # re-drivable via the implicit source — a visible parked state rather
     # than an infinite loop.
     if transition.failed_state:
+        previous = state.get_state()
         try:
             # On the instance's alias, and via _run_in_savepoint: see the
             # attempt savepoint in _run_atomic for why both matter.
@@ -831,6 +837,10 @@ def _handle_failure(
                 require_commit=True,
             )
         except Exception as write_error:
+            # Restore the attribute a discarded savepoint left refreshed —
+            # the failure hooks below must not see a state the database
+            # never had.
+            setattr(state.instance, state.field_name, previous)
             transition_logger.error(
                 f'{kwargs.get("tr_id")} could not write failed_state '
                 f'{transition.failed_state!r} on {state.instance_key}: '

--- a/django_logic/background/transitions.py
+++ b/django_logic/background/transitions.py
@@ -152,7 +152,30 @@ class BackgroundTransition(Transition):
             # Same under-the-lock revalidation as the synchronous path:
             # the source check ran before the lock was acquired.
             self._ensure_db_state_in_sources(state)
-            tm = self._phase_one_atomic(state, kwargs, queue_name)
+            try:
+                tm = self._phase_one_atomic(state, kwargs, queue_name)
+            except AlreadyInProgress:
+                # Same liveness classification as the sync gate (#195): the
+                # constraint held by a STRANDED row is not "retry shortly" —
+                # that answer would be wrong forever, at WARNING. Queried
+                # here, after _phase_one_atomic's rolled-back atomic, so the
+                # connection is healthy; still under the cache lock. A row
+                # that completed in the window keeps AlreadyInProgress —
+                # it JUST finished, so retrying is exactly right.
+                if TransitionMessage.in_flight_liveness(
+                    state.instance, state.process_name,
+                ) == TransitionMessage.LIVENESS_STRANDED:
+                    raise TransitionNotAllowed(
+                        f"BackgroundTransition '{self.action_name}' is not "
+                        f"allowed: the in-flight marker for "
+                        f"{state.instance_key} is past the retry horizon — "
+                        f"stranded, not in flight. Likely causes: the "
+                        f"safety-net beat tasks are not scheduled "
+                        f"(django_logic.W002), a queue backlog or worker "
+                        f"outage longer than the horizon, or a lost broker "
+                        f"message. Re-drive or complete the row."
+                    )
+                raise
         finally:
             state.unlock()
             transition_logger.info(

--- a/django_logic/conf.py
+++ b/django_logic/conf.py
@@ -171,13 +171,32 @@ def install_legacy_exception_base() -> None:
     # DjangoLogicException defines __init__, so a legacy base with a
     # non-message signature would otherwise boot green and then replace
     # every denial with a TypeError at its raise site.
+    probe_msg = 'legacy-base constructor compatibility probe'
     try:
-        TransitionNotAllowed('legacy-base constructor compatibility probe')
-    except Exception as exc:
+        probe = TransitionNotAllowed(probe_msg)
+    except BaseException as exc:
+        # BaseException, not Exception (#196): a fork __init__ that raises
+        # SystemExit/KeyboardInterrupt during boot must not leave the class
+        # half-mutated. Unwind always; translate only Exception.
         TransitionNotAllowed.__bases__ = original_bases
+        if not isinstance(exc, Exception):
+            raise
         raise ImproperlyConfigured(
             f"DJANGO_LOGIC['LEGACY_EXCEPTION_BASE'] {path!r} breaks "
             f"TransitionNotAllowed('message') construction "
             f"({type(exc).__name__}: {exc}). The legacy base must accept a "
             f"single message argument, like a plain Exception subclass."
+        )
+    if probe.args != (probe_msg,) or str(probe) != probe_msg:
+        # A message-eating base (the `self.message = message;
+        # super().__init__()` idiom) blanks str() and args for every denial,
+        # and args=() breaks exception (un)pickling wherever celery/tblib
+        # serialize exception info (#196).
+        TransitionNotAllowed.__bases__ = original_bases
+        raise ImproperlyConfigured(
+            f"DJANGO_LOGIC['LEGACY_EXCEPTION_BASE'] {path!r} alters the "
+            f"denial message (args={probe.args!r}, str={str(probe)!r}). "
+            f"Denial text and exception pickling depend on args, so the "
+            f"legacy base must pass the message through to Exception like "
+            f"a plain Exception subclass."
         )

--- a/django_logic/conf.py
+++ b/django_logic/conf.py
@@ -187,11 +187,13 @@ def install_legacy_exception_base() -> None:
             f"({type(exc).__name__}: {exc}). The legacy base must accept a "
             f"single message argument, like a plain Exception subclass."
         )
-    if probe.args != (probe_msg,) or str(probe) != probe_msg:
+    if probe.args != (probe_msg,) or probe_msg not in str(probe):
         # A message-eating base (the `self.message = message;
         # super().__init__()` idiom) blanks str() and args for every denial,
         # and args=() breaks exception (un)pickling wherever celery/tblib
-        # serialize exception info (#196).
+        # serialize exception info (#196). `in`, not equality, for str(): a
+        # fork __str__ that FORMATS the preserved message (prefixes, codes)
+        # is a working bridge, not a broken one.
         TransitionNotAllowed.__bases__ = original_bases
         raise ImproperlyConfigured(
             f"DJANGO_LOGIC['LEGACY_EXCEPTION_BASE'] {path!r} alters the "

--- a/django_logic/exceptions.py
+++ b/django_logic/exceptions.py
@@ -14,10 +14,11 @@ class TransitionTemporarilyUnavailable(TransitionNotAllowed):
 
     Catch this AHEAD of ``TransitionNotAllowed`` to answer "busy" instead
     of "forbidden". Covers the background concurrency guards
-    (``AlreadyInProgress``, ``SourceStateChanged``) and the sync gate that
-    rejects a transition while an uncompleted ``TransitionMessage`` exists
-    — all three resolve when the in-flight work completes. Lock contention
-    ("State is locked") deliberately stays plain ``TransitionNotAllowed``:
-    a TTL-stuck lock is not "retry shortly", so widening this type to
-    cover it would be a documented, deliberate decision — not drift.
+    (``AlreadyInProgress``, ``SourceStateChanged``) and the sync gate while
+    the uncompleted ``TransitionMessage`` is LIVE — all of these resolve
+    when the in-flight work completes. A row untouched past the retry
+    horizon is stranded, not busy, and raises the plain base (#195): it
+    has no TTL, so "retry shortly" would be wrong forever. Lock contention
+    ("State is locked") stays plain ``TransitionNotAllowed`` for the same
+    reason: a TTL-stuck lock is not "retry shortly".
     """

--- a/django_logic/transition.py
+++ b/django_logic/transition.py
@@ -20,7 +20,6 @@ in ``django_logic.background.transitions`` (phase 1) and
 ``django_logic.background.runner`` (phase 2).
 """
 import math
-from datetime import timedelta
 from uuid import UUID
 
 from django.core.exceptions import ImproperlyConfigured
@@ -363,6 +362,7 @@ class Transition:
                 # docstring above promised "the original exception keeps
                 # propagating either way"; without this the write's own
                 # exception won and the real cause was lost.
+                previous = state.get_state()
                 try:
                     # The instance's alias, not DEFAULT: set_state routes its
                     # write with hints={'instance': ...}, so a savepoint opened
@@ -376,6 +376,11 @@ class Transition:
                         require_commit=True,
                     )
                 except Exception as write_error:
+                    # A silent rollback discards the write AFTER set_state
+                    # refreshed the attribute to the savepoint's uncommitted
+                    # value — restore it, or the failure hooks and the sync
+                    # caller observe a state the database never had.
+                    setattr(state.instance, state.field_name, previous)
                     transition_logger.error(
                         f'{kwargs.get("tr_id")} could not write failed_state '
                         f'{self.failed_state!r} on {state.instance_key}: '
@@ -462,10 +467,21 @@ class Transition:
         work (the cache lock only guards short critical sections). Only
         meaningful while holding the lock: phase 1 needs the lock to create
         a new row, so the answer cannot flip underneath the holder.
-        """
-        from django_logic.background.dispatch import in_flight
 
-        return in_flight(state.instance, state.process_name)
+        Bare existence, deliberately stricter than the public
+        ``in_flight()`` probe: the Action's write-skip must never clobber
+        an uncompleted row's instance, stranded or not — force-failing a
+        stranded row's instance is what the retired sweep used to do.
+        """
+        from django.apps import apps
+
+        if not apps.is_installed('django_logic.background'):
+            return False
+        from django_logic.background.models import TransitionMessage
+
+        return TransitionMessage.in_flight_for(
+            state.instance, state.process_name,
+        ).exists()
 
     def _ensure_no_background_in_flight(self, state: State) -> None:
         """Reject a state-changing transition while a background transition
@@ -477,46 +493,31 @@ class Transition:
 
         A LIVE row raises the transient type (#191): it clears when the
         flight completes, so "come back in a moment" is the right answer.
-        A row past the retry horizon is stranded, not busy (#195) — a lost
-        broker message with the safety-net beat tasks unscheduled leaves it
-        uncompleted forever, and "retry shortly" forever is the same wrong
-        answer the transient type exists to prevent. Stale rows raise the
-        plain base, so generic handlers refuse and hook-path logging stays
-        at ERROR — a stuck instance must page.
+        A STRANDED row raises the plain base (#195): nothing is driving it,
+        so "retry shortly" would be wrong forever, and hook-path logging
+        must stay at ERROR — a stuck instance pages. The classification
+        (``TransitionMessage.in_flight_liveness``) is shared with phase 1's
+        constraint rejection and the public probe.
         """
         from django.apps import apps
 
         if not apps.is_installed('django_logic.background'):
             return
-        from django.utils import timezone
-
-        from django_logic.background import settings as bg_settings
         from django_logic.background.models import TransitionMessage
 
-        newest = (
-            TransitionMessage.in_flight_for(state.instance, state.process_name)
-            .order_by('-modified')
-            .values_list('modified', flat=True)
-            .first()
-        )
-        if newest is None:
+        liveness = TransitionMessage.in_flight_liveness(
+            state.instance, state.process_name)
+        if liveness is None:
             return
-        # An actively-retried row's ``modified`` refreshes on every attempt,
-        # so age-since-modified only grows on a row nothing is driving. The
-        # horizon is the whole retry pipeline's span plus slack, floored so
-        # short test/dev retry configs don't classify a fresh row as stale.
-        horizon_minutes = max(
-            bg_settings.retry_minutes() * (bg_settings.max_errors() + 1), 15,
-        )
-        age = timezone.now() - newest
-        if age > timedelta(minutes=horizon_minutes):
+        if liveness == TransitionMessage.LIVENESS_STRANDED:
             raise TransitionNotAllowed(
                 f"Transition '{self.action_name}' is not allowed: a "
                 f"background transition for {state.instance_key} has an "
-                f"uncompleted TransitionMessage untouched for "
-                f"{int(age.total_seconds() // 60)} minutes — stranded, not "
-                f"in flight. Check that the safety-net beat tasks are "
-                f"scheduled (django_logic.W002), or complete the row."
+                f"uncompleted TransitionMessage past the retry horizon — "
+                f"stranded, not in flight. Likely causes: the safety-net "
+                f"beat tasks are not scheduled (django_logic.W002), a "
+                f"queue backlog or worker outage longer than the horizon, "
+                f"or a lost broker message. Re-drive or complete the row."
             )
         raise TransitionTemporarilyUnavailable(
             f"Transition '{self.action_name}' is not allowed right now: "
@@ -638,6 +639,7 @@ class Action(Transition):
                         # a rejected write must not replace the original
                         # side-effect exception on its way out, and must not
                         # log a SET_STATE line for a write that never landed.
+                        previous = state.get_state()
                         try:
                             # The instance's alias, not DEFAULT: set_state
                             # routes its write with hints={'instance': ...},
@@ -651,6 +653,11 @@ class Action(Transition):
                                 require_commit=True,
                             )
                         except Exception as write_error:
+                            # Restore the attribute a discarded savepoint
+                            # left refreshed — hooks must not see a state
+                            # the database never had.
+                            setattr(
+                                state.instance, state.field_name, previous)
                             transition_logger.error(
                                 f'{kwargs.get("tr_id")} Action '
                                 f'{self.action_name!r}: could not write '

--- a/django_logic/transition.py
+++ b/django_logic/transition.py
@@ -20,6 +20,7 @@ in ``django_logic.background.transitions`` (phase 1) and
 ``django_logic.background.runner`` (phase 2).
 """
 import math
+from datetime import timedelta
 from uuid import UUID
 
 from django.core.exceptions import ImproperlyConfigured
@@ -32,6 +33,7 @@ from django_logic.commands import (
     NextTransition,
     Permissions,
     SideEffects,
+    _run_in_savepoint,
     note_deferred_unlock,
 )
 from django_logic.exceptions import (
@@ -364,14 +366,15 @@ class Transition:
                 try:
                     # The instance's alias, not DEFAULT: set_state routes its
                     # write with hints={'instance': ...}, so a savepoint opened
-                    # on DEFAULT would guard the wrong connection — no
-                    # savepoint around the actual write, and a stray
-                    # BEGIN/RELEASE on a connection that was not doing
-                    # anything.
-                    with transaction.atomic(
-                        using=state.instance._state.db or DEFAULT_DB_ALIAS
-                    ):
-                        state.set_state(self.failed_state)
+                    # on DEFAULT would guard the wrong connection.
+                    # require_commit: the else-branch logs SET_STATE, so a
+                    # silently discarded savepoint must take the honest
+                    # except-path instead (#192, the sync analog of #189).
+                    _run_in_savepoint(
+                        state.instance._state.db or DEFAULT_DB_ALIAS,
+                        lambda: state.set_state(self.failed_state),
+                        require_commit=True,
+                    )
                 except Exception as write_error:
                     transition_logger.error(
                         f'{kwargs.get("tr_id")} could not write failed_state '
@@ -460,19 +463,9 @@ class Transition:
         meaningful while holding the lock: phase 1 needs the lock to create
         a new row, so the answer cannot flip underneath the holder.
         """
-        from django.apps import apps
+        from django_logic.background.dispatch import in_flight
 
-        if not apps.is_installed('django_logic.background'):
-            return False
-        from django_logic.background.models import TransitionMessage
-
-        return TransitionMessage.objects.filter(
-            app_label=state.instance._meta.app_label,
-            model_name=state.instance._meta.model_name,
-            instance_id=str(state.instance.pk),
-            process_name=state.process_name,
-            is_completed=False,
-        ).exists()
+        return in_flight(state.instance, state.process_name)
 
     def _ensure_no_background_in_flight(self, state: State) -> None:
         """Reject a state-changing transition while a background transition
@@ -480,17 +473,56 @@ class Transition:
 
         Without this gate a synchronous transition could interleave with
         phase 2 and the two would overwrite each other's state writes.
-        Checked under the lock, like the source revalidation. Raises the
-        transient type (#191): the row clears when the flight completes, so
-        "come back in a moment" is the correct answer, unlike a genuine
-        source/permission refusal.
+        Checked under the lock, like the source revalidation.
+
+        A LIVE row raises the transient type (#191): it clears when the
+        flight completes, so "come back in a moment" is the right answer.
+        A row past the retry horizon is stranded, not busy (#195) — a lost
+        broker message with the safety-net beat tasks unscheduled leaves it
+        uncompleted forever, and "retry shortly" forever is the same wrong
+        answer the transient type exists to prevent. Stale rows raise the
+        plain base, so generic handlers refuse and hook-path logging stays
+        at ERROR — a stuck instance must page.
         """
-        if self._background_in_flight(state):
-            raise TransitionTemporarilyUnavailable(
-                f"Transition '{self.action_name}' is not allowed right now: "
-                f"a background transition is in progress for "
-                f"{state.instance_key} (uncompleted TransitionMessage)."
+        from django.apps import apps
+
+        if not apps.is_installed('django_logic.background'):
+            return
+        from django.utils import timezone
+
+        from django_logic.background import settings as bg_settings
+        from django_logic.background.models import TransitionMessage
+
+        newest = (
+            TransitionMessage.in_flight_for(state.instance, state.process_name)
+            .order_by('-modified')
+            .values_list('modified', flat=True)
+            .first()
+        )
+        if newest is None:
+            return
+        # An actively-retried row's ``modified`` refreshes on every attempt,
+        # so age-since-modified only grows on a row nothing is driving. The
+        # horizon is the whole retry pipeline's span plus slack, floored so
+        # short test/dev retry configs don't classify a fresh row as stale.
+        horizon_minutes = max(
+            bg_settings.retry_minutes() * (bg_settings.max_errors() + 1), 15,
+        )
+        age = timezone.now() - newest
+        if age > timedelta(minutes=horizon_minutes):
+            raise TransitionNotAllowed(
+                f"Transition '{self.action_name}' is not allowed: a "
+                f"background transition for {state.instance_key} has an "
+                f"uncompleted TransitionMessage untouched for "
+                f"{int(age.total_seconds() // 60)} minutes — stranded, not "
+                f"in flight. Check that the safety-net beat tasks are "
+                f"scheduled (django_logic.W002), or complete the row."
             )
+        raise TransitionTemporarilyUnavailable(
+            f"Transition '{self.action_name}' is not allowed right now: "
+            f"a background transition is in progress for "
+            f"{state.instance_key} (uncompleted TransitionMessage)."
+        )
 
 
 class Action(Transition):
@@ -571,7 +603,28 @@ class Action(Transition):
                 )
                 wrote_state = False
                 try:
-                    if self._background_in_flight(state):
+                    # Probe guarded (#194): the side-effect that brought us
+                    # here may have rollback-poisoned the connection (or the
+                    # database may be down), in which case the probe itself
+                    # raises. Escaping here replaced the original exception
+                    # with the probe's and skipped both failure hook bundles
+                    # — breaking this method's own contract. Unknown means
+                    # do not write.
+                    try:
+                        in_flight = self._background_in_flight(state)
+                    except Exception as probe_error:
+                        in_flight = None
+                        transition_logger.error(
+                            f'{kwargs.get("tr_id")} Action '
+                            f'{self.action_name!r}: could not probe for an '
+                            f'in-flight background transition on '
+                            f'{state.instance_key}: '
+                            f'{type(probe_error).__name__}: {probe_error}. '
+                            f'Skipping the failed_state write; the original '
+                            f'failure is re-raised unchanged.',
+                            exc_info=True,
+                        )
+                    if in_flight:
                         transition_logger.error(
                             f'{kwargs.get("tr_id")} Action '
                             f'{self.action_name!r}: skipping failed_state='
@@ -580,7 +633,7 @@ class Action(Transition):
                             f'{state.instance_key} until its flight '
                             f'completes.'
                         )
-                    else:
+                    elif in_flight is not None:
                         # Savepointed like Transition.fail_transition (#178):
                         # a rejected write must not replace the original
                         # side-effect exception on its way out, and must not
@@ -588,15 +641,15 @@ class Action(Transition):
                         try:
                             # The instance's alias, not DEFAULT: set_state
                             # routes its write with hints={'instance': ...},
-                            # so a savepoint opened on DEFAULT would guard the
-                            # wrong connection — no savepoint around the
-                            # actual write, and a stray BEGIN/RELEASE on a
-                            # connection that was not doing anything.
-                            with transaction.atomic(
-                                using=state.instance._state.db
-                                or DEFAULT_DB_ALIAS
-                            ):
-                                state.set_state(self.failed_state)
+                            # so a savepoint opened on DEFAULT would guard
+                            # the wrong connection. require_commit: a
+                            # silently discarded savepoint must take the
+                            # honest except-path (#192).
+                            _run_in_savepoint(
+                                state.instance._state.db or DEFAULT_DB_ALIAS,
+                                lambda: state.set_state(self.failed_state),
+                                require_commit=True,
+                            )
                         except Exception as write_error:
                             transition_logger.error(
                                 f'{kwargs.get("tr_id")} Action '

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-logic"
-version = "0.13.0"
+version = "0.13.1"
 description = "Declarative business logic & state machines for Django — sync and durable background transitions"
 readme = "README.md"
 license = { text = "MIT License" }

--- a/tests/background/test_sync_background_mutex.py
+++ b/tests/background/test_sync_background_mutex.py
@@ -21,11 +21,15 @@ instance + process must never interleave:
   uncompleted row exists, phase 2 owns the state field, so the write is
   skipped (#185 review).
 """
+from datetime import timedelta
+
 from django.core.cache import cache
+from django.db import IntegrityError
 from django.test import TestCase, TransactionTestCase, override_settings
+from django.utils import timezone
 
 from django_logic import Action
-from django_logic.background.dispatch import sync_execution
+from django_logic.background.dispatch import in_flight, sync_execution
 from django_logic.background.exceptions import AlreadyInProgress, SourceStateChanged
 from django_logic.background.models import TransitionMessage
 from django_logic.exceptions import (
@@ -129,6 +133,77 @@ class SyncTransitionGatedByTransitionMessageTests(TestCase):
         with self.assertRaises(TransitionTemporarilyUnavailable):
             self.widget.process.cancel()
 
+    def test_stale_uncompleted_tm_is_not_transient(self):
+        # A row untouched past the retry horizon is stranded, not busy
+        # (#195): "retry shortly" would be wrong forever, and the WARNING
+        # demotion would stop a stuck instance from paging. The plain base
+        # keeps generic handlers refusing and hook logging at ERROR.
+        tm = _make_tm(self.widget)
+        TransitionMessage.objects.filter(pk=tm.pk).update(
+            modified=timezone.now() - timedelta(hours=2))
+
+        with self.assertRaises(TransitionNotAllowed) as ctx:
+            self.widget.process.cancel()
+
+        self.assertNotIsInstance(
+            ctx.exception, TransitionTemporarilyUnavailable)
+        self.assertIn('stranded', str(ctx.exception))
+        # The refusal path must still release the lock.
+        self.assertFalse(State(self.widget, 'status', 'process').is_locked())
+
+    def test_public_in_flight_probe_reads_the_marker(self):
+        # #197: the documented probe for consumer API seams. One shared
+        # queryset (TransitionMessage.in_flight_for) backs this, the sync
+        # gate, and the Action failure path.
+        self.assertFalse(in_flight(self.widget, 'process'))
+
+        tm = _make_tm(self.widget)
+        self.assertTrue(in_flight(self.widget, 'process'))
+        # Default process_name is 'process'.
+        self.assertTrue(in_flight(self.widget))
+        # Scoped per process, and completed rows do not count.
+        self.assertFalse(in_flight(self.widget, 'other_process'))
+        TransitionMessage.objects.filter(pk=tm.pk).update(is_completed=True)
+        self.assertFalse(in_flight(self.widget, 'process'))
+
+    def test_probe_failure_keeps_the_original_exception_and_runs_hooks(self):
+        # #194: the side-effect that brought us to fail_transition may have
+        # rollback-poisoned the connection, so the in-flight probe itself
+        # raises TransactionManagementError. That error must not replace
+        # the original one, and both failure hook bundles must still run.
+        widget = Widget.objects.create()
+        hooks = []
+
+        def poison_then_fail(instance, **kwargs):
+            # IntegrityError propagates AND marks needs_rollback — the
+            # receiver-free version of the poisoned-connection shape.
+            Widget.objects.create(pk=instance.pk)
+
+        def record_fse(instance, exception, **kwargs):
+            hooks.append('failure_side_effects')
+
+        def record_fcb(instance, exception, **kwargs):
+            hooks.append('failure_callbacks')
+
+        action = Action(
+            'poke_fail', sources=['draft'], failed_state='poke_failed',
+            side_effects=[poison_then_fail],
+            failure_side_effects=[record_fse],
+            failure_callbacks=[record_fcb],
+        )
+        state = State(widget, 'status', 'process')
+
+        with self.assertLogs('django-logic.transition', level='ERROR') as logs:
+            with self.assertRaises(IntegrityError):
+                # SideEffects.execute routes the failure into
+                # fail_transition itself before re-raising.
+                action.change_state(state)
+
+        self.assertEqual(
+            hooks, ['failure_side_effects', 'failure_callbacks'])
+        self.assertFalse(state.is_locked())
+        self.assertIn('could not probe', '\n'.join(logs.output))
+
     def test_failing_action_skips_failed_state_write_while_tm_in_flight(self):
         # D2 (h): the cache lock is free for the whole queued/phase-2 span,
         # so the Action's atomic acquire succeeds — but the uncompleted row
@@ -147,11 +222,9 @@ class SyncTransitionGatedByTransitionMessageTests(TestCase):
 
         with self.assertLogs('django-logic.transition', level='ERROR') as logs:
             with self.assertRaises(ValueError):
-                try:
-                    action.change_state(state)
-                except Exception as exc:
-                    action.fail_transition(state, exc)
-                    raise
+                # SideEffects.execute routes the failure into
+                # fail_transition itself before re-raising.
+                action.change_state(state)
 
         self.widget.refresh_from_db()
         self.assertEqual(self.widget.status, 'draft')  # write skipped

--- a/tests/background/test_sync_background_mutex.py
+++ b/tests/background/test_sync_background_mutex.py
@@ -25,7 +25,12 @@ from datetime import timedelta
 
 from django.core.cache import cache
 from django.db import IntegrityError
-from django.test import TestCase, TransactionTestCase, override_settings
+from django.test import (
+    TestCase,
+    TransactionTestCase,
+    modify_settings,
+    override_settings,
+)
 from django.utils import timezone
 
 from django_logic import Action
@@ -151,6 +156,104 @@ class SyncTransitionGatedByTransitionMessageTests(TestCase):
         # The refusal path must still release the lock.
         self.assertFalse(State(self.widget, 'status', 'process').is_locked())
 
+    def test_running_attempt_inside_its_declared_budget_is_live(self):
+        # The watchdog's own liveness definition: an attempt inside
+        # started_at + timeout_seconds is live, however old `modified` is.
+        # Without this signal a healthy 40-minute attempt read as
+        # "stranded" at minute 16 (review of #195).
+        tm = _make_tm(self.widget)
+        TransitionMessage.objects.filter(pk=tm.pk).update(
+            modified=timezone.now() - timedelta(minutes=16),
+            started_at=timezone.now() - timedelta(minutes=16),
+            timeout_seconds=3600,
+        )
+
+        with self.assertRaises(TransitionTemporarilyUnavailable):
+            self.widget.process.cancel()
+
+    def test_attempt_past_its_budget_and_horizon_is_stranded(self):
+        # Budget exhausted AND nothing recorded since: the watchdog would
+        # have abandoned it — the horizon clock applies again.
+        tm = _make_tm(self.widget)
+        TransitionMessage.objects.filter(pk=tm.pk).update(
+            modified=timezone.now() - timedelta(hours=2),
+            started_at=timezone.now() - timedelta(hours=2),
+            timeout_seconds=60,
+        )
+
+        with self.assertRaises(TransitionNotAllowed) as ctx:
+            self.widget.process.cancel()
+        self.assertNotIsInstance(
+            ctx.exception, TransitionTemporarilyUnavailable)
+
+    def test_horizon_floor_keeps_short_retry_configs_transient(self):
+        # Suite settings give RETRY_MINUTES=2, MAX_ERRORS=3 → formula 8,
+        # floor 15. A 10-minute-old row sits between the two: only the
+        # floor keeps it transient.
+        tm = _make_tm(self.widget)
+        TransitionMessage.objects.filter(pk=tm.pk).update(
+            modified=timezone.now() - timedelta(minutes=10))
+
+        with self.assertRaises(TransitionTemporarilyUnavailable):
+            self.widget.process.cancel()
+
+    @override_settings(DJANGO_LOGIC=dl_settings(
+        TRANSITION_MESSAGE_MAX_ERRORS=2,
+        TRANSITION_MESSAGE_RETRY_MINUTES=20,
+    ))
+    def test_horizon_scales_with_the_retry_pipeline(self):
+        # RETRY_MINUTES=20, MAX_ERRORS=2 → horizon 60. A 30-minute-old row
+        # is still inside the pipeline's span: transient, not stranded.
+        # Kills a hardcoded-15 horizon.
+        tm = _make_tm(self.widget)
+        TransitionMessage.objects.filter(pk=tm.pk).update(
+            modified=timezone.now() - timedelta(minutes=30))
+
+        with self.assertRaises(TransitionTemporarilyUnavailable):
+            self.widget.process.cancel()
+
+    def test_stranded_row_reclassifies_the_background_rejection_too(self):
+        # Phase 1's constraint rejection shares the classification (#195
+        # review): re-driving the SAME background transition was the most
+        # likely consumer retry, and it kept answering AlreadyInProgress
+        # ("retry shortly", WARNING) forever on a stranded row.
+        tm = _make_tm(self.widget, process_name='process')
+        TransitionMessage.objects.filter(pk=tm.pk).update(
+            modified=timezone.now() - timedelta(hours=2))
+
+        with self.assertRaises(TransitionNotAllowed) as ctx:
+            with sync_execution():
+                self.widget.process.fulfil()
+
+        self.assertNotIsInstance(
+            ctx.exception, TransitionTemporarilyUnavailable)
+        self.assertIn('stranded', str(ctx.exception))
+        # No second row was created, and the lock was released.
+        self.assertEqual(TransitionMessage.objects.count(), 1)
+        self.assertFalse(State(self.widget, 'status', 'process').is_locked())
+
+    def test_live_row_still_rejects_background_redrive_as_transient(self):
+        # Control for the reclassification: a live row keeps
+        # AlreadyInProgress.
+        _make_tm(self.widget, process_name='process')
+
+        with self.assertRaises(AlreadyInProgress):
+            with sync_execution():
+                self.widget.process.fulfil()
+
+    @modify_settings(INSTALLED_APPS={'remove': 'django_logic.background'})
+    def test_probe_and_gate_answer_not_installed_with_no_query(self):
+        # The documented sync-only contract (#197): with the background app
+        # absent, in_flight() answers False — even though the row exists in
+        # the table — and the sync gate lets the transition through.
+        _make_tm(self.widget)
+
+        with self.assertNumQueries(0):
+            self.assertFalse(in_flight(self.widget, 'process'))
+        self.widget.process.cancel()
+        self.widget.refresh_from_db()
+        self.assertEqual(self.widget.status, 'cancelled')
+
     def test_public_in_flight_probe_reads_the_marker(self):
         # #197: the documented probe for consumer API seams. One shared
         # queryset (TransitionMessage.in_flight_for) backs this, the sync
@@ -164,6 +267,16 @@ class SyncTransitionGatedByTransitionMessageTests(TestCase):
         # Scoped per process, and completed rows do not count.
         self.assertFalse(in_flight(self.widget, 'other_process'))
         TransitionMessage.objects.filter(pk=tm.pk).update(is_completed=True)
+        self.assertFalse(in_flight(self.widget, 'process'))
+
+    def test_public_probe_answers_false_for_a_stranded_row(self):
+        # The probe shapes 409 "retry shortly" answers, so it shares the
+        # gate's liveness classification: a stranded row is not busy, and
+        # answering "busy" from it would be the forever-retry #195 removed.
+        tm = _make_tm(self.widget)
+        TransitionMessage.objects.filter(pk=tm.pk).update(
+            modified=timezone.now() - timedelta(hours=2))
+
         self.assertFalse(in_flight(self.widget, 'process'))
 
     def test_probe_failure_keeps_the_original_exception_and_runs_hooks(self):

--- a/tests/test_legacy_exception_base.py
+++ b/tests/test_legacy_exception_base.py
@@ -56,6 +56,24 @@ class ArgfulLegacyBase(Exception):
         super().__init__(f'{code}: {message}')
 
 
+class MessageEatingLegacyBase(Exception):
+    """The common fork idiom that constructs fine but blanks ``str(exc)``
+    and ``args`` for every denial — and ``args=()`` breaks exception
+    (un)pickling wherever celery/tblib serialize exception info (#196)."""
+
+    def __init__(self, message):
+        self.message = message
+        super().__init__()
+
+
+class SystemExitingLegacyBase(Exception):
+    """A fork ``__init__`` that raises a BaseException during boot. The
+    installer's unwind must still run (#196)."""
+
+    def __init__(self, *args):
+        raise SystemExit(3)
+
+
 NOT_A_CLASS = object()
 
 LEGACY_PATH = 'tests.test_legacy_exception_base.LegacyTransitionNotAllowed'
@@ -144,6 +162,26 @@ class BridgeRejectionTests(_BasesCleanup, SimpleTestCase):
             'tests.test_legacy_exception_base.ArgfulLegacyBase')
         # The probe unwound the mutation, so denials still construct.
         TransitionNotAllowed('still constructible')
+
+    def test_message_eating_base_rejected_and_rolled_back(self):
+        self.assert_install_rejected(
+            'tests.test_legacy_exception_base.MessageEatingLegacyBase')
+        # Denial messages still work after the unwind.
+        self.assertEqual(str(TransitionNotAllowed('kept')), 'kept')
+
+    def test_base_exception_during_probe_still_unwinds(self):
+        with override_settings(DJANGO_LOGIC=_conf(
+            LEGACY_EXCEPTION_BASE=(
+                'tests.test_legacy_exception_base.SystemExitingLegacyBase'),
+        )):
+            # Not translated to ImproperlyConfigured — SystemExit must
+            # propagate as itself — but the class must not stay
+            # half-mutated.
+            with self.assertRaises(SystemExit):
+                install_legacy_exception_base()
+        self.assertEqual(TransitionNotAllowed.__bases__, self._saved_bases)
+        probe = TransitionNotAllowed('kept')
+        self.assertEqual(probe.args, ('kept',))
 
     def test_non_str_values_rejected_at_boot(self):
         for bad in (123, True, [LEGACY_PATH], b'legacy', ''):

--- a/tests/test_legacy_exception_base.py
+++ b/tests/test_legacy_exception_base.py
@@ -74,6 +74,14 @@ class SystemExitingLegacyBase(Exception):
         raise SystemExit(3)
 
 
+class FormattingStrLegacyBase(Exception):
+    """A fork base that FORMATS the message but preserves ``args`` — a
+    working bridge the probe must accept (#196 review)."""
+
+    def __str__(self):
+        return f'TransitionError: {self.args[0] if self.args else ""}'
+
+
 NOT_A_CLASS = object()
 
 LEGACY_PATH = 'tests.test_legacy_exception_base.LegacyTransitionNotAllowed'
@@ -168,6 +176,21 @@ class BridgeRejectionTests(_BasesCleanup, SimpleTestCase):
             'tests.test_legacy_exception_base.MessageEatingLegacyBase')
         # Denial messages still work after the unwind.
         self.assertEqual(str(TransitionNotAllowed('kept')), 'kept')
+
+    def test_formatting_str_base_is_accepted(self):
+        # args survive and the message is IN str() — a formatting __str__
+        # is a working bridge, not a broken one; the probe must not
+        # boot-reject it.
+        with override_settings(DJANGO_LOGIC=_conf(
+            LEGACY_EXCEPTION_BASE=(
+                'tests.test_legacy_exception_base.FormattingStrLegacyBase'),
+        )):
+            install_legacy_exception_base()
+        self.assertTrue(
+            issubclass(TransitionNotAllowed, FormattingStrLegacyBase))
+        denial = TransitionNotAllowed('denied')
+        self.assertEqual(denial.args, ('denied',))
+        self.assertIn('denied', str(denial))
 
     def test_base_exception_during_probe_still_unwinds(self):
         with override_settings(DJANGO_LOGIC=_conf(

--- a/tests/test_silent_rollback_accounting.py
+++ b/tests/test_silent_rollback_accounting.py
@@ -18,7 +18,7 @@ from django.db import IntegrityError, transaction
 from django.db.models.signals import post_init
 from django.test import TestCase, override_settings
 
-from django_logic import Process, ProcessManager
+from django_logic import Action, Process, ProcessManager, Transition
 from django_logic.background import BackgroundAction, BackgroundTransition
 from django_logic.background.models import TransitionMessage
 from django_logic.commands import _SilentRollback
@@ -294,6 +294,97 @@ class FseCorrectlyNestedIsUntouchedTests(_Base):
         self.assertEqual(inv.status, 'failed')
         self.assertTrue(inv.customer_received)  # the cleanup committed
         self.assertEqual(tm.failure_side_effect_error, '')
+
+
+class SyncFailPoisonProcess(Process):
+    process_name = 'sync_fail_poison_proc'
+    transitions = [
+        Transition('go', sources=['draft'], target='done',
+                   failed_state='failed', side_effects=[_fail_attempt]),
+    ]
+
+
+class ActionWritePoisonProcess(Process):
+    process_name = 'action_write_poison_proc'
+    transitions = [
+        Action('go', sources=['draft'], failed_state='failed',
+               side_effects=[_fail_attempt]),
+    ]
+
+
+class _SyncPoisonBase(_Base):
+    """The #192 shape: the sync failure paths' ``failed_state`` savepoints
+    must not log a false SET_STATE when a receiver silently discards them
+    (the sync analog of #189; same ``post_init`` receiver spot)."""
+
+    def setUp(self):
+        super().setUp()
+        post_init.connect(
+            _suppress_db_error_on_failed_materialization, sender=Invoice)
+        self.addCleanup(
+            post_init.disconnect,
+            _suppress_db_error_on_failed_materialization, sender=Invoice)
+
+    def assert_discarded_write_reported(self, drive):
+        inv = Invoice.objects.create(status='draft')
+
+        with self.assertLogs('django-logic.transition', level='INFO') as logs:
+            with self.assertRaises(ValueError):
+                drive(inv)
+
+        inv.refresh_from_db()
+        # The write really was discarded — the instance stays at its source.
+        self.assertEqual(inv.status, 'draft')
+        output = '\n'.join(logs.output)
+        self.assertIn('could not write failed_state', output)
+        self.assertNotIn('Set State failed', output)
+
+
+@override_settings(DJANGO_LOGIC=_SYNC)
+class SyncTransitionWritePoisonedTests(_SyncPoisonBase):
+    process = SyncFailPoisonProcess
+
+    def test_discarded_write_is_reported_not_logged_as_landed(self):
+        self.assert_discarded_write_reported(
+            lambda inv: inv.sync_fail_poison_proc.go())
+
+
+@override_settings(DJANGO_LOGIC=_SYNC)
+class SyncActionWritePoisonedTests(_SyncPoisonBase):
+    process = ActionWritePoisonProcess
+
+    def test_discarded_write_is_reported_not_logged_as_landed(self):
+        self.assert_discarded_write_reported(
+            lambda inv: inv.action_write_poison_proc.go())
+
+
+@override_settings(DJANGO_LOGIC=_SYNC)
+class SyncTransitionWriteCorrectlyNestedTests(_Base):
+    """Control: the nested-atomic idiom in the same receiver spot must
+    leave both sync writers untouched — no over-firing."""
+
+    process = SyncFailPoisonProcess
+
+    def setUp(self):
+        super().setUp()
+        post_init.connect(
+            _suppress_db_error_correctly_on_failed_materialization,
+            sender=Invoice)
+        self.addCleanup(
+            post_init.disconnect,
+            _suppress_db_error_correctly_on_failed_materialization,
+            sender=Invoice)
+
+    def test_the_write_lands_and_set_state_is_logged(self):
+        inv = Invoice.objects.create(status='draft')
+
+        with self.assertLogs('django-logic.transition', level='INFO') as logs:
+            with self.assertRaises(ValueError):
+                inv.sync_fail_poison_proc.go()
+
+        inv.refresh_from_db()
+        self.assertEqual(inv.status, 'failed')
+        self.assertIn('Set State failed', '\n'.join(logs.output))
 
 
 @override_settings(DJANGO_LOGIC={**_SYNC, 'TRANSITION_MESSAGE_MAX_ERRORS': 1})

--- a/tests/test_silent_rollback_accounting.py
+++ b/tests/test_silent_rollback_accounting.py
@@ -181,6 +181,13 @@ def _suppress_db_error_correctly_on_failed_materialization(
         pass
 
 
+FSE_SAW: list = []
+
+
+def _record_fse_observed_status(instance, **kwargs):
+    FSE_SAW.append(instance.status)
+
+
 class TerminalWritePoisonProcess(Process):
     process_name = 'terminal_write_poison_proc'
     transitions = [
@@ -188,6 +195,7 @@ class TerminalWritePoisonProcess(Process):
             'sync_out', sources=['draft'], target='done',
             in_progress_state='syncing', failed_state='failed',
             side_effects=[_fail_attempt],
+            failure_side_effects=[_record_fse_observed_status],
             callbacks=[_record_callback],
         ),
     ]
@@ -209,6 +217,8 @@ class TerminalFailedStateWritePoisonedTests(_Base):
             _suppress_db_error_on_failed_materialization, sender=Invoice)
 
     def test_discarded_write_is_reported_not_logged_as_landed(self):
+        FSE_SAW.clear()
+        self.addCleanup(FSE_SAW.clear)
         inv = Invoice.objects.create(status='draft')
 
         with self.assertLogs('django-logic.transition', level='INFO') as logs:
@@ -221,6 +231,9 @@ class TerminalFailedStateWritePoisonedTests(_Base):
         self.assertTrue(tm.is_completed)
         # The proof the write was discarded: the instance stays parked.
         self.assertEqual(inv.status, 'syncing')
+        # The failure hooks saw the restored state, not the phantom value
+        # the discarded savepoint left on the in-memory instance.
+        self.assertEqual(FSE_SAW, ['syncing'])
         # …and both problems are visible where an operator looks.
         self.assertIn('failed_state write', tm.failure_side_effect_error)
         self.assertIn('boom', tm.last_error_message)
@@ -332,6 +345,10 @@ class _SyncPoisonBase(_Base):
             with self.assertRaises(ValueError):
                 drive(inv)
 
+        # BEFORE the refresh: the in-memory attribute must not hold the
+        # discarded value — the failure hooks and the sync caller read it,
+        # and a phantom 'failed' here is a state the database never had.
+        self.assertEqual(inv.status, 'draft')
         inv.refresh_from_db()
         # The write really was discarded — the instance stays at its source.
         self.assertEqual(inv.status, 'draft')


### PR DESCRIPTION
## 0.13.1 — hardening the 0.13.0 surfaces

Scope agreed in triage: the four issues from the 0.13.0 adoption review plus the deferred sync analog.

### What ships

- **#194 (regression fix, closes #194):** `Action.fail_transition` guards its in-flight probe — a rollback-poisoned connection no longer replaces the original exception or skips the failure hooks.
- **#195 (closes #195):** one shared liveness classification (`TransitionMessage.in_flight_liveness`) bounds the transient typing at **both** entry points (sync gate + phase 1's constraint rejection). It reads the watchdog's own signals first, so a declared-budget attempt is never called stranded mid-run. Stranded rows raise the plain base and page at ERROR.
- **#192 (closes #192):** both sync `failed_state` savepoints pass `require_commit=True`; all four terminal writers also restore the in-memory attribute a discarded savepoint leaves refreshed — hooks never observe a state the database never had.
- **#196 (closes #196):** the `LEGACY_EXCEPTION_BASE` probe verifies message preservation (`args` exact, message in `str()` — formatting `__str__` accepted) and unwinds on `BaseException`.
- **#197 (closes #197):** public `django_logic.background.in_flight()` probe answering the *busy* question (live rows only); the marker filter lives in exactly one place for the future #184/#186 rework.

### Process

Per-issue implementation with mutation-verified pins, then an adversarial review of this diff which confirmed nine gaps in the first cut — all fixed and pinned (13 mutants killed in total). Suite: 606 → 623 tests, green; metadata drift check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect core transition failure paths, sync/background mutex behavior, and exception typing at API boundaries—high impact areas but narrowly scoped fixes with extensive tests.
> 
> **Overview**
> **Release 0.13.1** tightens background concurrency semantics and failure-path honesty without changing the public API shape beyond one new helper.
> 
> **Liveness (#195)** adds `TransitionMessage.in_flight_for` / `in_flight_liveness` so sync gates, background phase-1 `AlreadyInProgress`, and docs agree: only **live** uncompleted rows raise `TransitionTemporarilyUnavailable`; **stranded** rows (past retry horizon, with watchdog budget + slack considered) raise plain `TransitionNotAllowed` with actionable causes.
> 
> **Public probe (#197)** exposes `django_logic.background.in_flight()` for API-layer 409 vs 400, matching that classification; internal Action write-skip still uses bare row existence.
> 
> **Regression (#194)** wraps `Action.fail_transition`'s in-flight probe so a poisoned DB connection cannot replace the original exception or skip failure hooks.
> 
> **Sync failed_state (#192)** routes `Transition`/`Action` failure writes through `_run_in_savepoint(..., require_commit=True)` and restores in-memory state when the savepoint is discarded (aligned with background #189).
> 
> **Boot (#196)** strengthens `LEGACY_EXCEPTION_BASE` probes for message/`args` preservation and unwinds on `BaseException` during smoke construction.
> 
> Version bumps to **0.13.1**; README/CHANGELOG and broad mutation-pinned tests cover the above.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a147f6c72ed9ef370297654acb2082cca747add. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->