### PR TITLE
Rewrite names, comments, and exceptions in plain English

### DIFF
--- a/.cursor/rules/readable-names-and-comments.mdc
+++ b/.cursor/rules/readable-names-and-comments.mdc
@@ -1,0 +1,44 @@
+---
+description: Plain English for names, comments, and exceptions. Do not copy the repo's old private dialect.
+alwaysApply: true
+---
+
+# Plain English
+
+Write as you would to a colleague. Short sentences. One meaning per word. No metaphors.
+
+Existing comments in this repo are often a private dialect (`phase 1`, `liveness`, `#195`). Do not copy them. Rewrite what you touch.
+
+## Allowed words
+
+transition, background transition, `TransitionMessage`, source state, retry window, stranded (nothing is retrying it), enqueue (save the row and send it), execute (the worker runs the side-effects), uncompleted, in progress.
+
+## Banned
+
+`tm`, `msg`, `inst`, `bg`, `phase 1`, `phase 2`, `liveness`, `retry horizon`, `re-drive`, `in-flight marker`, `speculative-insert`, `owning process`, `finishing flight`, `#123`, `issue #N`, `W002` in exceptions.
+
+Ticket numbers belong in `CHANGELOG.md` only.
+
+## Names
+
+```python
+# BAD
+tm = self._phase_one_atomic(state, kwargs, queue_name)
+
+# GOOD
+transition_message = self._enqueue_atomic(state, kwargs, queue_name)
+```
+
+Use full words. Type names (`State`, `TransitionMessage`) and Python conventions (`self`, `kwargs`, `exc`) are fine.
+
+## Comments and exceptions
+
+```python
+# BAD
+# Same liveness classification as the sync gate (#195).
+
+# GOOD
+# Nothing is retrying this row, so "try again shortly" would be wrong forever.
+```
+
+If you would not say it out loud, rewrite it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,15 @@
 
 - **Comments, exception text, and a handful of internal names** now use
   ordinary English. Enqueue vs execute, not phase 1 / phase 2. Ticket
-  numbers stay in this changelog, not in `.py` comments. Public APIs
-  that already made sense are unchanged (`BackgroundTransition`,
-  `TransitionMessage`, `in_progress_state`, `in_flight()`).
-  `TransitionMessage.retry_status()` replaces `in_flight_liveness()`;
-  `RETRYING` / `STRANDED` / `RETRY_SLACK` replace `LIVENESS_*`.
-  `_enqueue_atomic` replaces `_phase_one_atomic`. Stranded-row
-  exceptions no longer mention `W002`, `retry horizon`, or `re-drive`.
+  numbers stay in this changelog, not in `.py` comments. The README,
+  testing guide, logger notes, and nested-process recipe use the same
+  words. Public APIs that already made sense are unchanged
+  (`BackgroundTransition`, `TransitionMessage`, `in_progress_state`,
+  `in_flight()`). `TransitionMessage.retry_status()` replaces
+  `in_flight_liveness()`; `RETRYING` / `STRANDED` / `RETRY_SLACK`
+  replace `LIVENESS_*`. `_enqueue_atomic` replaces `_phase_one_atomic`.
+  Stranded-row exceptions no longer mention `W002`, `retry horizon`,
+  or `re-drive`.
 
 ## [0.13.1] — 2026-08-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **Comments, exception text, and a handful of internal names** now use
+  ordinary English. Enqueue vs execute, not phase 1 / phase 2. Ticket
+  numbers stay in this changelog, not in `.py` comments. Public APIs
+  that already made sense are unchanged (`BackgroundTransition`,
+  `TransitionMessage`, `in_progress_state`, `in_flight()`).
+  `TransitionMessage.retry_status()` replaces `in_flight_liveness()`;
+  `RETRYING` / `STRANDED` / `RETRY_SLACK` replace `LIVENESS_*`.
+  `_enqueue_atomic` replaces `_phase_one_atomic`. Stranded-row
+  exceptions no longer mention `W002`, `retry horizon`, or `re-drive`.
+
 ## [0.13.1] — 2026-08-10
 
 Five fixes from the 0.13.0 adoption review (raised by the gv consumer as

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,12 +1,37 @@
 # django-logic — guidance for AI assistants
 
-This repo is the **django-logic** library: declarative business logic & state
+This repo is the **django-logic** library: declarative business logic and state
 machines for Django, with durable, queue-routed background transitions
 (`django_logic.background`). This file tells an AI how to **use the library
 correctly** when generating or reviewing code that depends on it. The rules
 below are distilled from a full
 production-style validation on Heroku (RabbitMQ + PostgreSQL + multiple
 workers + induced worker crashes, deploys, broker loss, and pgbouncer).
+
+## Voice — write like a person
+
+This library was largely written by AI tools. Much of the existing prose is a
+private dialect (numbered “phases”, “liveness”, “retry horizon”, ticket ids in
+comments). **Do not copy that voice.** Write as you would to a colleague.
+
+- Short sentences. One meaning per word. No metaphors.
+- Names are full words: `transition_message`, not `tm`.
+- Comments explain a non-obvious *why* in one or two sentences. Do not narrate
+  the next line, and do not cite GitHub issues, PRs, or check ids (`#195`,
+  `W002`). `CHANGELOG.md` owns that provenance.
+- Exception text is for operators. Say what happened and what to do.
+- If you would not say it out loud, rewrite it.
+- When you touch a file, rewrite dialect in the lines you touch. Do not add
+  more of it.
+
+**Allowed words:** transition, background transition, `TransitionMessage`,
+source state, retry window, stranded (nothing is retrying it), enqueue (save
+the row and send it to the queue), execute (the worker runs the side-effects),
+uncompleted, in progress.
+
+**Do not use:** `phase 1` / `phase 2`, `liveness`, `retry horizon`, `re-drive`,
+`in-flight marker`, `speculative-insert`, `owning process`, `finishing flight`,
+clipped locals (`tm`, `msg`, `inst`).
 
 ## What to generate
 
@@ -18,7 +43,7 @@ app's `AppConfig.ready()`** — with
 `ProcessManager.bind_model_process(Model, MyProcess, state_field='status')`
 (import the model and process *inside* `ready()`). Never bind at module import
 time in `models.py`/`process.py`: that forces a
-`model → process → actions → model` circular import (issue #100), because the
+`model → process → actions → model` circular import, because the
 process and its action functions both reference the model. `ready()` runs after
 every app's models are loaded, so the cycle never forms and action modules can
 import the model at the top level. Then drive it via
@@ -52,29 +77,30 @@ change on success) for anything slow, external, or retriable.
    state). Never re-raise a child error into the parent.
 4. **Set a `failed_state`** so failures are contained. `in_progress_state`
    is **background-only** (0.12.0): on a `BackgroundTransition` it is written
-   atomically with the `TransitionMessage` row; declaring it on a synchronous
-   `Transition`/`Action` raises at class creation. It may be shared freely —
-   every marked instance carries its exact transition on the row, so recovery
-   never guesses an owner (the old `django_logic.E001` ownership check is
-   retired). A synchronous "busy" phase is modelled as a real state: a fast
-   transition into it chained via `next_transition` to a
-   `BackgroundTransition` that does the work, plus a small periodic re-drive
+   in the same transaction as the `TransitionMessage` row; declaring it on a
+   synchronous `Transition`/`Action` raises at class creation. It may be shared
+   freely — every marked instance carries its exact transition on the row, so
+   recovery never guesses which transition it belongs to (the old
+   `django_logic.E001` check is retired). A synchronous "busy" step is a real
+   state: a fast transition into it chained via `next_transition` to a
+   `BackgroundTransition` that does the work, plus a small periodic retry
    for the crash window (see the README migration note).
 5. **Test in sync mode**: `DJANGO_LOGIC['BACKGROUND_EXECUTION']='sync'` (or the
-   `sync_execution()` context manager) runs phase 2 inline with no broker and
-   propagates exceptions; `retry_pending()` simulates the periodic starter.
-   The global default is `'celery'`, so test settings must opt into sync.
-   See `docs/TESTING_GUIDE.md` for the full scenario catalog.
-6. **One in-flight background transition per instance per process.** While an
+   `sync_execution()` context manager) runs the worker path inline with no
+   broker and propagates exceptions; `retry_pending()` simulates the periodic
+   starter. The global default is `'celery'`, so test settings must opt into
+   sync. See `docs/TESTING_GUIDE.md` for the full scenario catalog.
+6. **One uncompleted background transition per instance per process.** While an
    uncompleted `TransitionMessage` exists, a second background transition
    raises `AlreadyInProgress` and a *synchronous* transition on the same
    instance+process raises `TransitionTemporarilyUnavailable` (both subclass
    `TransitionNotAllowed`; catch the transient type first to answer
    "retry shortly") — design flows so follow-up work chains from terminal
-   hooks, not mid-flight. A failing `Action`'s `failed_state` write is
-   skipped while the row is uncompleted: phase 2 owns the state field.
+   hooks, not while another transition is still running. A failing `Action`'s
+   `failed_state` write is skipped while the row is uncompleted: the worker
+   owns the state field.
 7. **Manual state fixes win.** If an instance is moved externally while a
-   background row is pending, phase 2 completes the row as *superseded*
+   background row is pending, the worker completes the row as *superseded*
    (`'[superseded]'` in `last_error_message`) and skips side-effects. This is
    unconditional since 0.10.0.
 
@@ -91,7 +117,7 @@ change on success) for anything slow, external, or retriable.
 - Crash re-delivery is built in (every django-logic task sets
   `acks_late=True` + `reject_on_worker_lost=True`); set the global Celery
   pair only for your *own* tasks. You still need a **single beat**
-  scheduling the four `django_logic.*` safety-net tasks — and a worker for
+  scheduling the four `django_logic.*` periodic tasks — and a worker for
   every queue you use. Install them by writing the `CELERY_`-namespaced key,
   because a plain `app.conf.beat_schedule = …` assignment is silently ignored
   when the project also defines `CELERY_BEAT_SCHEDULE` in Django settings:
@@ -103,7 +129,7 @@ change on success) for anything slow, external, or retriable.
   }
   ```
 
-  `django_logic.W002` reports missing entries on `manage.py check` — a
+  `manage.py check` reports missing entries as `django_logic.W002` — a
   *warning*, so it does not fail the command unless you run
   `check --fail-level WARNING`.
 - Behind **pgbouncer transaction pooling**: `OPTIONS={'prepare_threshold':
@@ -117,9 +143,9 @@ change on success) for anything slow, external, or retriable.
   PostgreSQL concurrency + stability suites under `tests/stability`,
   `tests/background`. There is no pytest configuration — do not add one
   without wiring `DJANGO_SETTINGS_MODULE`.
-- `django_logic/background/` is the durable engine: `transitions.py`,
-  `dispatch.py`, `runner.py` (phase 2), `tasks.py` (Celery + periodic),
-  `models.py` (`TransitionMessage`), `settings.py`.
+- `django_logic/background/` is the durable engine: `transitions.py`
+  (enqueue), `dispatch.py`, `runner.py` (execute on the worker), `tasks.py`
+  (Celery + periodic), `models.py` (`TransitionMessage`), `settings.py`.
 - Read `docs/design/BACKGROUND_TRANSITION_ANALYSIS.md` and
   `docs/recipes/nested-processes.md` (the fan-out pattern and the
   cascading-failure anti-pattern it replaces) before changing the
@@ -127,10 +153,3 @@ change on success) for anything slow, external, or retriable.
 - `CHANGELOG.md` is the record of what shipped and why; `TODO.md` holds what
   has not. Neither is a design document — do not add planning docs that
   duplicate them.
-
-## Comments and docstrings: explain *why*, never narrate *what*
-
-A comment earns its place only when it captures non-obvious intent or a gotcha
-the code cannot express — and then it is terse. Do not restate the next line,
-narrate a change, or record issue archaeology: `CHANGELOG.md` owns history.
-A bare `(#NNN)` marker is enough when a guard needs provenance.

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ Use next_transition to automatically continue the process.
 
 > `next_transition` chains from a **completion**, so a synchronous `Action`
 > ignores it — an Action changes no state and has no completion to chain from.
-> (A `BackgroundAction` *does* run it, from phase 2.) Drive the follow-up from
+> (A `BackgroundAction` *does* run it, from the worker.) Drive the follow-up from
 > a callback instead, or use a `Transition`.
 
 ```python 
@@ -560,13 +560,14 @@ handler should answer them differently:
 
 **Transient concurrency** — the action is fine, retry shortly. These raise
 `TransitionTemporarilyUnavailable` (a `TransitionNotAllowed` subclass, importable
-from `django_logic.exceptions`): another flight owns the instance right now
-(`AlreadyInProgress`, or the sync gate while a **live** background row is
-uncompleted), or the state moved while phase 1 waited (`SourceStateChanged`).
-A row past its liveness window is stranded, not busy — both the sync gate and
-a background re-drive then raise the plain base again, so "retry shortly" is
-never a forever answer. (A running attempt inside its declared `timeout=`
-budget always counts as live.) Catch the transient type **ahead of** the base
+from `django_logic.exceptions`): another transition owns the instance right now
+(`AlreadyInProgress`, or the sync gate while a background row is still
+being retried), or the state moved while enqueue waited
+(`SourceStateChanged`). A stranded row — nothing is retrying it — is
+not busy: both the sync gate and a later enqueue then raise the plain
+base again, so "retry shortly" is never a forever answer. (A running
+attempt inside its declared `timeout=` budget always counts as still
+being retried.) Catch the transient type **ahead of** the base
 class:
 
 ```python
@@ -597,8 +598,8 @@ If the state field is not updating:
 Multiple processes trying to transition the same object can cause race conditions.
 
 **Solution**: Django-Logic serializes work on a state field with two mechanisms (see [Concurrency and locking](#concurrency-and-locking)):
-- a **cache lock** (atomic set-if-absent on the `default` cache) held for a synchronous transition's whole flight and for a background transition's phase-1 critical section, with the persisted state re-validated under the lock; and
-- the **`TransitionMessage` row** — while a background transition is in flight, a second one raises `AlreadyInProgress` and a synchronous transition on the same instance + process raises `TransitionTemporarilyUnavailable` (both are `TransitionNotAllowed` subclasses).
+- a **cache lock** (atomic set-if-absent on the `default` cache) held for a synchronous transition's whole run and for a background transition's enqueue critical section, with the persisted state re-validated under the lock; and
+- the **`TransitionMessage` row** — while a background transition is in progress, a second one raises `AlreadyInProgress` and a synchronous transition on the same instance + process raises `TransitionTemporarilyUnavailable` (both are `TransitionNotAllowed` subclasses).
 
 Use a cross-process cache so the lock is shared between web processes and workers.
 
@@ -690,7 +691,7 @@ class OrderProcess(Process):
     transitions = [...]
 ```
 
-Every state read and write for that process then goes through your class, including the ones the background engine performs (phase-1's `in_progress_state`, phase-2's target and `failed_state`). Two rules: `get_persisted_state()` must keep reading the database row — the under-the-lock revalidation and the phase-2 state guard rely on it being authoritative, so never override it with a cached read — and `set_state` must call `super()`.
+Every state read and write for that process then goes through your class, including the ones the background engine performs (enqueue's `in_progress_state`, the worker's target and `failed_state`). Two rules: `get_persisted_state()` must keep reading the database row — the under-the-lock revalidation and the worker's state guard rely on it being authoritative, so never override it with a cached read — and `set_state` must call `super()`.
 
 ### Context Passing
 Pass data between side effects and callbacks:
@@ -699,14 +700,14 @@ Pass data between side effects and callbacks:
 > `process_class` and `owning_process_class` on every drive (they carry
 > transition identity and lineage, and are forwarded to `next_transition`
 > follow-ups), replaces `user` with `user_id` on the background wire, and
-> rebuilds `context` in phase 2. Passing any of those as your own data means
+> rebuilds `context` on the worker. Passing any of those as your own data means
 > the engine overwrites it. Use different names.
 
 > `context` is scoped to **one execution**, not persisted. A caller-supplied
 > `context=` reaches a synchronous transition's hooks, but for a *background*
-> transition phase 1 drops it and phase 2 rebuilds an empty one — it is a
+> transition enqueue drops it and the worker rebuilds an empty one — it is a
 > channel between hooks within a run, not a way to pass data across the queue.
-> Anything phase 2 must see belongs in ordinary kwargs (which are serialized)
+> Anything the worker must see belongs in ordinary kwargs (which are serialized)
 > or on the instance.
 
 
@@ -732,16 +733,16 @@ Transition(
 
 For long-running side-effects (payment processing, PDF generation, external API calls), use `BackgroundTransition` / `BackgroundAction` from `django_logic.background`. **Background transitions are Celery tasks** — Celery ships as a core dependency and `'celery'` is the default execution mode.
 
-**How execution is split (the "two phases").** A synchronous `Transition` does everything at once, in the caller's call frame. A background transition *cannot* — its work runs later, on another machine — so it follows the standard transactional-outbox pattern, and the docs/code refer to the two halves as:
+**How execution is split.** A synchronous `Transition` does everything at once, in the caller's call frame. A background transition *cannot* — its work runs later, on another machine — so it follows the standard transactional-outbox pattern:
 
-- **Phase 1** (synchronous, in your request): validate, then in **one** database transaction write `in_progress_state` and a durable `TransitionMessage` row (the recorded intent), then enqueue the Celery task on commit. Fast — milliseconds.
-- **Phase 2** (on a Celery worker): load the row, run the side-effects, write the target state, mark the row completed — all in one atomic block. If the worker crashes or the broker loses the message, the durable row from phase 1 is what lets the safety-net tasks retry or finalize the work. (Success/failure *callbacks* run after phase 2's transaction commits — best-effort by contract, sometimes called "phase 3" in the runner's comments; there is nothing beyond that.)
+- **Enqueue** (synchronous, in your request): validate, then in **one** database transaction write `in_progress_state` and a durable `TransitionMessage` row (the recorded intent), then send the Celery task on commit. Fast — milliseconds.
+- **Execute** (on a Celery worker): load the row, run the side-effects, write the target state, mark the row completed — all in one atomic block. If the worker crashes or the broker loses the message, the durable row from enqueue is what lets the safety-net tasks retry or finalize the work. Success/failure *callbacks* run after the worker's transaction commits — best-effort by contract.
 
 They provide:
 
 - **Durable execution.** Every background transition is persisted as a `TransitionMessage` row inside the same atomic block that writes `in_progress_state`. Worker crashes, broker losses, and dropped `transaction.on_commit` hooks are all recovered by a periodic safety-net task.
 - **Queue routing per transition.** `queue=` is optional — transitions without it run on `DJANGO_LOGIC['DEFAULT_QUEUE']` (`'django_logic'`). Name queues per SLA (`critical` / `slow` / `fast`) and give each its own worker to manage performance per queue.
-- **Sync mode for tests.** `'sync'` runs phase 2 inline in the same process — for unit tests, CI, management commands, and the Django shell. No Celery broker is needed to test business processes; see [Testing Your Processes](#testing-your-processes).
+- **Sync mode for tests.** `'sync'` runs the worker path inline in the same process — for unit tests, CI, management commands, and the Django shell. No Celery broker is needed to test business processes; see [Testing Your Processes](#testing-your-processes).
 - **Single-task, all-or-nothing attempts.** All side-effects plus the target-state write happen inside **one** Celery task with `acks_late=True`, inside **one** atomic block, with the side-effects in a savepoint: a failed attempt **rolls back every database write it made**. A worker crash re-delivers the whole task; the state never gets stuck mid-flight between side-effects. The idempotency you owe is for *external* calls only — a retried attempt re-runs side-effects from scratch.
 
 ### Install
@@ -859,7 +860,7 @@ class ShopConfig(AppConfig):
 ### Call it
 
 ```python
-# In a view — returns immediately (Celery mode) or after phase 2 completes (Sync mode).
+# In a view — returns immediately (Celery mode) or after the worker completes (Sync mode).
 tr_id = order.process.fulfil(user=request.user)
 ```
 
@@ -918,33 +919,33 @@ class MessagingConfig(AppConfig):
 conversation.process.send_message_via_integration(user=request.user)
 ```
 
-Phase 1 resolves exactly one transition (the conditions are mutually exclusive)
-and records the **owning nested process class** on the `TransitionMessage`;
-phase 2 restores that exact transition from the recorded owner — it does not
+Enqueue resolves exactly one transition (the conditions are mutually exclusive)
+and records the **nested process class that declared it** on the `TransitionMessage`;
+the worker restores that exact transition from the recorded class — it does not
 re-evaluate the condition, so routing is deterministic even if the instance
-changes mid-flight. Constraints: a background `action_name` must only be
+changes while the row is pending. Constraints: a background `action_name` must only be
 **unique within a single process class** (two in one class are
 indistinguishable at restore). `in_progress_state` may be shared freely —
 useful when a UI only knows one "busy" value: every marked instance carries
 its exact transition on the `TransitionMessage` row, so recovery never has to
 guess an owner (the `django_logic.E001` ownership check that used to police
 sharing was retired in 0.12.0 along with the stranded sweep). A background `action_name` *may* coincide with a
-synchronous transition of the same name (phase 2 restores only background
-transitions; phase 1 routes the call by condition) — so a synchronous fast-path
+synchronous transition of the same name (the worker restores only background
+transitions; enqueue routes the call by condition) — so a synchronous fast-path
 and a durable background slow-path can share one `action_name`.
 
 > **`in_progress_state` is background-only (0.12.0).** On a `BackgroundTransition`
 > the marker is written atomically with the `TransitionMessage` row, so every
 > marked instance has a recovery owner. A *synchronous* transition used to write
 > it under a cache lock with no durable record — a hard-killed worker left the
-> instance parked in a state with no outbound edges (#136), and the engine
+> instance parked in a state with no outbound edges, and the engine
 > needed a whole sweeping subsystem (`recover_stranded_states`, retired) to find
 > those. Declaring it on a plain `Transition`/`Action` now raises
-> `ImproperlyConfigured`. Without a marker, a killed synchronous run simply
-> rolls back to its source state and is re-drivable once the lock TTL expires —
+> `ImproperlyConfigured`. Without that write, a killed synchronous run simply
+> rolls back to its source state and can be run again once the lock TTL expires —
 > nothing to sweep.
 >
-> **Migrating a sync transition that used the marker:** model the busy phase as
+> **Migrating a sync transition that used the marker:** model the busy step as
 > a real state with explicit edges —
 >
 > ```python
@@ -957,8 +958,8 @@ and a durable background slow-path can share one `action_name`.
 > Readers see `fulfilling` exactly as before, and the work itself is TM-durable.
 > The pattern accepts one narrow window the old atomic marker did not have: a
 > crash between `submit`'s commit and the chained dispatch parks the instance at
-> `fulfilling` with no row. The recovery is a three-line periodic re-drive,
-> safe by construction — instances genuinely in flight raise
+> `fulfilling` with no row. The recovery is a three-line periodic retry,
+> safe by construction — instances genuinely in progress raise
 > `AlreadyInProgress` and are skipped, parked ones retry *forward*:
 >
 > ```python
@@ -974,13 +975,13 @@ and a durable background slow-path can share one `action_name`.
 > transition into this shared-name nested pattern, deploy it with no in-flight
 > rows for that action (or split it across two deploys). Rows enqueued by older
 > code don't carry the owning-process discriminator; once the name becomes
-> shared, phase 2 can't tell which nested sibling such a row meant and finalizes
+> shared, the worker can't tell which nested sibling such a row meant and finalizes
 > it without running its side-effects (safe, but the work won't run). Rows
 > enqueued after the upgrade always record their owner.
 
 ### Testing background transitions
 
-Set `BACKGROUND_EXECUTION='sync'` in your test settings — the global default is `'celery'`, so this opt-in is required — and every `instance.process.fulfil(...)` call runs phase 1 **and** phase 2 inline, no broker involved:
+Set `BACKGROUND_EXECUTION='sync'` in your test settings — the global default is `'celery'`, so this opt-in is required — and every `instance.process.fulfil(...)` call enqueues **and** executes inline, no broker involved:
 
 ```python
 class FulfilmentTests(TestCase):
@@ -1048,19 +1049,19 @@ BackgroundTransition(
 )
 ```
 
-`watchdog_stale_attempts` scans in-flight rows whose current attempt (`started_at`) has run past `timeout`, records a synthetic `TimeoutError` as a failed attempt, and — once `errors_count` reaches `MAX_ERRORS` — finalizes the row to `failed_state`. Rows without `timeout` are never watched. An attempt is charged **at most once**: if it has already recorded an error of its own since it started, the watchdog leaves it alone rather than spending a second retry on it. `started_at` is written in its own committed statement before the attempt begins, precisely so it stays visible while the attempt runs and survives a worker dying mid-flight — which is what makes a hung or crashed attempt observable at all. Because the watchdog cannot tell a crashed attempt from a merely slow one, a re-dispatched attempt may run side-effects again while the original is still executing — **side-effects must be idempotent against external systems** (their database writes are per-attempt atomic and roll back on failure, but an external API call made by both attempts happens twice).
+`watchdog_stale_attempts` scans uncompleted rows whose current attempt (`started_at`) has run past `timeout`, records a synthetic `TimeoutError` as a failed attempt, and — once `errors_count` reaches `MAX_ERRORS` — finalizes the row to `failed_state`. Rows without `timeout` are never watched. An attempt is charged **at most once**: if it has already recorded an error of its own since it started, the watchdog leaves it alone rather than spending a second retry on it. `started_at` is written in its own committed statement before the attempt begins, precisely so it stays visible while the attempt runs and survives a worker dying mid-flight — which is what makes a hung or crashed attempt observable at all. Because the watchdog cannot tell a crashed attempt from a merely slow one, a re-dispatched attempt may run side-effects again while the original is still executing — **side-effects must be idempotent against external systems** (their database writes are per-attempt atomic and roll back on failure, but an external API call made by both attempts happens twice).
 
 ### Concurrency and locking
 
 Two mechanisms serialize work on a state field, each with a precise scope:
 
-1. **The cache lock** (atomic set-if-absent on the `default` cache) is held for a *synchronous* transition's whole flight, and for a background transition's **phase-1 critical section only** (validate → create the `TransitionMessage` → write `in_progress_state`, then released). Both re-validate the **persisted** state under the lock before proceeding, so two requests racing to transition the same instance can't both win.
-2. **The uncompleted `TransitionMessage` row** is the durable in-flight marker for background work. While one exists for an instance + process:
+1. **The cache lock** (atomic set-if-absent on the `default` cache) is held for a *synchronous* transition's whole run, and for a background transition's **enqueue critical section only** (validate → create the `TransitionMessage` → write `in_progress_state`, then released). Both re-validate the **persisted** state under the lock before proceeding, so two requests racing to transition the same instance can't both win.
+2. **The uncompleted `TransitionMessage` row** is what gates concurrent background work. While one exists for an instance + process:
    - a second background transition raises `AlreadyInProgress` (`from django_logic.background.exceptions import AlreadyInProgress`; also catchable as `TransitionTemporarilyUnavailable` from `django_logic.exceptions` without importing the background subpackage) — enforced by a partial unique constraint, so it holds across processes and dynos;
-   - a **synchronous transition on the same instance + process raises `TransitionTemporarilyUnavailable`** — phase 2 owns the state field until the row completes;
+   - a **synchronous transition on the same instance + process raises `TransitionTemporarilyUnavailable`** — the worker owns the state field until the row completes;
    - synchronous `Action`s still run (they don't change state on success); a failing Action's `failed_state` write is skipped while the row is uncompleted, for the same ownership reason.
 
-The constraint is scoped **per process**: two independent state machines bound to different fields of the same model (say `status` and `payment_status`) can both have background work in flight.
+The constraint is scoped **per process**: two independent state machines bound to different fields of the same model (say `status` and `payment_status`) can both have background work in progress.
 
 To shape answers at your own API seams ("busy, try again shortly"), read the marker through the documented probe instead of duplicating the filter:
 
@@ -1071,9 +1072,9 @@ if in_flight(order, 'process'):
     return Response(status=409, data={'detail': 'Busy — please retry shortly.'})
 ```
 
-The read is racy — a flight can start or complete right after it — so use it for shaping answers, not as a pre-flight gate; the engine's own guards stay authoritative. It answers the *busy* question: a stranded row (uncompleted but past the retry horizon) is `False`, matching the plain `TransitionNotAllowed` the engine's gates raise for it.
+The read is racy — a transition can start or complete right after it — so use it for shaping answers, not as a pre-flight gate; the engine's own guards stay authoritative. It answers the *busy* question: a stranded row (uncompleted, nothing retrying it) is `False`, matching the plain `TransitionNotAllowed` the engine's gates raise for it.
 
-Because the in-flight marker is a database row rather than a held lock, nothing leaks if the caller's surrounding transaction rolls back — the row, the `in_progress_state` write, and the dispatch all disappear together.
+Because the gate is a database row rather than a held lock, nothing leaks if the caller's surrounding transaction rolls back — the row, the `in_progress_state` write, and the dispatch all disappear together.
 
 **Lock ownership.** Every acquisition stores a unique ownership token, and release is a compare-and-delete: a synchronous run that outlives its lock TTL can no longer delete the lock a successor legitimately acquired — the token no longer matches, so it leaves it intact and returns silently. A `State` object that never locked keeps the historical unconditional delete as a manual force-release path.
 
@@ -1085,9 +1086,9 @@ DJANGO_LOGIC = {..., 'DEFER_UNLOCK_UNTIL_COMMIT': True}
 
 The unlock then rides `transaction.on_commit`. Trade-offs to design for: on **rollback** the hook never fires, so the lock expires via its TTL — a bounded lockout, the same failure mode as a crashed process (give rollback-prone flows a per-transition `lock_timeout`); and same-instance follow-ups (`callbacks` / `next_transition`) inside the atomic block find the state still locked and are skipped — chain them from `transaction.on_commit` in the caller instead. Alternatively, keep the default and invoke transitions via `transaction.on_commit` so they start only once the surrounding write is visible.
 
-Practical consequence: you **cannot** chain a background transition from another transition's `callbacks`/`next_transition` on the *same* instance while the first row is still uncompleted — the chained phase 1 will hit `AlreadyInProgress`. Chain follow-up background work from a *terminal* hook (success/failure callback that fires after the first row is marked completed), or target a different instance.
+Practical consequence: you **cannot** chain a background transition from another transition's `callbacks`/`next_transition` on the *same* instance while the first row is still uncompleted — the chained enqueue will hit `AlreadyInProgress`. Chain follow-up background work from a *terminal* hook (success/failure callback that fires after the first row is marked completed), or target a different instance.
 
-> ⚠️ **Swallow-dedup loses mid-execution updates.** Catching `AlreadyInProgress` as "already queued — the running job will pick up my changes" is only safe while the existing attempt has **not started**. If phase 2 is already executing, it has already read its inputs: your update lands after the read, the in-flight run commits a result computed from pre-update data, and nothing ever re-runs. For recompute-style transitions, persist a dirty flag (or version) *before* dispatching, clear it inside the side-effect, and re-dispatch from a success callback if it is set again:
+> ⚠️ **Swallow-dedup loses mid-execution updates.** Catching `AlreadyInProgress` as "already queued — the running job will pick up my changes" is only safe while the existing attempt has **not started**. If the worker is already executing, it has already read its inputs: your update lands after the read, that run commits a result computed from pre-update data, and nothing ever re-runs. For recompute-style transitions, persist a dirty flag (or version) *before* dispatching, clear it inside the side-effect, and dispatch again from a success callback if it is set again:
 >
 > ```python
 > def recompute(instance, **kwargs):
@@ -1100,11 +1101,11 @@ Practical consequence: you **cannot** chain a background transition from another
 >         instance.process.recompute_rates()
 > ```
 
-### The phase-2 state guard
+### The worker's state guard
 
-Phase 2 restores the transition by name and deliberately bypasses the source-state gate — so what happens if the instance was moved by something *else* while the row was pending (a manual ops fix in the admin, a data migration, a support script)? With retries spanning `RETRY_MINUTES × MAX_ERRORS`, that collision is a realistic production event.
+The worker restores the transition by name and deliberately bypasses the source-state gate — so what happens if the instance was moved by something *else* while the row was pending (a manual ops fix in the admin, a data migration, a support script)? With retries spanning `RETRY_MINUTES × MAX_ERRORS`, that collision is a realistic production event.
 
-Before running side-effects, phase 2 verifies the persisted state still matches what phase 1 left behind (`in_progress_state`, or a declared source when the transition has none). On mismatch the row is completed as **superseded**: side-effects are skipped, the external state change wins, and the reason is recorded on the row (`last_error_message` starts with `[superseded]`) and logged at ERROR.
+Before running side-effects, the worker verifies the persisted state still matches what enqueue left behind (`in_progress_state`, or a declared source when the transition has none). On mismatch the row is completed as **superseded**: side-effects are skipped, the external state change wins, and the reason is recorded on the row (`last_error_message` starts with `[superseded]`) and logged at ERROR.
 
 The same guard protects the `failed_state` writes made by the safety-net tasks, so a watchdog finalizing a long-stranded row never clobbers a manual fix.
 
@@ -1167,7 +1168,7 @@ DATABASES['default']['DISABLE_SERVER_SIDE_CURSORS'] = True
 
 Also do **not** force `sslmode=require` on the app→pgbouncer connection (it's
 local/plaintext; pgbouncer terminates TLS upstream). If you skip
-`prepare_threshold=None`, phase 2 will intermittently fail/hang with
+`prepare_threshold=None`, the worker will intermittently fail/hang with
 prepared-statement errors. (Validated end-to-end on Heroku behind an in-dyno
 pgbouncer.)
 
@@ -1188,7 +1189,7 @@ SELECT count(*) FROM django_logic_background_transitionmessage
  WHERE last_error_message LIKE '[superseded]%';
 ```
 
-Also alert on beat liveness — if beat stops, the safety net stops.
+Also alert if beat stops — the safety net stops with it.
 
 **Migrating an existing deployment.** Migration `0005` widens `instance_id` from integer to `varchar(255)` via `ALTER COLUMN ... TYPE` (Django emits the `USING ...::varchar` cast, so existing integer rows convert in place). On a very large `TransitionMessage` table this rewrites the column under a lock — run it in a maintenance window or with your usual online-migration tooling. Migration `0006` (0.4.0) adds the `field_name` column and swaps the partial unique constraint from per-instance (`dl_bg_only_one_uncompleted_per_instance`) to per-process (`dl_bg_one_uncompleted_per_process`) — a quick metadata + index change, safe to run in place.
 
@@ -1220,7 +1221,7 @@ class TestOrderFulfilment(ProcessScenario):
         order = self.create_instance(status='approved')
         self.assert_available(order, ['fulfil', 'cancel'])
 
-        self.background_transition(order, 'fulfil')      # phase 1 + phase 2, no Celery
+        self.background_transition(order, 'fulfil')      # enqueue + execute, no Celery
         self.assert_state(order, 'fulfilled')
         self.assert_side_effects_ran(['reserve_stock', 'call_courier'])
         self.assert_callbacks_ran(['send_confirmation_email'])
@@ -1277,7 +1278,7 @@ class TestOrderFulfilment(ProcessScenario):
 |--------|--------------|
 | `create_instance(**fields)` | Create a model instance (state via the `state_field` kwarg) |
 | `transition(obj, action, **kwargs)` | Run a synchronous transition |
-| `background_transition(obj, action, **kwargs)` | Run a `BackgroundTransition`/`BackgroundAction` phase 1 **and** phase 2 inline |
+| `background_transition(obj, action, **kwargs)` | Run a `BackgroundTransition`/`BackgroundAction` enqueue **and** execute inline |
 | `retry_transition(obj)` | Re-run the instance's uncompleted transition — simulates the periodic starter |
 
 Add `fail_side_effect='name'`, `fail_with=SomeError(...)` to `background_transition`/`retry_transition`/`transition` to make a named side-effect raise. Only that side-effect is wrapped — every other one runs for real, so you exercise the true failure path. Add `expect_raises=SomeError` to assert the failure **propagated to the caller** (the `side_effects` re-raise contract), or `expect_raises=False` to assert it was **swallowed** (`callbacks` / `next_transition` / `failure_side_effects`); omit it to absorb the injected exception and assert on the recorded error instead.
@@ -1340,7 +1341,7 @@ report = coverage_report(log_path='/tmp/fsm_coverage.log')
 ```
 
 A pair is recorded at *initiation* (direct calls, `next_transition`
-follow-ups, background phase 1); phase-2 restore and retries don't re-notify.
+follow-ups, background enqueue); worker restore and retries don't re-notify.
 Diffing `report['uncovered']` in CI catches transitions that silently stop
 being exercised. Logs written by 0.8/0.9.0 recorders are **no longer read** —
 0.10.0 removed the cross-version readers, so a log in an older format reports

--- a/TODO.md
+++ b/TODO.md
@@ -23,7 +23,7 @@ Carried over from the Heroku validation round.
 - [ ] Document the Postgres **connection budget**: each in-flight task holds a
       connection (two if the app opens a second one per task), so size
       `concurrency × workers` against the DB limit (pgbouncer or plan cap).
-- [ ] Document a beat-liveness alert recipe — e.g. Sentry cron monitors via
+- [ ] Document a beat-is-running alert recipe — e.g. Sentry cron monitors via
       `CeleryIntegration(monitor_beat_tasks=True)`. See also the system check
       added for a schedule that never installed the safety-net entries.
 - [ ] Log level for handled safety-net conditions: `detect_stuck`

--- a/django_logic/apps.py
+++ b/django_logic/apps.py
@@ -27,7 +27,7 @@ class DjangoLogicConfig(AppConfig):
         validate_core_settings()
         install_legacy_exception_base()
 
-        # Transition-coverage recording (#132). Activated in ready() so
+        # Transition-coverage recording. Activated in ready() so
         # spawn-based parallel test workers, which re-run it, self-activate;
         # fork-based workers inherit the parent's recorder. The path is
         # type-validated by validate_core_settings above — open() accepts a

--- a/django_logic/background/__init__.py
+++ b/django_logic/background/__init__.py
@@ -5,10 +5,11 @@ Public API:
 * :class:`BackgroundTransition` / :class:`BackgroundAction` — declarative
   background-executed transitions with per-transition queue routing.
 * :func:`sync_execution` — context manager that forces the current block
-  to run phase 2 inline (for tests, management commands, the shell).
+  to run the worker path inline (for tests, management commands, the shell).
 * :func:`retry_pending` — run the periodic safety-net task once inline.
-* :func:`in_flight` — racy read of the durable in-flight marker, for
-  shaping "busy, try again shortly" answers at API seams (#197).
+* :func:`in_flight` — racy read of whether an uncompleted row is still
+  being retried, for shaping "busy, try again shortly" answers at API
+  seams.
 * :func:`beat_schedule` — ready-made Celery beat entries for the five
   safety-net tasks, routed to ``DJANGO_LOGIC['STARTER_QUEUE']``.
 

--- a/django_logic/background/apps.py
+++ b/django_logic/background/apps.py
@@ -17,10 +17,10 @@ class BackgroundConfig(AppConfig):
         )
 
         # Idempotent — covers an install shape where only the background
-        # app's ready() runs before denials are raised or caught (#190).
+        # app's ready() runs before denials are raised or caught.
         install_legacy_exception_base()
 
-        # Transition-coverage recording (#132). Activated here (not in the
+        # Transition-coverage recording. Activated here (not in the
         # recorder module) so spawn-based parallel test workers, which re-run
         # ready(), self-activate; fork-based workers inherit the parent's. The
         # path is type-validated by validate_on_ready above — open() accepts a

--- a/django_logic/background/dispatch.py
+++ b/django_logic/background/dispatch.py
@@ -1,13 +1,13 @@
-"""Dispatch — where phase 1 hands off to phase 2.
+"""Dispatch — where enqueue hands off to the worker.
 
 Two modes:
 
 * **Celery mode** (``DJANGO_LOGIC['BACKGROUND_EXECUTION'] = 'celery'``):
   schedule a Celery task on the transition's queue via
-  ``transaction.on_commit``. The worker picks it up and runs phase 2.
+  ``transaction.on_commit``. The worker picks it up and executes.
 
-* **Sync mode** (``'sync'``): run phase 2 inline, immediately after the
-  phase-1 atomic block exits. Bypasses ``transaction.on_commit`` so it
+* **Sync mode** (``'sync'``): execute inline, immediately after the
+  enqueue atomic block exits. Bypasses ``transaction.on_commit`` so it
   works correctly under Django's ``TestCase`` (which wraps every test
   in a transaction that never commits).
 
@@ -32,7 +32,8 @@ def sync_execution():
     """Force Sync mode for the duration of the ``with`` block.
 
     Useful inside a test / management command when the global setting
-    is ``'celery'`` but you want phase 2 to run inline for this block.
+    is ``'celery'`` but you want the worker path to run inline for this
+    block.
     """
     token = _force_sync.set(True)
     try:
@@ -47,18 +48,18 @@ def _current_mode() -> str:
     return bg_settings.background_execution()
 
 
-def dispatch_transition(tm) -> None:
-    """Hand a fresh TransitionMessage off to phase 2.
+def dispatch_transition(transition_message) -> None:
+    """Hand a fresh TransitionMessage off to the worker.
 
     In Celery mode, schedules the Celery task via ``transaction.on_commit``
     so the DB row is visible to the worker.
 
-    In Sync mode, runs phase 2 inline. Exceptions propagate to the caller.
+    In Sync mode, executes inline. Exceptions propagate to the caller.
     """
     mode = _current_mode()
     if mode == bg_settings.EXECUTION_SYNC:
         from django_logic.background.runner import run_background_transition
-        run_background_transition(tm.pk)
+        run_background_transition(transition_message.pk)
         return
 
     # Celery mode — deferred import avoids loading the task module (and
@@ -70,11 +71,13 @@ def dispatch_transition(tm) -> None:
 
     # `shadow` gives this dispatch a per-transition name in Celery events /
     # Flower / RabbitMQ management, even though it's the one shared task.
-    shadow = task_label(tm)
+    shadow = task_label(transition_message)
 
     def _enqueue():
         run_background_transition_task.apply_async(
-            args=[tm.pk], queue=tm.queue_name, shadow=shadow
+            args=[transition_message.pk],
+            queue=transition_message.queue_name,
+            shadow=shadow,
         )
 
     transaction.on_commit(_enqueue)
@@ -95,11 +98,8 @@ def _warn_once_about_celery_config(task) -> None:
     in-memory transport no worker drains: ``apply_async`` succeeds but the
     task never runs, leaving the instance stuck in ``in_progress_state``.
 
-    (The old acks_late/reject_on_worker_lost warning is gone: it read the
-    *global* ``conf.task_acks_late`` and so never fired for the per-task
-    ``acks_late=True`` that actually creates the hazard — issue #91. The
-    hazard itself is now eliminated at the source: every django-logic task
-    sets ``reject_on_worker_lost=True`` alongside ``acks_late=True``.)
+    Every django-logic task sets ``reject_on_worker_lost=True`` alongside
+    ``acks_late=True``, so a worker crash redelivers the message.
     """
     global _celery_config_warned
     if _celery_config_warned:
@@ -136,18 +136,18 @@ def retry_pending() -> int:
 
 
 def in_flight(instance, process_name: str = 'process') -> bool:
-    """Whether a background transition is LIVE for ``instance`` +
-    ``process_name`` (#197) — an uncompleted ``TransitionMessage`` exists
-    and is inside its liveness window.
+    """Whether a background transition is still being retried for
+    ``instance`` + ``process_name`` — an uncompleted ``TransitionMessage``
+    exists and is inside its retry window.
 
     For shaping answers at API seams ("busy, try again shortly"), NOT as a
-    pre-flight gate: the read is racy — a flight can start or complete
+    pre-flight gate: the read is racy — a transition can start or complete
     between this call and whatever the caller does next. The engine's own
-    guards (phase 1's unique constraint, the sync gate's under-lock check)
+    guards (enqueue's unique constraint, the sync gate's under-lock check)
     stay authoritative.
 
-    A STRANDED row (past the retry horizon, #195) answers ``False``: it is
-    not "busy, retry shortly", and the engine's gates raise the plain
+    A stranded row (nothing is retrying it) answers ``False``: it is not
+    "busy, retry shortly", and the engine's gates raise the plain
     ``TransitionNotAllowed`` for it — so a consumer answering 409 on this
     probe and 400 on the plain base stays consistent. The engine's own
     failure-path write-skip deliberately uses bare existence instead —
@@ -162,6 +162,6 @@ def in_flight(instance, process_name: str = 'process') -> bool:
     from django_logic.background.models import TransitionMessage
 
     return (
-        TransitionMessage.in_flight_liveness(instance, process_name)
-        == TransitionMessage.LIVENESS_LIVE
+        TransitionMessage.retry_status(instance, process_name)
+        == TransitionMessage.RETRYING
     )

--- a/django_logic/background/exceptions.py
+++ b/django_logic/background/exceptions.py
@@ -2,7 +2,7 @@ from django_logic.exceptions import TransitionTemporarilyUnavailable
 
 
 class AlreadyInProgress(TransitionTemporarilyUnavailable):
-    """Raised by phase 1 when an uncompleted TransitionMessage already
+    """Raised when enqueue finds an uncompleted TransitionMessage already
     exists for the target instance + process (the partial unique
     constraint fires).
 
@@ -10,24 +10,24 @@ class AlreadyInProgress(TransitionTemporarilyUnavailable):
 
         Swallowing this as "already queued, the running job will pick up
         my changes" is only safe while the existing attempt has NOT
-        started. If phase 2 is already executing — has already read its
-        inputs — the in-flight run commits a result computed from
-        pre-update data and **the update's signal is lost**: nothing
-        re-runs (issue #92). Consumers whose side-effects derive data from
-        mutable rows need a recheck: persist a dirty flag / version before
-        dispatching, clear it inside the side-effect, and re-dispatch from
-        a success callback when it is still set.
+        started. If the worker is already executing — has already read
+        its inputs — that run commits a result computed from pre-update
+        data and **the update's signal is lost**: nothing re-runs.
+        Consumers whose side-effects derive data from mutable rows need
+        a recheck: persist a dirty flag / version before dispatching,
+        clear it inside the side-effect, and dispatch again from a
+        success callback when it is still set.
     """
 
 
 class SourceStateChanged(TransitionTemporarilyUnavailable):
-    """Raised by phase 1's post-create recheck when the persisted state left
-    the transition's sources while the insert waited on a finishing flight.
+    """Raised when the persisted state left the transition's sources
+    while the insert waited on the unique constraint.
 
-    A named subclass because this is an *expected* concurrency outcome — the
-    guard doing its job, the same class of event as ``AlreadyInProgress``;
-    both share ``TransitionTemporarilyUnavailable``, which is why the hook
-    runner logs them at WARNING rather than ERROR (#154). Consumers that
-    treat it distinctly can catch it by type; everything catching
-    ``TransitionNotAllowed`` keeps working.
+    A named subclass because this is an expected concurrency outcome —
+    the guard doing its job, the same class of event as
+    ``AlreadyInProgress``; both share ``TransitionTemporarilyUnavailable``,
+    which is why the hook runner logs them at WARNING rather than ERROR.
+    Consumers that treat it distinctly can catch it by type; everything
+    catching ``TransitionNotAllowed`` keeps working.
     """

--- a/django_logic/background/migrations/0006_per_process_constraint_and_field_name.py
+++ b/django_logic/background/migrations/0006_per_process_constraint_and_field_name.py
@@ -8,9 +8,9 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        # Record the state field the process is bound to, so phase 2 can
-        # reconstruct the process from the stored process_class without
-        # guessing the field name. Blank on pre-0.4 rows.
+        # Record the state field the process is bound to, so the worker
+        # can reconstruct the process from the stored process_class
+        # without guessing the field name. Blank on pre-0.4 rows.
         migrations.AddField(
             model_name='transitionmessage',
             name='field_name',

--- a/django_logic/background/migrations/0007_transitionmessage_owning_process_class.py
+++ b/django_logic/background/migrations/0007_transitionmessage_owning_process_class.py
@@ -2,18 +2,19 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-    """Add the phase-2 owner discriminator (issue #98).
+    """Add the column that records which process class declared the transition.
 
-    Records the (possibly nested) Process class that DECLARES the transition, so
-    phase-2 restore can pick the exact background transition when an action_name
-    is shared across condition-disambiguated nested processes. Blank on rows
-    created before this field existed — phase 2 then resolves by transition_name
-    only when that name is unambiguous across the tree (see runner._find_transition).
+    Records the (possibly nested) Process class that declared the
+    transition, so the worker can pick the exact background transition
+    when an action_name is shared across nested processes that use
+    conditions to choose. Blank on rows created before this field
+    existed — the worker then resolves by transition_name only when that
+    name is unambiguous across the tree (see runner._find_transition).
 
     Deploy note (PostgreSQL): this AddField does NOT rewrite the table (a
     constant default on PG 11+ is metadata-only), but ADD COLUMN still takes a
     brief ACCESS EXCLUSIVE lock on ``transitionmessage`` — the engine's hottest
-    table (phase 1 inserts into it; phase 2 holds rows under
+    table (enqueue inserts into it; the worker holds rows under
     ``select_for_update(nowait=True)``). If a worker is holding a row lock in a
     long-open transaction, the ALTER queues at the head of the lock queue and
     briefly blocks other access. django-logic transactions are short by design,

--- a/django_logic/background/models.py
+++ b/django_logic/background/models.py
@@ -1,16 +1,17 @@
 """TransitionMessage — the durable record of an in-progress transition.
 
-Every ``BackgroundTransition`` / ``BackgroundAction`` creates one row in
-phase 1, atomically with the ``in_progress_state`` write on the target
-instance. Phase 2 reads the row under ``select_for_update(nowait=True)``
-and marks it completed at the end of a successful execution.
+Every ``BackgroundTransition`` / ``BackgroundAction`` creates one row
+when it enqueues, atomically with the ``in_progress_state`` write on the
+target instance. The worker reads the row under
+``select_for_update(nowait=True)`` and marks it completed at the end of
+a successful execution.
 
 The partial unique constraint ``(app_label, model_name, instance_id,
 process_name)`` where ``is_completed=False`` is the concurrency guard —
 only one uncompleted message can exist per instance *per process* at a
 time. Two processes bound to different state fields of the same model
 are independent state machines and may both have background work in
-flight.
+progress.
 """
 from __future__ import annotations
 
@@ -64,48 +65,50 @@ class TransitionMessage(TimeStampedModel):
     # branch in the first place.
     failure_side_effect_error = models.TextField(blank=True)
 
-    # Phase-2 timing. ``started_at`` is (re)written at the top of every
-    # phase-2 attempt, so on retry it reflects the *current* attempt —
-    # a watchdog can scan ``is_completed=False AND started_at < cutoff``
+    # Worker timing. ``started_at`` is (re)written at the top of every
+    # attempt, so on retry it reflects the *current* attempt — a
+    # watchdog can scan ``is_completed=False AND started_at < cutoff``
     # to find hung attempts. ``completed_at`` is set once when the row
     # is marked completed (success or terminal failure). ``duration_ms``
-    # measures the last attempt only; null if phase 2 never ran.
+    # measures the last attempt only; null if the worker never ran.
     started_at = models.DateTimeField(blank=True, null=True)
     completed_at = models.DateTimeField(blank=True, null=True)
     duration_ms = models.PositiveIntegerField(blank=True, null=True)
 
     app_label = models.CharField(max_length=100)
     model_name = models.CharField(max_length=100)
-    # Stored as text (``str(instance.pk)``) rather than an integer so the
-    # background path supports every primary-key type the synchronous core
-    # already supports: BigAutoField PKs beyond 2**31-1, UUIDField, and
+    # Stored as text (``str(instance.pk)``) so the background path
+    # supports every primary-key type the synchronous core already
+    # supports: BigAutoField PKs beyond 2**31-1, UUIDField, and
     # CharField primary keys. ``_restore`` looks the instance up with
     # ``model._base_manager.get(pk=instance_id)`` (immune to filtered
-    # default managers — issue #90), which coerces the string back
-    # to the model's real pk type.
+    # default managers), which coerces the string back to the model's
+    # real pk type.
     instance_id = models.CharField(max_length=255)
     process_name = models.CharField(max_length=100)
-    # The model field the process is bound to. Lets phase 2 reconstruct
+    # The model field the process is bound to. Lets the worker reconstruct
     # the process from the recorded ``process_class`` without guessing
-    # the field name when the model property has been renamed/rebound
-    # between phases. Blank on rows created before 0.4.0.
+    # the field name when the model property has been renamed or rebound
+    # between enqueue and execute. Blank on rows created before 0.4.0.
     field_name = models.CharField(max_length=100, blank=True, default='')
     transition_name = models.CharField(max_length=100)
-    # Dotted path of the (possibly nested) Process class that DECLARES the
-    # transition. Phase 2 uses it to restore the EXACT background transition when
-    # an ``action_name`` is shared across condition-disambiguated nested
-    # processes (e.g. per-integration Gmail/Dummy sub-processes). It is recorded
-    # for EVERY background transition started through the Process entrypoint —
-    # for a transition on the bound process itself it equals the bound class
-    # path; for a nested one it is the nested class path. Blank only on rows
-    # created before this discriminator existed (pre-0.4.x) or, rarely, ones
-    # enqueued outside the Process entrypoint; phase 2 then resolves by
-    # ``transition_name`` (only when that name is unambiguous across the tree).
+    # Dotted path of the (possibly nested) Process class that declared the
+    # transition. The worker uses it to restore that exact background
+    # transition when an ``action_name`` is shared across nested processes
+    # that use conditions to choose (e.g. per-integration Gmail/Dummy
+    # sub-processes). It is recorded for every background transition
+    # started through the Process entrypoint — for a transition on the
+    # bound process itself it equals the bound class path; for a nested
+    # one it is the nested class path. Blank only on rows created before
+    # this column existed (pre-0.4.x) or, rarely, ones enqueued outside
+    # the Process entrypoint; the worker then resolves by
+    # ``transition_name`` (only when that name is unambiguous across the
+    # tree).
     #
     # TextField (not a length-capped CharField) to mirror the unbounded
-    # ``process_class`` stored in ``kwargs``: a deeply-namespaced dotted path
-    # must never overflow and abort phase 1. Never indexed — only read by pk in
-    # phase-2 restore and compared for equality.
+    # ``process_class`` stored in ``kwargs``: a deeply-namespaced dotted
+    # path must never overflow and abort enqueue. Never indexed — only
+    # read by pk when the worker restores and compared for equality.
     owning_process_class = models.TextField(blank=True, default='')
     queue_name = models.CharField(max_length=100)
 
@@ -134,7 +137,7 @@ class TransitionMessage(TimeStampedModel):
             ),
         ]
         constraints = [
-            # One in-flight background transition per instance PER PROCESS.
+            # One uncompleted background transition per instance PER PROCESS.
             # Without process_name in the constraint, two independent state
             # machines on the same model (e.g. ``status`` and
             # ``payment_status``) would falsely conflict.
@@ -154,13 +157,11 @@ class TransitionMessage(TimeStampedModel):
 
     @classmethod
     def in_flight_for(cls, instance, process_name: str):
-        """The uncompleted rows for ``instance`` + ``process_name`` — the
-        durable in-flight marker (#197).
+        """The uncompleted rows for ``instance`` + ``process_name``.
 
-        The ONE place the marker filter is written. The sync gate, the
-        Action failure path, and the public ``in_flight()`` probe all read
-        through it, so a future change to the marker's keying (the
-        #184/#186 identity rework) changes it exactly once.
+        The one place this filter is written. The sync gate, the Action
+        failure path, and the public ``in_flight()`` probe all read
+        through it, so a future change to the keying changes it once.
         """
         return cls.objects.filter(
             app_label=instance._meta.app_label,
@@ -170,34 +171,36 @@ class TransitionMessage(TimeStampedModel):
             is_completed=False,
         )
 
-    LIVENESS_LIVE = 'live'
-    LIVENESS_STRANDED = 'stranded'
+    RETRYING = 'retrying'
+    STRANDED = 'stranded'
 
     #: Grace between an attempt exhausting its declared budget and the
     #: watchdog abandoning it (which writes ``modified`` via record_error,
-    #: putting the row back on the horizon clock).
-    LIVENESS_SLACK = timedelta(minutes=5)
+    #: putting the row back on the retry-window clock).
+    RETRY_SLACK = timedelta(minutes=5)
 
     @classmethod
-    def in_flight_liveness(cls, instance, process_name: str):
-        """``None`` (no uncompleted row), ``LIVENESS_LIVE``, or
-        ``LIVENESS_STRANDED`` (#195) — one classification shared by the
-        sync gate, phase 1's constraint rejection, and ``in_flight()``, so
-        they can never disagree about the same row.
+    def retry_status(cls, instance, process_name: str):
+        """``None`` (no uncompleted row), ``RETRYING``, or ``STRANDED``.
 
-        Liveness signals, in order:
+        One classification shared by the sync gate, enqueue's constraint
+        rejection, and ``in_flight()``, so they can never disagree about
+        the same row.
+
+        In order:
 
         * a running attempt inside its declared per-attempt budget
-          (``started_at + timeout_seconds`` plus slack) is LIVE — the
-          watchdog's own definition, so the gate cannot call an attempt
-          stranded while the watchdog still calls it live;
-        * otherwise a row whose newest activity (``modified``, refreshed at
-          attempt start / on every recorded error, or ``started_at``) is
-          within the retry horizon is LIVE;
-        * past the horizon it is STRANDED: nothing has driven it for longer
-          than the whole retry pipeline's span. This cannot distinguish a
-          truly lost row from a queue backlogged for that long — the
-          stranded message names both causes.
+          (``started_at + timeout_seconds`` plus slack) is still being
+          retried — the watchdog's own definition, so the gate cannot
+          call an attempt stranded while the watchdog still treats it
+          as live;
+        * otherwise a row whose newest activity (``modified``, refreshed
+          at attempt start / on every recorded error, or ``started_at``)
+          is within the retry window is still being retried;
+        * past the window it is stranded: nothing has retried it for
+          longer than the whole retry pipeline's span. This cannot
+          distinguish a truly lost row from a queue backlogged for that
+          long — the stranded message names both causes.
         """
         from django_logic.background import settings as bg_settings
 
@@ -213,26 +216,26 @@ class TransitionMessage(TimeStampedModel):
         started, timeout = row['started_at'], row['timeout_seconds']
         if (
             started is not None and timeout is not None
-            and now < started + timedelta(seconds=timeout) + cls.LIVENESS_SLACK
+            and now < started + timedelta(seconds=timeout) + cls.RETRY_SLACK
         ):
-            return cls.LIVENESS_LIVE
+            return cls.RETRYING
         newest = max(t for t in (row['modified'], started) if t is not None)
         # The whole retry pipeline's span plus slack, floored so short
         # test/dev retry configs don't classify a fresh row as stale.
-        horizon = max(
+        retry_window = max(
             bg_settings.retry_minutes() * (bg_settings.max_errors() + 1), 15,
         )
-        if now - newest > timedelta(minutes=horizon):
-            return cls.LIVENESS_STRANDED
-        return cls.LIVENESS_LIVE
+        if now - newest > timedelta(minutes=retry_window):
+            return cls.STRANDED
+        return cls.RETRYING
 
     @classmethod
-    def stamp_attempt_started(cls, tm_id: int) -> bool:
+    def stamp_attempt_started(cls, transition_message_id: int) -> bool:
         """Mark an attempt as beginning, in its own committed statement.
 
-        Deliberately called from *outside* the attempt's ``atomic`` block
-        (#179). ``started_at`` is the only field that must be visible to
-        other connections *while* the attempt runs, and must survive the
+        Deliberately called from *outside* the attempt's ``atomic`` block.
+        ``started_at`` is the only field that must be visible to other
+        connections *while* the attempt runs, and must survive the
         attempt rolling back:
 
         * A hung attempt holds its transaction open, so a ``started_at``
@@ -251,18 +254,19 @@ class TransitionMessage(TimeStampedModel):
         Durability is mode-dependent, as for
         ``runner._mark_unrestorable_completed``:
 
-        * **Celery mode** — phase 2 is the top-level unit of work with no
-          surrounding transaction, so this UPDATE autocommits and is visible
-          to the watchdog immediately. Verified against real PostgreSQL from
-          a second connection. This is the mode the watchdog exists for.
+        * **Celery mode** — the worker is the top-level unit of work with
+          no surrounding transaction, so this UPDATE autocommits and is
+          visible to the watchdog immediately. Verified against real
+          PostgreSQL from a second connection. This is the mode the
+          watchdog exists for.
         * **Sync mode inside a caller's ``atomic()``** — it is part of the
-          caller's transaction and invisible to other connections until the
-          caller commits. Harmless: the phase-1 INSERT that created the row
-          is in that same transaction, so on rollback there is no surviving
-          row to abandon, and on commit the row and this marker become
-          visible together. There is also no worker to abandon — the
-          "attempt" is the caller's own thread, which a watchdog could not
-          rescue anyway.
+          caller's transaction and invisible to other connections until
+          the caller commits. Harmless: the INSERT that created the row
+          is in that same transaction, so on rollback there is no
+          surviving row to abandon, and on commit the row and this stamp
+          become visible together. There is also no worker to abandon —
+          the "attempt" is the caller's own thread, which a watchdog
+          could not rescue anyway.
 
         Acquires the row lock with ``nowait`` first and gives up if another
         attempt holds it. That is not an optimisation — a bare ``UPDATE``
@@ -285,12 +289,14 @@ class TransitionMessage(TimeStampedModel):
                 held = (
                     cls.objects
                     .select_for_update(nowait=True)
-                    .filter(pk=tm_id, is_completed=False)
+                    .filter(pk=transition_message_id, is_completed=False)
                     .exists()
                 )
                 if not held:
                     return False
-                cls.objects.filter(pk=tm_id, is_completed=False).update(
+                cls.objects.filter(
+                    pk=transition_message_id, is_completed=False
+                ).update(
                     started_at=now, modified=now,
                 )
         except OperationalError:
@@ -303,7 +309,7 @@ class TransitionMessage(TimeStampedModel):
 
         ``measure_duration`` must be ``False`` when the row is finalized by
         a safety-net task (watchdog / detect_stuck) rather than by an actual
-        phase-2 attempt. In that case ``started_at`` belongs to an abandoned
+        worker attempt. In that case ``started_at`` belongs to an abandoned
         attempt that may be minutes or hours old, so ``now - started_at`` is
         the time-to-finalize, not an execution time — recording it as
         ``duration_ms`` would grossly inflate latency metrics. Leaving
@@ -325,7 +331,7 @@ class TransitionMessage(TimeStampedModel):
         """Terminal outcome for a row whose instance was moved by something
         else (manual ops fix, external write) while the row was pending.
 
-        The phase-2 state guard calls this instead of running side-effects:
+        The worker's state guard calls this instead of running side-effects:
         the row completes (so retries stop), the external state wins, and
         the reason is recorded on ``last_error_message`` for the audit
         trail. ``errors_count`` is NOT incremented — nothing failed.

--- a/django_logic/background/observability.py
+++ b/django_logic/background/observability.py
@@ -18,23 +18,27 @@ Both are best-effort and never affect transition execution.
 from __future__ import annotations
 
 
-def task_label(tm) -> str:
+def task_label(transition_message) -> str:
     """Stable, readable per-transition label, e.g. ``django_logic.orders.fulfill``."""
-    return f'django_logic.{tm.app_label}.{tm.transition_name}'
+    return (
+        f'django_logic.{transition_message.app_label}.'
+        f'{transition_message.transition_name}'
+    )
 
 
-def set_sentry_context(tm) -> None:
+def set_sentry_context(transition_message) -> None:
     """Name + tag the current Sentry scope per transition. No-op if sentry-sdk
     is absent. Never raises."""
     try:
         import sentry_sdk
 
         scope = sentry_sdk.get_current_scope()
-        scope.set_transaction_name(task_label(tm), source='custom')
-        scope.set_tag('dl.app', tm.app_label)
-        scope.set_tag('dl.model', tm.model_name)
-        scope.set_tag('dl.transition', tm.transition_name)
-        scope.set_tag('dl.instance_id', tm.instance_id)
-        scope.set_tag('dl.queue', tm.queue_name)
+        scope.set_transaction_name(
+            task_label(transition_message), source='custom')
+        scope.set_tag('dl.app', transition_message.app_label)
+        scope.set_tag('dl.model', transition_message.model_name)
+        scope.set_tag('dl.transition', transition_message.transition_name)
+        scope.set_tag('dl.instance_id', transition_message.instance_id)
+        scope.set_tag('dl.queue', transition_message.queue_name)
     except Exception:
         pass

--- a/django_logic/background/runner.py
+++ b/django_logic/background/runner.py
@@ -1,10 +1,10 @@
-"""Phase 2 execution.
+"""Worker execution of a background transition.
 
-``run_background_transition(tm_id)`` owns a single attempt at executing
+``run_background_transition(transition_message_id)`` owns a single attempt at executing
 a durable background transition. It runs the same way in:
 
 * the Celery task wrapper (:mod:`django_logic.background.tasks`), and
-* sync mode, directly after phase 1 in the same process.
+* sync mode, directly after enqueue in the same process.
 
 Structure:
 
@@ -14,7 +14,7 @@ Structure:
      (another worker already holds it → raise ``OperationalError`` →
      caller exits silently),
    * restores the instance + transition,
-   * verifies the instance is still in the state phase 1 left behind
+   * verifies the instance is still in the state enqueue left behind
      (the *state guard* — on mismatch the row completes as superseded
      and side-effects are skipped, so a manual ops fix is never
      overwritten),
@@ -23,8 +23,8 @@ Structure:
      transaction healthy even when the side-effect raised a genuine
      ``DatabaseError``, so the error bookkeeping below always works),
    * on success, writes ``target`` state (for ``BackgroundTransition``)
-     and marks the TM completed,
-   * on failure, records the error and either leaves the TM for retry
+     and marks the TransitionMessage completed,
+   * on failure, records the error and either leaves the row for retry
      or, at ``MAX_ERRORS``, writes ``failed_state`` and marks completed.
 
 2. After the atomic block (best-effort):
@@ -63,7 +63,7 @@ from django_logic.process import _iter_process_tree, _transition_context
 
 @dataclass
 class _Outcome:
-    """What phase 2's atomic block produced — drives best-effort phase 3."""
+    """What the worker's atomic block produced — drives best-effort hooks."""
 
     terminal: bool  # Work is done (target, failed, or nothing to run)
     succeeded: bool
@@ -80,7 +80,7 @@ def run_background_transition(transition_message_id: int) -> None:
     inline sync dispatcher.
     """
     # Committed BEFORE the attempt's atomic block, and deliberately not
-    # rolled back with it (#179) — see TransitionMessage.stamp_attempt_started.
+    # rolled back with it — see TransitionMessage.stamp_attempt_started.
     # This is the marker the watchdog and the retry starter's recency guard
     # read; written inside the atomic it was invisible to both.
     if not TransitionMessage.stamp_attempt_started(transition_message_id):
@@ -104,12 +104,12 @@ def run_background_transition(transition_message_id: int) -> None:
         # The atomic block rolled back, so we couldn't mark_as_completed
         # from inside it. Do it here, in its own statement, to stop the
         # retry loop from picking the row up forever.
-        _mark_unrestorable_completed(exc.tm_id, exc.reason)
+        _mark_unrestorable_completed(exc.transition_message_id, exc.reason)
         return
     except _NothingToDo:
         return
 
-    # Phase 3 (best-effort).
+    # Best-effort hooks after the transaction commits.
     if outcome.terminal and outcome.succeeded and outcome.transition is not None:
         _run_success_hooks(outcome)
     elif outcome.terminal and not outcome.succeeded and outcome.transition is not None:
@@ -134,42 +134,42 @@ def run_background_transition(transition_message_id: int) -> None:
 
 
 class _NothingToDo(Exception):
-    """Internal signal: the TM is already completed, missing, or locked
+    """Internal signal: the row is already completed, missing, or locked
     by another worker. Caller should exit silently."""
 
 
 class _StopRetry(Exception):
-    """Internal signal: the TM refers to a model/transition that no
+    """Internal signal: the row refers to a model/transition that no
     longer exists. The atomic block rolled back; the outer handler
-    marks the TM completed in its own statement so retries stop.
+    marks the row completed in its own statement so retries stop.
     ``reason`` carries the restore-failure description for the audit
     trail on ``last_error_message``."""
 
-    def __init__(self, tm_id: int, reason: str = ''):
-        self.tm_id = tm_id
+    def __init__(self, transition_message_id: int, reason: str = ''):
+        self.transition_message_id = transition_message_id
         self.reason = reason
 
 
 UNRESTORABLE_MARKER = '[unrestorable]'
 
 
-def _mark_unrestorable_completed(tm_id: int, reason: str = '') -> None:
-    """Mark an unrestorable TM completed so the periodic starter stops
+def _mark_unrestorable_completed(transition_message_id: int, reason: str = '') -> None:
+    """Mark an unrestorable row completed so the periodic starter stops
     re-dispatching it forever, recording WHY on ``last_error_message``
     (mirroring the ``'[superseded]'`` convention — see
     ``TransitionMessage.mark_as_superseded``) so an operator reading the
     row later isn't left with a completed row and no explanation.
 
     Runs as a single UPDATE outside the (already-exited, rolled-back)
-    phase-2 atomic block. Durability depends on the execution mode:
+    worker atomic block. Durability depends on the execution mode:
 
-    * Celery mode — phase 2 runs as the top-level unit of work with no
+    * Celery mode — the worker runs as the top-level unit of work with no
       surrounding transaction, so this UPDATE autocommits and is durable.
       This is the path the original infinite-retry bug lived on.
-    * Sync mode — phase 1 (which created the row) and phase 2 run in the
+    * Sync mode — enqueue (which created the row) and execute run in the
       same call stack and share the caller's transaction state. If the
       caller wraps the whole call in ``atomic()`` and later rolls back,
-      this UPDATE rolls back too — but so does the phase-1 INSERT, so there
+      this UPDATE rolls back too — but so does the enqueue INSERT, so there
       is no surviving row to re-dispatch and the stop-retry guarantee still
       holds. It is NOT a write that survives an *independent* parent
       rollback on its own; correcting an earlier docstring that claimed so.
@@ -182,7 +182,7 @@ def _mark_unrestorable_completed(tm_id: int, reason: str = '') -> None:
     # stop-retry guarantee this function exists to provide.
     note = db_safe_text(f'{UNRESTORABLE_MARKER} {reason or "restore failed"}')
     try:
-        TransitionMessage.objects.filter(pk=tm_id, is_completed=False).update(
+        TransitionMessage.objects.filter(pk=transition_message_id, is_completed=False).update(
             is_completed=True,
             completed_at=now,
             last_error_message=note,
@@ -191,13 +191,13 @@ def _mark_unrestorable_completed(tm_id: int, reason: str = '') -> None:
         )
     except Exception as e:
         transition_logger.error(
-            f'Failed to mark unrestorable TransitionMessage#{tm_id} '
+            f'Failed to mark unrestorable TransitionMessage#{transition_message_id} '
             f'completed: {e}'
         )
 
 
-def abandon_timed_out_attempt(tm_id: int) -> bool:
-    """Record a synthetic timeout error on a TM whose current attempt
+def abandon_timed_out_attempt(transition_message_id: int) -> bool:
+    """Record a synthetic timeout error on a row whose current attempt
     has exceeded its declared ``timeout_seconds``.
 
     Skips rows currently held by a worker (``select_for_update(nowait)``
@@ -224,16 +224,16 @@ def abandon_timed_out_attempt(tm_id: int) -> bool:
     hooks = None
     with transaction.atomic():
         try:
-            tm = (
+            transition_message = (
                 TransitionMessage.objects
                 .select_for_update(nowait=True)
-                .get(pk=tm_id, is_completed=False)
+                .get(pk=transition_message_id, is_completed=False)
             )
         except TransitionMessage.DoesNotExist:
             return False
         except OperationalError:
             transition_logger.info(
-                f'watchdog: TransitionMessage#{tm_id} currently locked '
+                f'watchdog: TransitionMessage#{transition_message_id} currently locked '
                 f'by a worker; deferring abandon'
             )
             return False
@@ -248,20 +248,20 @@ def abandon_timed_out_attempt(tm_id: int) -> bool:
         # out from under its live worker at MAX_ERRORS. The scan's staleness
         # verdict is only a hint; the locked read is the truth.
         if (
-            tm.started_at is None
-            or tm.timeout_seconds is None
-            or tm.started_at + timedelta(seconds=tm.timeout_seconds)
+            transition_message.started_at is None
+            or transition_message.timeout_seconds is None
+            or transition_message.started_at + timedelta(seconds=transition_message.timeout_seconds)
             >= timezone.now()
         ):
             transition_logger.info(
-                f'watchdog: TransitionMessage#{tm.pk} is not stale when '
-                f're-checked under the row lock (started_at={tm.started_at}, '
-                f'timeout_seconds={tm.timeout_seconds}); a newer attempt '
+                f'watchdog: TransitionMessage#{transition_message.pk} is not stale when '
+                f're-checked under the row lock (started_at={transition_message.started_at}, '
+                f'timeout_seconds={transition_message.timeout_seconds}); a newer attempt '
                 f'started since the scan. Leaving it alone.'
             )
             return False
 
-        # One charge per attempt (#179). If an error has been recorded since
+        # One charge per attempt. If an error has been recorded since
         # this attempt started, the attempt already accounted for itself —
         # it is not abandoned, and charging again would burn a retry the
         # consumer never used. Left unguarded, the watchdog re-charged the
@@ -269,51 +269,51 @@ def abandon_timed_out_attempt(tm_id: int) -> bool:
         # new attempts), so declaring timeout= made a transition strictly
         # LESS reliable than omitting it.
         if (
-            tm.last_error_dt is not None
-            and tm.started_at is not None
-            and tm.last_error_dt >= tm.started_at
+            transition_message.last_error_dt is not None
+            and transition_message.started_at is not None
+            and transition_message.last_error_dt >= transition_message.started_at
         ):
             transition_logger.info(
-                f'watchdog: TransitionMessage#{tm.pk} exceeded '
-                f'timeout_seconds={tm.timeout_seconds} but its attempt '
-                f'already recorded an error at {tm.last_error_dt}; not '
+                f'watchdog: TransitionMessage#{transition_message.pk} exceeded '
+                f'timeout_seconds={transition_message.timeout_seconds} but its attempt '
+                f'already recorded an error at {transition_message.last_error_dt}; not '
                 f'charging it twice.'
             )
             return False
 
         transition_logger.error(
-            f'watchdog: TransitionMessage#{tm.pk} '
-            f'{tm.app_label}.{tm.model_name}#{tm.instance_id} '
-            f'{tm.transition_name} exceeded timeout_seconds='
-            f'{tm.timeout_seconds}; recording timeout error'
+            f'watchdog: TransitionMessage#{transition_message.pk} '
+            f'{transition_message.app_label}.{transition_message.model_name}#{transition_message.instance_id} '
+            f'{transition_message.transition_name} exceeded timeout_seconds='
+            f'{transition_message.timeout_seconds}; recording timeout error'
         )
         err = TimeoutError(
             f'[watchdog timeout] attempt exceeded '
-            f'timeout_seconds={tm.timeout_seconds}'
+            f'timeout_seconds={transition_message.timeout_seconds}'
         )
-        tm.record_error(err)
+        transition_message.record_error(err)
 
         max_errors = bg_settings.max_errors()
-        if tm.errors_count >= max_errors:
+        if transition_message.errors_count >= max_errors:
             # Terminal. Finalize inside this same atomic — we already
             # hold the row lock so we cannot recurse through
             # finalize_stuck_attempt (deadlock).
-            hooks = _finalize_terminal_from_watchdog(tm, err, source='watchdog')
+            hooks = _finalize_terminal_from_watchdog(transition_message, err, source='watchdog')
 
     # Run failure_callbacks after the atomic commits and the row lock is
-    # released (phase 3, best-effort) — see _run_failure_callbacks.
+    # released (best-effort) — see _run_failure_callbacks.
     if hooks is not None:
         _run_failure_callbacks(*hooks)
     return True
 
 
-def finalize_stuck_attempt(tm_id: int) -> bool:
-    """Force a stuck (``errors_count >= MAX_ERRORS``, uncompleted) TM
+def finalize_stuck_attempt(transition_message_id: int) -> bool:
+    """Force a stuck (``errors_count >= MAX_ERRORS``, uncompleted) row
     into a terminal state (``failed_state`` + ``failure_side_effects``
     + ``mark_as_completed``).
 
     Called by ``detect_stuck_transitions``. If the row is currently
-    locked by a worker running phase 2 we exit silently — the running
+    locked by a worker we exit silently — the running
     attempt will finalize on its own. Otherwise we restore the
     transition, run the terminal-failure sequence, and mark completed.
 
@@ -322,52 +322,52 @@ def finalize_stuck_attempt(tm_id: int) -> bool:
     hooks = None
     with transaction.atomic():
         try:
-            tm = (
+            transition_message = (
                 TransitionMessage.objects
                 .select_for_update(nowait=True)
-                .get(pk=tm_id, is_completed=False)
+                .get(pk=transition_message_id, is_completed=False)
             )
         except TransitionMessage.DoesNotExist:
             return False
         except OperationalError:
             transition_logger.info(
-                f'detect_stuck: TransitionMessage#{tm_id} locked by a '
+                f'detect_stuck: TransitionMessage#{transition_message_id} locked by a '
                 f'worker; deferring finalization'
             )
             return False
 
         transition_logger.error(
-            f'Stuck transition: TransitionMessage#{tm.pk} '
-            f'{tm.app_label}.{tm.model_name}#{tm.instance_id} '
-            f'{tm.transition_name} queue={tm.queue_name} '
-            f'errors={tm.errors_count} '
-            f'last_error={tm.last_error_message!r}; forcing terminal state'
+            f'Stuck transition: TransitionMessage#{transition_message.pk} '
+            f'{transition_message.app_label}.{transition_message.model_name}#{transition_message.instance_id} '
+            f'{transition_message.transition_name} queue={transition_message.queue_name} '
+            f'errors={transition_message.errors_count} '
+            f'last_error={transition_message.last_error_message!r}; forcing terminal state'
         )
         # Rehydrate an exception from the stored last_error_message so
         # failure_side_effects see the same error shape the final in-task
         # attempt would have seen.
         err = RuntimeError(
-            f'[detect_stuck] {tm.last_error_message or "transition stuck"}'
+            f'[detect_stuck] {transition_message.last_error_message or "transition stuck"}'
         )
-        hooks = _finalize_terminal_from_watchdog(tm, err, source='detect_stuck')
+        hooks = _finalize_terminal_from_watchdog(transition_message, err, source='detect_stuck')
 
-    # Run failure_callbacks after the atomic commits (phase 3, best-effort).
+    # Run failure_callbacks after the atomic commits (best-effort).
     if hooks is not None:
         _run_failure_callbacks(*hooks)
     return True
 
 
 def _finalize_terminal_from_watchdog(
-    tm: TransitionMessage,
+    transition_message: TransitionMessage,
     exception: BaseException,
     source: str,
 ):
     """Shared terminal-failure path for the watchdog / detect-stuck tasks.
 
-    Must run inside the caller's atomic block, with the TM row already
+    Must run inside the caller's atomic block, with the row already
     locked. Mirrors ``_handle_failure``'s terminal branch: set
     failed_state, run failure_side_effects (capturing swallowed errors
-    onto the TM), mark completed.
+    onto the row), mark completed.
 
     If the transition can't be restored (model uninstalled / transition
     renamed), we still mark_as_completed so the retry loop stops;
@@ -377,7 +377,7 @@ def _finalize_terminal_from_watchdog(
     Returns the ``(transition, state, kwargs, exception)`` tuple the caller
     needs to run ``failure_callbacks`` *after* its atomic block commits
     (so callbacks don't run while holding the row lock, matching the
-    in-task phase-3 timing), or ``None`` when the row was unrestorable
+    in-task hook timing), or ``None`` when the row was unrestorable
     (nothing to run callbacks on).
     """
     try:
@@ -385,11 +385,11 @@ def _finalize_terminal_from_watchdog(
         # the user table), so a genuine DatabaseError inside it would poison
         # the caller's atomic and take the completion below down with it.
         with transaction.atomic():
-            _, process, transition = _restore(tm)
+            _, process, transition = _restore(transition_message)
     except _RestoreError:
         # No attempt ran here, so started_at (if any) belongs to an
         # abandoned attempt — don't record a misleading duration.
-        tm.mark_as_completed(measure_duration=False)
+        transition_message.mark_as_completed(measure_duration=False)
         return None
     except Exception as exc:
         # Anything _restore did not classify as permanent (a consumer
@@ -397,21 +397,21 @@ def _finalize_terminal_from_watchdog(
         # Escaping here rolled back the whole finalization on every tick, so
         # the safety net looped forever on this one row. Completing it stops
         # the loop; the instance stays in its in_progress_state, which is an
-        # implicit source — re-drivable by an operator or a periodic re-drive.
+        # implicit source — an operator can run the transition again.
         transition_logger.error(
-            f'{source}: TransitionMessage#{tm.pk} could not be restored '
+            f'{source}: TransitionMessage#{transition_message.pk} could not be restored '
             f'({type(exc).__name__}: {exc}); completing it so the safety net '
             f'stops retrying. The instance is left parked in its '
             f'in_progress_state, which is an implicit source of the same '
-            f'transition — re-drive it to move it on.',
+            f'transition — run it again to move it on.',
             exc_info=True,
         )
-        tm.mark_as_completed(measure_duration=False)
+        transition_message.mark_as_completed(measure_duration=False)
         return None
 
     try:
         with transaction.atomic():
-            kwargs = deserialize_kwargs(tm.kwargs)
+            kwargs = deserialize_kwargs(transition_message.kwargs)
     except Exception as exc:
         # Terminal finalization must not be blocked by kwargs that no
         # longer decode: proceed with empty kwargs so failed_state and
@@ -419,7 +419,7 @@ def _finalize_terminal_from_watchdog(
         # keeps the outer transaction healthy if the failure was a
         # genuine DatabaseError (restore_user queries the user table).
         transition_logger.error(
-            f'{source}: TransitionMessage#{tm.pk} kwargs failed to decode '
+            f'{source}: TransitionMessage#{transition_message.pk} kwargs failed to decode '
             f'({type(exc).__name__}: {exc}); finalizing with empty kwargs.'
         )
         kwargs = {}
@@ -427,7 +427,7 @@ def _finalize_terminal_from_watchdog(
     kwargs.setdefault('context', {})
     state = process.state
 
-    # Same state guard as the phase-2 attempt path, and with the same verdict:
+    # Same state guard as the worker attempt path, and with the same verdict:
     # a manual ops fix wins WHOLE (CLAUDE.md contract 7), not just against the
     # failed_state write. Guarding only the write meant a safety net still ran
     # failure_side_effects and failure_callbacks against an instance an
@@ -441,17 +441,17 @@ def _finalize_terminal_from_watchdog(
             f'{current!r} — the instance was moved by something else while '
             f'this row was pending. failed_state and failure hooks skipped; '
             f'the external state change wins. Prior error: '
-            f'{tm.last_error_message or "(none recorded)"}'
+            f'{transition_message.last_error_message or "(none recorded)"}'
         )
         transition_logger.error(
-            f'{source}: TransitionMessage#{tm.pk} {transition.action_name} '
+            f'{source}: TransitionMessage#{transition_message.pk} {transition.action_name} '
             f'{state.instance_key}: {note}'
         )
-        tm.mark_as_superseded(note)
+        transition_message.mark_as_superseded(note)
         return None
 
     if transition.failed_state:
-        # Savepointed and never allowed to escape (#178): this runs inside the
+        # Savepointed and never allowed to escape: this runs inside the
         # caller's atomic with the row locked, so a rejected write used to
         # abort the whole finalization — leaving the row uncompleted with
         # errors_count already at MAX_ERRORS, which detect_stuck retried on
@@ -463,7 +463,7 @@ def _finalize_terminal_from_watchdog(
         try:
             # require_commit: the else-branch below logs the write as landed,
             # so a silently discarded savepoint must surface as the failure
-            # it is and take the honest except-path instead (#189).
+            # it is and take the honest except-path instead.
             _run_in_savepoint(
                 state.instance._state.db or DEFAULT_DB_ALIAS,
                 lambda: state.set_state(transition.failed_state),
@@ -481,7 +481,7 @@ def _finalize_terminal_from_watchdog(
                 f'Completing the row anyway so it stops retrying.',
                 exc_info=True,
             )
-            tm.record_failure_side_effect_error(
+            transition_message.record_failure_side_effect_error(
                 write_error, label='failed_state write')
         else:
             transition_logger.info(
@@ -490,17 +490,17 @@ def _finalize_terminal_from_watchdog(
             )
 
     # FailureSideEffects.execute savepoints itself inside an open
-    # transaction and returns the swallowed exception; record it on the TM
+    # transaction and returns the swallowed exception; record it on the row
     # so a broken cleanup path is not invisible.
     fse_error = transition.failure_side_effects.execute(
         state, exception=exception, **kwargs
     )
     if fse_error is not None:
-        tm.record_failure_side_effect_error(
+        transition_message.record_failure_side_effect_error(
             fse_error, label='failure_side_effects')
     # A safety-net finalization is not a worker attempt; started_at points
     # at the abandoned attempt, so don't let it inflate duration_ms.
-    tm.mark_as_completed(measure_duration=False)
+    transition_message.mark_as_completed(measure_duration=False)
     return (transition, state, kwargs, exception)
 
 
@@ -527,7 +527,7 @@ def _run_failure_callbacks(transition, state, kwargs, exception) -> None:
         )
 
 
-def _run_atomic(tm_id: int) -> _Outcome:
+def _run_atomic(transition_message_id: int) -> _Outcome:
     # Invariant: everything that must survive together lives inside this
     # atomic block — row lock, side-effects, the target state write, and
     # either mark_as_completed (on success / terminal failure) or the
@@ -535,33 +535,33 @@ def _run_atomic(tm_id: int) -> _Outcome:
     # mark_as_* / record_error calls out is what broke the unrestorable-row
     # path (see _StopRetry). Don't do it.
     #
-    # started_at is the deliberate exception (#179): it is a MARKER, not
+    # started_at is the deliberate exception: it is a MARKER, not
     # accounting, and it has to be visible to other connections while the
     # attempt runs and to survive the attempt rolling back — so it is stamped
     # and committed by the caller before this block opens.
     with transaction.atomic():
         try:
-            tm = (
+            transition_message = (
                 TransitionMessage.objects
                 .select_for_update(nowait=True)
-                .get(pk=tm_id, is_completed=False)
+                .get(pk=transition_message_id, is_completed=False)
             )
         except TransitionMessage.DoesNotExist as exc:
             transition_logger.info(
-                f'TransitionMessage#{tm_id} already completed or missing; '
+                f'TransitionMessage#{transition_message_id} already completed or missing; '
                 f'nothing to do'
             )
             raise _NothingToDo() from exc
         except OperationalError as exc:
             transition_logger.info(
-                f'TransitionMessage#{tm_id} locked by another worker; '
+                f'TransitionMessage#{transition_message_id} locked by another worker; '
                 f'skipping this attempt'
             )
             raise _NothingToDo() from exc
 
         # Per-transition monitoring identity (Sentry transaction name + tags);
-        # best-effort, no-op without sentry-sdk. See observability.py / issue #78.
-        set_sentry_context(tm)
+        # best-effort, no-op without sentry-sdk. See observability.py.
+        set_sentry_context(transition_message)
 
         # A decode failure must be accounted like any attempt failure —
         # raised here it would escape before record_error with errors_count
@@ -574,13 +574,13 @@ def _run_atomic(tm_id: int) -> _Outcome:
         decode_error = None
         try:
             with transaction.atomic():
-                kwargs = deserialize_kwargs(tm.kwargs)
+                kwargs = deserialize_kwargs(transition_message.kwargs)
         except Exception as exc:
             decode_error = exc
             kwargs = {}
         # Mirror the synchronous path (Transition._init_transition_context):
         # side-effects/callbacks may read a framework-provided ``context``
-        # dict. serialize_kwargs drops it at phase 1, so rebuild it here —
+        # dict. serialize_kwargs drops it at enqueue, so rebuild it here —
         # otherwise a side-effect declared as ``def fn(instance, context,
         # **kwargs)`` works synchronously but raises in background mode.
         kwargs.setdefault('context', {})
@@ -592,35 +592,35 @@ def _run_atomic(tm_id: int) -> _Outcome:
             # genuine DatabaseError must poison only the savepoint or the
             # error bookkeeping below cannot run.
             with transaction.atomic():
-                instance, process, transition = _restore(tm)
+                instance, process, transition = _restore(transition_message)
         except _RestoreError as exc:
             transition_logger.error(
-                f'TransitionMessage#{tm.pk} cannot be restored: {exc}. '
+                f'TransitionMessage#{transition_message.pk} cannot be restored: {exc}. '
                 f'Marking completed to stop retries.'
             )
             # Don't mark_as_completed() here — we're inside an atomic
             # block that will roll back when we exit. The outer handler
             # in run_background_transition() performs the mark in a
             # fresh statement so the stop-retry flag actually persists.
-            raise _StopRetry(tm.pk, str(exc)) from exc
+            raise _StopRetry(transition_message.pk, str(exc)) from exc
         except Exception as exc:
             # _restore only classifies the PERMANENT failures (model
             # uninstalled, row gone, transition renamed) as _RestoreError.
             # Anything else — a consumer ``process`` property raising, a
             # corrupt instance_id failing pk coercion, a transient database
-            # error — used to escape phase 2 with errors_count still 0, so the
+            # error — used to escape the worker with errors_count still 0, so the
             # starter re-dispatched the row forever: the same unaccounted
-            # infinite-retry class #178 closed for rejected state writes.
+            # infinite-retry class that rejected state writes used to have.
             # Account it like any other attempt failure instead: transient
             # causes get their retries, permanent ones burn MAX_ERRORS and stop.
             restore_error = exc
 
         if restore_error is not None:
-            return _handle_restore_failure(tm, restore_error)
+            return _handle_restore_failure(transition_message, restore_error)
 
         state = process.state
 
-        # State guard: phase 2 restores by name and deliberately bypasses
+        # State guard: the worker restores by name and deliberately bypasses
         # the source-state gate, so without this check it would overwrite
         # any state change made while the row was pending — including a
         # manual ops fix. With retries spanning RETRY_MINUTES × MAX_ERRORS
@@ -628,23 +628,23 @@ def _run_atomic(tm_id: int) -> _Outcome:
         matches, expected, current = _state_guard_matches(transition, state)
         if not matches:
             note = (
-                f'[superseded] phase-2 state guard: expected {expected}, '
+                f'[superseded] worker state guard: expected {expected}, '
                 f'found {current!r} — the instance was moved by something '
                 f'else while this transition was pending. Side-effects '
                 f'skipped; the external state change wins.'
             )
             transition_logger.error(
-                f'{kwargs.get("tr_id")} TransitionMessage#{tm.pk} '
+                f'{kwargs.get("tr_id")} TransitionMessage#{transition_message.pk} '
                 f'{transition.action_name} {state.instance_key}: {note}'
             )
-            tm.mark_as_superseded(note)
+            transition_message.mark_as_superseded(note)
             return _Outcome(terminal=True, succeeded=False)
 
         # started_at was already stamped and committed by the caller
         # (stamp_attempt_started), so the row loaded above carries it and
         # the watchdog can see this attempt while it runs. Nothing to write
         # here — writing it inside this atomic is exactly what made the
-        # marker invisible (#179).
+        # stamp invisible.
         token = _transition_context.set(
             {
                 'root_id': kwargs.get('root_id'),
@@ -655,11 +655,11 @@ def _run_atomic(tm_id: int) -> _Outcome:
             transition_logger.info(
                 f'{kwargs.get("tr_id")} Phase2 Start '
                 f'{transition.action_name} {state.instance_key} '
-                f'queue={tm.queue_name}'
+                f'queue={transition_message.queue_name}'
             )
             if decode_error is not None:
                 return _handle_failure(
-                    tm, transition, state, kwargs, decode_error
+                    transition_message, transition, state, kwargs, decode_error
                 )
             def _attempt():
                 for command in transition.side_effects.commands:
@@ -669,8 +669,8 @@ def _run_atomic(tm_id: int) -> _Outcome:
                         f'{getattr(command, "__name__", repr(command))}'
                     )
                     command(instance, **kwargs)
-                # The target write belongs INSIDE the attempt savepoint
-                # (#178). It is part of the attempt, so a write the
+                # The target write belongs INSIDE the attempt savepoint.
+                # It is part of the attempt, so a write the
                 # database rejects — CHECK constraint, pre_save receiver,
                 # save() override, column length — must roll the attempt
                 # back and be accounted like any other failure. Outside
@@ -724,15 +724,15 @@ def _run_atomic(tm_id: int) -> _Outcome:
                     require_commit=True,
                 )
             except Exception as error:
-                return _handle_failure(tm, transition, state, kwargs, error)
+                return _handle_failure(transition_message, transition, state, kwargs, error)
             else:
-                return _handle_success(tm, transition, state, kwargs)
+                return _handle_success(transition_message, transition, state, kwargs)
         finally:
             _transition_context.reset(token)
 
 
 def _handle_restore_failure(
-    tm: TransitionMessage, error: BaseException,
+    transition_message: TransitionMessage, error: BaseException,
 ) -> _Outcome:
     """Account a restore failure that is not one of the permanent classes.
 
@@ -741,39 +741,39 @@ def _handle_restore_failure(
     remain, and at ``MAX_ERRORS`` complete the row loudly so the retry loop
     stops. No ``failed_state`` is written (nothing restored to write it on),
     so the instance is left parked in its ``in_progress_state`` — which is an
-    implicit source of the same transition, so it stays re-drivable: a visible
+    implicit source of the same transition, so it can be run again: a visible
     parked state rather than an infinite loop, with the reason on the completed
     row.
     """
-    tm.record_error(error)
+    transition_message.record_error(error)
     transition_logger.error(
-        f'TransitionMessage#{tm.pk} restore raised '
+        f'TransitionMessage#{transition_message.pk} restore raised '
         f'{type(error).__name__}: {error}',
         exc_info=True,
     )
-    if tm.errors_count < bg_settings.max_errors():
+    if transition_message.errors_count < bg_settings.max_errors():
         return _Outcome(terminal=False, succeeded=False, exception=error)
 
     transition_logger.error(
-        f'TransitionMessage#{tm.pk} restore failed {tm.errors_count} times; '
+        f'TransitionMessage#{transition_message.pk} restore failed {transition_message.errors_count} times; '
         f'completing the row so it stops retrying. No failed_state could be '
         f'written — the instance is left parked in its in_progress_state, '
-        f're-drivable via the implicit source.'
+        f'ready to run again via the implicit source.'
     )
-    tm.mark_as_completed(measure_duration=False)
+    transition_message.mark_as_completed(measure_duration=False)
     return _Outcome(terminal=True, succeeded=False, exception=error)
 
 
 def _handle_success(
-    tm: TransitionMessage,
+    transition_message: TransitionMessage,
     transition: BackgroundTransition,
     state,
     kwargs: dict,
 ) -> _Outcome:
-    # The target write happens inside the attempt savepoint in _run_atomic
-    # (#178), so by here the state is already committed-pending and this
-    # only has to close the row out.
-    tm.mark_as_completed()
+    # The target write happens inside the attempt savepoint in _run_atomic,
+    # so by here the state is already committed-pending and this only has
+    # to close the row out.
+    transition_message.mark_as_completed()
     transition_logger.info(
         f'{kwargs.get("tr_id")} {TransitionEventType.COMPLETE.value}'
     )
@@ -787,13 +787,13 @@ def _handle_success(
 
 
 def _handle_failure(
-    tm: TransitionMessage,
+    transition_message: TransitionMessage,
     transition: BackgroundTransition,
     state,
     kwargs: dict,
     error: BaseException,
 ) -> _Outcome:
-    tm.record_error(error)
+    transition_message.record_error(error)
     transition_logger.error(
         f'{kwargs.get("tr_id")} {TransitionEventType.FAIL.value}: '
         f'{type(error).__name__}: {error}',
@@ -801,7 +801,7 @@ def _handle_failure(
     )
 
     max_errors = bg_settings.max_errors()
-    if tm.errors_count < max_errors:
+    if transition_message.errors_count < max_errors:
         # Leave uncompleted → periodic starter will retry.
         return _Outcome(
             terminal=False,
@@ -814,15 +814,15 @@ def _handle_failure(
 
     # Terminal failure: write failed_state (if any) and mark completed.
     #
-    # Savepointed, and never allowed to escape (#178). This write comes
+    # Savepointed, and never allowed to escape. This write comes
     # AFTER record_error, so letting it propagate rolled that error back and
     # pinned errors_count one below MAX_ERRORS forever — the row could never
     # terminalise and retried indefinitely. Completing the row is what stops
     # the retry loop, so a rejected failed_state must not prevent it: log it,
     # record it where an operator will see it, and carry on to
     # mark_as_completed. The instance is then left in its in_progress_state
-    # re-drivable via the implicit source — a visible parked state rather
-    # than an infinite loop.
+    # and can be run again via the implicit source — a visible parked
+    # state rather than an infinite loop.
     if transition.failed_state:
         previous = state.get_state()
         try:
@@ -830,7 +830,7 @@ def _handle_failure(
             # attempt savepoint in _run_atomic for why both matter.
             # require_commit: the else-branch below logs SET_STATE, so a
             # silently discarded savepoint must surface as the failure it is
-            # and take the honest except-path instead (#189).
+            # and take the honest except-path instead.
             _run_in_savepoint(
                 state.instance._state.db or DEFAULT_DB_ALIAS,
                 lambda: state.set_state(transition.failed_state),
@@ -846,11 +846,11 @@ def _handle_failure(
                 f'{transition.failed_state!r} on {state.instance_key}: '
                 f'{type(write_error).__name__}: {write_error}. Completing the '
                 f'row anyway so it stops retrying; the instance stays parked '
-                f'in {transition.in_progress_state!r}, re-drivable via the '
-                f'implicit source.',
+                f'in {transition.in_progress_state!r}, ready to run again '
+                f'via the implicit source.',
                 exc_info=True,
             )
-            tm.record_failure_side_effect_error(
+            transition_message.record_failure_side_effect_error(
                 write_error, label='failed_state write')
         else:
             transition_logger.info(
@@ -863,9 +863,9 @@ def _handle_failure(
         state, exception=error, **kwargs
     )
     if fse_error is not None:
-        tm.record_failure_side_effect_error(
+        transition_message.record_failure_side_effect_error(
             fse_error, label='failure_side_effects')
-    tm.mark_as_completed()
+    transition_message.mark_as_completed()
     return _Outcome(
         terminal=True,
         succeeded=False,
@@ -902,14 +902,14 @@ def _run_success_hooks(outcome: _Outcome) -> None:
 
 class _RestoreError(Exception):
     """The TransitionMessage refers to a model/instance/transition that
-    no longer exists. The TM is marked completed to stop the retry loop.
+    no longer exists. The row is marked completed to stop the retry loop.
     """
 
 
 def _state_guard_matches(transition, state) -> tuple[bool, str, str]:
-    """Does the persisted state still match what phase 1 left behind?
+    """Does the persisted state still match what enqueue left behind?
 
-    * Transition with ``in_progress_state`` — phase 1 wrote it, so the
+    * Transition with ``in_progress_state`` — enqueue wrote it, so the
       instance must still be exactly there.
     * Transition without ``in_progress_state`` / BackgroundAction — the
       instance must still be in one of the declared sources.
@@ -930,14 +930,14 @@ def _state_guard_matches(transition, state) -> tuple[bool, str, str]:
     )
 
 
-def _restore(tm: TransitionMessage):
-    """Resolve ``(instance, process, transition)`` from a TM row."""
+def _restore(transition_message: TransitionMessage):
+    """Resolve ``(instance, process, transition)`` from a TransitionMessage row."""
     try:
-        app = apps.get_app_config(tm.app_label)
-        model = app.get_model(tm.model_name)
+        app = apps.get_app_config(transition_message.app_label)
+        model = app.get_model(transition_message.model_name)
     except LookupError as exc:
         raise _RestoreError(
-            f'model {tm.app_label}.{tm.model_name} not installed'
+            f'model {transition_message.app_label}.{transition_message.model_name} not installed'
         ) from exc
 
     try:
@@ -948,24 +948,24 @@ def _restore(tm: TransitionMessage):
         # in_progress_state with no failed_state and no retries. Framework
         # code reloading by pk must be immune to default-manager filtering
         # (Django's own convention for related-object loading).
-        instance = model._base_manager.get(pk=tm.instance_id)
+        instance = model._base_manager.get(pk=transition_message.instance_id)
     except model.DoesNotExist as exc:
         raise _RestoreError(
-            f'{tm.app_label}.{tm.model_name}#{tm.instance_id} not found'
+            f'{transition_message.app_label}.{transition_message.model_name}#{transition_message.instance_id} not found'
         ) from exc
 
-    recorded_path = (tm.kwargs or {}).get('process_class')
+    recorded_path = (transition_message.kwargs or {}).get('process_class')
     try:
-        process = getattr(instance, tm.process_name)
+        process = getattr(instance, transition_message.process_name)
     except AttributeError:
         # Fall back to process_class stored in kwargs, if any.
         if not recorded_path:
             raise _RestoreError(
-                f'instance has no process named {tm.process_name!r} and '
+                f'instance has no process named {transition_message.process_name!r} and '
                 f'no process_class stored on the message'
             )
         try:
-            process = _load_process_from_path(instance, recorded_path, tm)
+            process = _load_process_from_path(instance, recorded_path, transition_message)
         except Exception as exc:
             # Fail closed, through the accounted stop-retry path. A raw
             # ImportError here would escape _run_atomic (which only
@@ -977,82 +977,84 @@ def _restore(tm: TransitionMessage):
                 f'loaded: {exc}'
             ) from exc
     else:
-        # Verify the attribute resolved the same class phase 1 enqueued.
+        # Verify the attribute resolved the same class enqueue recorded.
         # Every Process defaults to process_name='process', so a name
         # collision (directly-instantiated process vs the bound one, or a
-        # rebind between deploy of phase 1 and phase 2) silently restores
-        # the WRONG class — phase 2 would run side-effects the caller
-        # never asked for. Prefer the recorded class on mismatch.
+        # rebind between enqueue and execute) silently restores the WRONG
+        # class — the worker would run side-effects the caller never asked
+        # for. Prefer the recorded class on mismatch.
         if recorded_path:
             resolved_path = f'{type(process).__module__}.{type(process).__name__}'
             if resolved_path != recorded_path:
                 transition_logger.warning(
-                    f'TransitionMessage#{tm.pk}: process_name '
-                    f'{tm.process_name!r} resolved to {resolved_path}, but '
+                    f'TransitionMessage#{transition_message.pk}: process_name '
+                    f'{transition_message.process_name!r} resolved to {resolved_path}, but '
                     f'the message was enqueued by {recorded_path}; using '
                     f'the recorded class.'
                 )
                 try:
                     process = _load_process_from_path(
-                        instance, recorded_path, tm
+                        instance, recorded_path, transition_message
                     )
                 except Exception as exc:
                     # Fail closed: running the attribute-resolved process
-                    # instead would execute side-effects phase 1 never
+                    # instead would execute side-effects enqueue never
                     # asked for. The row completes as unrestorable (no
-                    # side-effects, no state write): drain in-flight rows
-                    # before renaming a Process class.
+                    # side-effects, no state write): complete pending
+                    # rows before renaming a Process class.
                     raise _RestoreError(
                         f'recorded process_class {recorded_path!r} could '
                         f'not be loaded: {exc}'
                     ) from exc
 
-    transition = _find_transition(process, tm)
+    transition = _find_transition(process, transition_message)
     if transition is None:
         raise _RestoreError(
-            f'transition {tm.transition_name!r} not found on process '
+            f'transition {transition_message.transition_name!r} not found on process '
             f'{type(process).__module__}.{type(process).__name__}'
         )
     return instance, process, transition
 
 
-def _load_process_from_path(instance, dotted: str, tm: TransitionMessage):
+def _load_process_from_path(instance, dotted: str, transition_message: TransitionMessage):
     module_path, class_name = dotted.rsplit('.', 1)
     module = importlib.import_module(module_path)
     process_class = getattr(module, class_name)
-    if not tm.field_name:
-        # Phase 1 has recorded the bound field since 0.4; a row without one
+    if not transition_message.field_name:
+        # Enqueue has recorded the bound field since 0.4; a row without one
         # cannot be restored to a known field, and guessing 'state' could
         # drive the wrong machine on a multi-process model.
         raise _RestoreError(
-            f'TransitionMessage {tm.pk} has no field_name; it predates 0.4 '
+            f'TransitionMessage {transition_message.pk} has no field_name; it predates 0.4 '
             f'or was created by hand'
         )
-    return process_class(field_name=tm.field_name, instance=instance)
+    return process_class(field_name=transition_message.field_name, instance=instance)
 
 
-def _find_transition(process, tm: TransitionMessage):
+def _find_transition(process, transition_message: TransitionMessage):
     """Resolve the exact background transition a ``TransitionMessage`` refers to.
 
-    Phase 1 can enqueue a background transition declared on a *nested* process
-    (the sync lookup recurses into
-    ``nested_processes``), but the message records only the *bound*
-    ``process_name``, so phase 2 restores the parent and must descend the
-    ``nested_processes`` tree — each sub-process constructed with the parent's
-    shared ``state``, exactly the way ``Process.get_available_transitions``
-    does. Without this descent the nested transition is never found: the
-    message is marked completed, the side-effects never run, and the instance
-    is stranded in ``in_progress_state``.
+    Enqueue can record a background transition declared on a *nested*
+    process (the sync lookup recurses into ``nested_processes``), but the
+    message records only the *bound* ``process_name``, so the worker
+    restores the parent and must descend the ``nested_processes`` tree —
+    each sub-process constructed with the parent's shared ``state``,
+    exactly the way ``Process.get_available_transitions`` does. Without
+    this descent the nested transition is never found: the message is
+    marked completed, the side-effects never run, and the instance is
+    stranded in ``in_progress_state``.
 
-    Phase 1 also records the (possibly nested) process class that DECLARES the
-    transition on ``tm.owning_process_class``. When present it pins the search
-    to that exact class, so an ``action_name`` shared across
-    condition-disambiguated nested processes resolves to the one phase 1
-    actually chose (see ``_validate_unique_background_action_names``). It is
-    recorded for *every* background transition started through the Process
-    entrypoint — for a transition on the bound process itself it equals the
-    bound class. It is blank only for rows enqueued before this discriminator
-    existed (pre-0.4.x) or, rarely, outside the Process entrypoint.
+    Enqueue also records the (possibly nested) process class that
+    declared the transition on ``transition_message.owning_process_class``.
+    When present it pins the search to that exact class, so an
+    ``action_name`` shared across nested processes that use conditions
+    to choose resolves to the one enqueue actually chose (see
+    ``_validate_unique_background_action_names``). It is recorded for
+    *every* background transition started through the Process
+    entrypoint — for a transition on the bound process itself it equals
+    the bound class. It is blank only for rows enqueued before this
+    column existed (pre-0.4.x) or, rarely, outside the Process
+    entrypoint.
 
     When the owner is blank or no longer in the tree, we fall back to matching by
     ``action_name`` — but ONLY when the name identifies exactly one background
@@ -1070,32 +1072,33 @@ def _find_transition(process, tm: TransitionMessage):
     ``action_name`` into a shared nested one; drain such rows before that
     refactor — see the upgrade note in the changelog.)
 
-    Only ``is_background`` transitions are candidates: phase 2 never restores a
-    synchronous transition (a ``TransitionMessage`` is created solely by a
-    background transition's phase 1). A state-aware lookup would not work here
-    either — phase 2 runs while the instance sits in ``in_progress_state`` (not
-    in the transition's declared ``sources``), and the sync path's lookup is
-    gated on state membership; we bypass that gate deliberately.
+    Only ``is_background`` transitions are candidates: the worker never
+    restores a synchronous transition (a ``TransitionMessage`` is created
+    solely by enqueue). A state-aware lookup would not work here either
+    — the worker runs while the instance sits in ``in_progress_state``
+    (not in the transition's declared ``sources``), and the sync path's
+    lookup is gated on state membership; we bypass that gate
+    deliberately.
     """
-    owning_path = (tm.owning_process_class or '').strip()
+    owning_path = (transition_message.owning_process_class or '').strip()
     if owning_path:
         found = _find_background_transition_in_owner(
-            process, tm.transition_name, owning_path
+            process, transition_message.transition_name, owning_path
         )
         if found is not None:
             return found
         # The owner was recorded but is not in the tree — e.g. the nested
-        # process class was renamed/removed between the phase-1 and phase-2
-        # deploys. Fall through to the name-based fallback (which refuses to
-        # guess if the name is ambiguous), logging so the mismatch is visible.
+        # process class was renamed/removed between enqueue and execute.
+        # Fall through to the name-based fallback (which refuses to guess
+        # if the name is ambiguous), logging so the mismatch is visible.
         transition_logger.warning(
-            f'TransitionMessage#{tm.pk}: recorded owning process '
+            f'TransitionMessage#{transition_message.pk}: recorded process class '
             f'{owning_path!r} for background transition '
-            f'{tm.transition_name!r} was not found in the process tree '
+            f'{transition_message.transition_name!r} was not found in the process tree '
             f'(renamed or removed?); attempting name-based fallback.'
         )
 
-    matches = _background_transitions_named(process, tm.transition_name)
+    matches = _background_transitions_named(process, transition_message.transition_name)
     if len(matches) == 1:
         # Unambiguous — the legacy/pre-discriminator common case, safe to use.
         return matches[0]
@@ -1104,15 +1107,15 @@ def _find_transition(process, tm: TransitionMessage):
         # finalizes the row (stops retries) without running any side-effects —
         # far safer than running the wrong condition-disambiguated sibling.
         raise _RestoreError(
-            f'background transition {tm.transition_name!r} matches '
+            f'background transition {transition_message.transition_name!r} matches '
             f'{len(matches)} transitions across the process tree and the '
             f'message has no resolvable owning_process_class '
-            f'(recorded={tm.owning_process_class!r}); refusing to guess which '
-            f'condition-disambiguated sibling to run. This is an in-flight row '
-            f'enqueued before the owner discriminator existed, or whose owning '
-            f'nested process was renamed/removed mid-flight. Drain in-flight '
-            f'rows before refactoring a background action_name into shared '
-            f'nested processes.'
+            f'(recorded={transition_message.owning_process_class!r}); refusing to guess which '
+            f'condition-disambiguated sibling to run. This is an uncompleted '
+            f'row enqueued before the owner column existed, or whose nested '
+            f'process class was renamed or removed while the row was pending. '
+            f'Complete pending rows before refactoring a background '
+            f'action_name into shared nested processes.'
         )
     return None  # zero matches -> generic not-found _RestoreError in _restore
 
@@ -1123,7 +1126,7 @@ def _find_background_transition_in_owner(process, action_name, owning_path):
 
     Walks through ``_iter_process_tree`` for its cycle guard: a nested topology
     that revisits a class (A nests B nests A — legal, and blessed by the sync
-    walk since #180) recursed until ``RecursionError`` here, on the very
+    walk) recursed until ``RecursionError`` here, on the very
     fall-through path the caller is written to handle gracefully.
     """
     for process_cls in _iter_process_tree(type(process)):

--- a/django_logic/background/serializers.py
+++ b/django_logic/background/serializers.py
@@ -295,7 +295,7 @@ def serialize_kwargs(kwargs: dict) -> dict:
 
 
 def deserialize_kwargs(raw: dict | None) -> dict:
-    """Phase-2 inverse of :func:`serialize_kwargs`.
+    """Worker inverse of :func:`serialize_kwargs`.
 
     Restores tag-encoded values to their original Python types and swaps
     ``user_id`` back for a live ``user``.
@@ -319,6 +319,6 @@ def restore_user(kwargs: dict) -> None:
     try:
         kwargs['user'] = get_user_model().objects.get(pk=user_id)
     except get_user_model().DoesNotExist:
-        # The user disappeared between phases; leave user=None so
+        # The user disappeared between enqueue and execute; leave user=None so
         # permission checks treat the work as system-initiated.
         kwargs['user'] = None

--- a/django_logic/background/serializers.py
+++ b/django_logic/background/serializers.py
@@ -3,31 +3,31 @@
 ``TransitionMessage.kwargs`` is a JSONField, so everything we write must
 be JSON-serializable. Values that JSON cannot represent natively are
 stored with a self-describing type tag and restored to their original
-Python type in phase 2, so a side-effect receives the same types whether
+Python type in the worker, so a side-effect receives the same types whether
 its transition is synchronous or background.
 
 Deliberate handling:
 
 * ``request`` — dropped, loudly: a warning is logged, and
   ``DJANGO_LOGIC['STRICT_KWARGS_SERIALIZATION'] = True`` raises instead.
-  A live request cannot cross the phase boundary; extract ``user`` (which
+  A live request cannot cross the queue; extract ``user`` (which
   is rehydrated) or pass plain values.
-* ``user`` — replaced with ``user_id`` (restored on the phase-2 side).
+* ``user`` — replaced with ``user_id`` (restored on the worker side).
 * ``datetime`` / ``date`` / ``time`` / ``Decimal`` / ``UUID`` / ``tuple``
-  / ``set`` / ``frozenset`` — tag-encoded, restored in phase 2 with the
+  / ``set`` / ``frozenset`` — tag-encoded, restored in the worker with the
   original type (recursively, inside dicts/lists/tuples/sets). Two known
   fidelity limits of the isoformat round-trip: a ``ZoneInfo`` tzinfo
   degrades to a fixed-offset ``timezone`` (the UTC instant is preserved,
   the zone identity is not), and ``datetime.fold`` is not preserved.
 * ``_transition_context``-managed keys (``tr_id``, ``root_id``,
   ``parent_id``) — stringified when present.
-* Model instances and arbitrary objects — rejected at phase 1 via
+* Model instances and arbitrary objects — rejected at enqueue via
   ``json.dumps`` (``TypeError``). Pass a pk and re-fetch in the hook:
-  phase 2 may run much later and must see fresh rows, not a stale
+  the worker may run much later and must see fresh rows, not a stale
   snapshot.
 * Non-string dict keys — JSON objects only have string keys, so these are
   stringified in storage and do **not** round-trip. Flagged loudly at
-  phase 1 (warning, or ``TypeError`` under the strict setting).
+  enqueue (warning, or ``TypeError`` under the strict setting).
 
 .. note::
 
@@ -49,11 +49,11 @@ from django_logic.logger import transition_logger
 
 
 class KwargsSerializationError(TypeError):
-    """Strict-mode rejection of kwargs that phase 1 would otherwise mutate
+    """Strict-mode rejection of kwargs that enqueue would otherwise mutate
     silently (a dropped ``request``, stringified non-string dict keys).
 
     A ``TypeError`` subclass, so the documented "raises ``TypeError``"
-    contract holds — but distinct, so the phase-1 dispatcher re-raises it
+    contract holds — but distinct, so the enqueue dispatcher re-raises it
     as-is instead of wrapping it in the generic "not JSON-serializable"
     ``ImproperlyConfigured``.
     """
@@ -127,7 +127,7 @@ def decode_value(value):
         except Exception as e:
             # A known tag whose payload no longer decodes (hand-edited row,
             # cross-version writer bug): mirror the unknown-tag passthrough
-            # below rather than crash phase 2 — the raw tagged form stays
+            # below rather than crash the worker — the raw tagged form stays
             # visible to the side-effect and the log says why.
             transition_logger.warning(
                 f"malformed payload for kwargs type tag {tag!r} "
@@ -135,7 +135,7 @@ def decode_value(value):
             )
             return value
         # A row written by a newer version than this worker: pass the
-        # tagged form through rather than crash phase 2.
+        # tagged form through rather than crash the worker.
         transition_logger.warning(
             f"unknown kwargs type tag {tag!r} — passing value through "
             f"undecoded (worker older than the row writer?)"
@@ -150,8 +150,8 @@ def _non_string_key_paths(value, path='kwargs'):
     JSON objects only have string keys, so ``{1: 'a'}`` is persisted as
     ``{"1": "a"}`` — silently, since ``json.dumps`` stringifies int/float/
     bool/None keys instead of raising. That breaks the type-faithful
-    round-trip (a phase-2 hook sees ``'1'`` where the synchronous path saw
-    ``1``), so phase 1 flags it loudly instead.
+    round-trip (a worker hook sees ``'1'`` where the synchronous path saw
+    ``1``), so enqueue flags it loudly instead.
     """
     if isinstance(value, dict):
         for k, v in value.items():
@@ -193,29 +193,29 @@ def serialize_kwargs(kwargs: dict) -> dict:
     Drops ``request`` and a caller-supplied ``user_id`` (warning, or
     ``KwargsSerializationError`` under ``STRICT_KWARGS_SERIALIZATION``) —
     both are reserved. Replaces ``user`` with ``user_id``.
-    Tag-encodes non-JSON-native values so phase 2 restores real types.
+    Tag-encodes non-JSON-native values so the worker restores real types.
     Non-string dict keys are stringified by JSON persistence and cannot
     round-trip — flagged with a warning (or ``TypeError`` under the strict
     setting). Non-finite floats (``float('nan')`` / ``float('inf')``) are
     not valid JSON despite passing ``json.dumps`` — rejected with a
     ``TypeError`` naming the offending value. Raises ``TypeError`` via
     ``json.dumps`` if something unexpected slips through — the caller
-    should let that propagate so the failure is visible at phase 1 rather
-    than at phase 2.
+    should let that propagate so the failure is visible at enqueue rather
+    than at the worker.
     """
     out = dict(kwargs)
     if 'request' in out:
         out.pop('request')
         message = (
             f"{out.get('tr_id')} 'request' dropped at kwargs serialization "
-            f"— phase-2 hooks must not read it (the engine rehydrates "
+            f"— worker hooks must not read it (the engine rehydrates "
             f"'user'; pass anything else as plain values)"
         )
         if bg_settings.strict_kwargs_serialization():
             raise KwargsSerializationError(message)
         transition_logger.warning(message)
     # ``user_id`` is the engine's own wire form for ``user`` (restored in
-    # phase 2 by restore_user). A caller passing it as ordinary data used to
+    # the worker by restore_user). A caller passing it as ordinary data used to
     # be silently consumed: restore_user popped it and replaced it with a
     # live ``user``, so the hook never saw the value — and the same call ran
     # correctly in sync mode, a parity break that only showed up in
@@ -224,22 +224,22 @@ def serialize_kwargs(kwargs: dict) -> dict:
         out.pop('user_id')
         message = (
             f"{out.get('tr_id')} 'user_id' dropped at kwargs serialization "
-            f"— it is the engine's wire form for 'user' and phase 2 replaces "
+            f"— it is the engine's wire form for 'user' and the worker replaces "
             f"it with a live user object, so a caller-supplied value could "
             f"never reach a hook. Pass it under a different name."
         )
         if bg_settings.strict_kwargs_serialization():
             raise KwargsSerializationError(message)
         transition_logger.warning(message)
-    out.pop('context', None)  # rebuilt in phase 2
+    out.pop('context', None)  # rebuilt in the worker
     # Persisted on its own TransitionMessage column, not in the kwargs JSON:
-    # phase 2 reads it from the column, and it must not leak into the kwargs
+    # the worker reads it from the column, and it must not leak into the kwargs
     # passed to side-effects (it is engine bookkeeping, not caller data).
     out.pop('owning_process_class', None)
 
     user = out.pop('user', None)
     if user is not None:
-        # Read .pk (not .id) to match the phase-2 restore (get(pk=user_id))
+        # Read .pk (not .id) to match the worker restore (get(pk=user_id))
         # and to support custom user models whose primary key isn't named
         # 'id'. AnonymousUser (pk is None) is dropped, as before.
         user_id = getattr(user, 'pk', None)
@@ -252,7 +252,7 @@ def serialize_kwargs(kwargs: dict) -> dict:
 
     # PostgreSQL jsonb rejects NUL and lone surrogates, which json.dumps
     # happily encodes — the same class of value as the non-finite floats
-    # rejected below, and with the same consequence: phase 1 would die with a
+    # rejected below, and with the same consequence: enqueue would die with a
     # raw backend DataError at the row write instead of a named TypeError here.
     unstorable = sorted(set(_unstorable_text_paths(out)))
     if unstorable:
@@ -269,7 +269,7 @@ def serialize_kwargs(kwargs: dict) -> dict:
         message = (
             f"{out.get('tr_id')} non-string dict keys in background "
             f"transition kwargs ({', '.join(bad_keys)}) are stringified by "
-            f"JSON persistence — a phase-2 hook sees '1' where the "
+            f"JSON persistence — a worker hook sees '1' where the "
             f"synchronous path saw 1, and colliding keys ({{1: …, '1': …}}) "
             f"silently lose data. Use string keys, or a list of pairs."
         )
@@ -280,7 +280,7 @@ def serialize_kwargs(kwargs: dict) -> dict:
     out = encode_value(out)
 
     # Round-trip through json to surface any remaining non-serializable
-    # types at phase 1. Cheap on small dicts and invaluable in tests.
+    # types at enqueue. Cheap on small dicts and invaluable in tests.
     # allow_nan=False: Python's json emits the non-standard NaN/Infinity
     # tokens by default, which would then fail backend-dependently at the
     # row write. Translated to TypeError to keep the dispatcher contract
@@ -308,7 +308,7 @@ def deserialize_kwargs(raw: dict | None) -> dict:
 def restore_user(kwargs: dict) -> None:
     """In-place: if ``user_id`` is set, swap it for a live ``user`` object.
 
-    Called in phase 2 (via :func:`deserialize_kwargs`). No-op if
+    Called in the worker (via :func:`deserialize_kwargs`). No-op if
     ``user_id`` is absent.
     """
     user_id = kwargs.pop('user_id', None)

--- a/django_logic/background/settings.py
+++ b/django_logic/background/settings.py
@@ -25,7 +25,7 @@ def background_execution() -> str:
     """Return the configured execution mode.
 
     Defaults to ``'celery'`` — background transitions are Celery tasks.
-    ``'sync'`` runs phase 2 inline in the same process and exists for
+    ``'sync'`` runs the worker inline in the same process and exists for
     tests, CI, management commands, and the shell.
     """
     configured = _conf().get('BACKGROUND_EXECUTION')
@@ -183,7 +183,7 @@ def validate_on_ready() -> None:
     # Surface value errors now rather than on first use.
     default_queue()
     starter_queue()
-    # Safety settings (#149): every numeric knob the retry/cleanup/lock
+    # Safety settings: every numeric knob the retry/cleanup/lock
     # machinery depends on is validated at boot in EVERY mode — a bad
     # value must not wait for its first use (which may be a 3am retry
     # tick) to explode, or worse, silently misbehave.
@@ -198,7 +198,7 @@ def validate_on_ready() -> None:
     if mode == EXECUTION_CELERY:
         _reject_sqlite_in_celery_mode()
         _check_lock_cache_in_celery_mode()
-        # NB: broker liveness is NOT checked here — validate_on_ready runs
+        # NB: whether the broker is reachable is NOT checked here — validate_on_ready runs
         # at Django app-ready, which in the standard celery.py pattern is
         # *before* the project's Celery app sets broker_url, so it would
         # false-warn on every boot. The check lives in dispatch (where the
@@ -207,7 +207,7 @@ def validate_on_ready() -> None:
 
 def _reject_sqlite_in_celery_mode() -> None:
     """SQLite doesn't support ``select_for_update(nowait=True)`` nor
-    partial unique indexes, so the phase-2 concurrency guard silently
+    partial unique indexes, so the worker concurrency guard silently
     degrades to "serialize everything" — which masks real bugs in dev
     and fails in prod.
 
@@ -269,7 +269,7 @@ def _check_lock_cache_in_celery_mode() -> None:
 
 
 def _validate_bool(key: str) -> None:
-    """Reject a non-bool on a setting that gates behaviour (#182).
+    """Reject a non-bool on a setting that gates behaviour.
 
     Truthiness coercion is unsafe for these: the strings 'false'/'no'/'0'
     are all truthy, so a value meant to disable a feature enabled it.
@@ -284,16 +284,16 @@ def _validate_bool(key: str) -> None:
 
 
 def strict_kwargs_serialization() -> bool:
-    """When True, phase-1 kwargs serialization raises on silently-droppable
+    """When True, enqueue kwargs serialization raises on silently-droppable
     caller kwargs (``request``) instead of logging a warning.
 
     Default False: generic API layers commonly pass ``request`` to every
     transition uniformly, so raising by default would break them. Enable
     once call sites are clean to turn the drop into a hard contract.
 
-    Only a literal ``True`` enables it (#182). It used to be
+    Only a literal ``True`` enables it. It used to be
     ``bool(...)``-coerced, so any non-empty string switched strict mode ON —
-    reading ``DL_STRICT=false`` from an env var made phase 1 start raising.
+    reading ``DL_STRICT=false`` from an env var made enqueue start raising.
     Mirrors ``conf.defer_unlock_until_commit``; boot validation rejects
     non-bools and this reader stays safe where that has not run.
     """

--- a/django_logic/background/tasks.py
+++ b/django_logic/background/tasks.py
@@ -47,7 +47,7 @@ from django_logic.logger import logger
     bind=False,
 )
 def run_background_transition_task(transition_message_id: int) -> None:
-    """Phase-2 entrypoint for one transition.
+    """Worker entrypoint for one transition.
 
     ``acks_late=True`` + ``reject_on_worker_lost=True`` are set per-task so
     a worker killed mid-execution (SIGKILL / OOM / deploy) re-delivers the

--- a/django_logic/background/tasks.py
+++ b/django_logic/background/tasks.py
@@ -2,11 +2,11 @@
 
 Celery is a core dependency of django-logic: background transitions are
 Celery tasks. (Sync execution mode never schedules these tasks — it runs
-phase 2 inline — but the tasks are always importable and registered.)
+the worker inline — but the tasks are always importable and registered.)
 
 Tasks defined here:
 
-* :func:`run_background_transition_task` — executes phase 2 for one
+* :func:`run_background_transition_task` — executes the worker for one
   ``TransitionMessage``.
 * :func:`retry_stale_transitions` — periodic; re-dispatches uncompleted
   messages back to their own queue.
@@ -15,7 +15,7 @@ Tasks defined here:
 * :func:`detect_stuck_transitions` — periodic; finalizes messages
   stuck at ``MAX_ERRORS`` (writes ``failed_state``, runs
   ``failure_side_effects``, marks completed) so the retry loop stops.
-* :func:`watchdog_stale_attempts` — periodic; abandons phase-2
+* :func:`watchdog_stale_attempts` — periodic; abandons worker
   attempts whose current run has exceeded their declared
   ``timeout_seconds``.
 
@@ -53,7 +53,7 @@ def run_background_transition_task(transition_message_id: int) -> None:
     a worker killed mid-execution (SIGKILL / OOM / deploy) re-delivers the
     message regardless of the project's global Celery configuration — the
     pair is what the crash-redelivery guarantee depends on, so it is not
-    left to consumer settings (issue #91).
+    left to consumer settings.
 
     Side-effect failures are recorded on the TransitionMessage row and NOT
     re-raised in celery mode (monitor the row, not Celery task failures —
@@ -84,7 +84,7 @@ def _retry_pending_inline() -> int:
     # Mirror dispatch_transition's mode awareness: in Sync mode there is
     # no Celery worker to consume an apply_async message (with no broker
     # configured Celery silently publishes to an in-memory transport that
-    # nobody drains), so phase 2 must run inline. In Celery mode we
+    # nobody drains), so the worker must run inline. In Celery mode we
     # re-dispatch to the row's own queue. The check also honours an
     # active sync_execution() block.
     from django_logic.background.dispatch import _current_mode
@@ -135,7 +135,7 @@ def _retry_pending_inline() -> int:
             dispatched += 1
         except Exception as e:
             # A dispatch-layer error (broker down, serialization, etc.)
-            # or an inline phase-2 failure shouldn't stop us from trying
+            # or an inline worker failure shouldn't stop us from trying
             # the remaining rows.
             logger.error(
                 'retry_stale_transitions: failed to dispatch '
@@ -218,7 +218,7 @@ def detect_stuck_transitions() -> int:
     bind=False,
 )
 def watchdog_stale_attempts() -> int:
-    """Periodic: abandon phase-2 attempts that have been running beyond
+    """Periodic: abandon worker attempts that have been running beyond
     their declared ``timeout_seconds``.
 
     Only rows that opted in via ``BackgroundTransition(timeout=N)`` are

--- a/django_logic/background/transitions.py
+++ b/django_logic/background/transitions.py
@@ -1,7 +1,6 @@
 """BackgroundTransition / BackgroundAction — durable, queue-routed Celery tasks.
 
-Phase 1 (what ``change_state`` does) is identical in both Celery and
-Sync execution modes:
+``change_state`` enqueues the work (same steps in Celery and Sync mode):
 
 * validate conditions + permissions,
 * acquire the state lock for the critical section and revalidate the
@@ -9,12 +8,12 @@ Sync execution modes:
 * atomically write ``in_progress_state`` (for ``BackgroundTransition``)
   and create a ``TransitionMessage`` row,
 * release the lock — from here on the uncompleted ``TransitionMessage``
-  row is the durable in-flight marker that gates concurrent transitions,
+  row is what gates concurrent transitions,
 * hand the row id to the dispatcher, which either ``apply_async`` the
-  Celery task (Celery mode) or call phase 2 inline (Sync mode).
+  Celery task (Celery mode) or executes the worker path inline (Sync mode).
 
-Phase 2 lives in :mod:`django_logic.background.runner` and is shared
-between both modes.
+The worker path lives in :mod:`django_logic.background.runner` and is
+shared between both modes.
 """
 from __future__ import annotations
 
@@ -52,12 +51,12 @@ class BackgroundTransition(Transition):
 
     Recommended:
         - ``in_progress_state`` — if omitted, the state field does not
-          change until phase 2 finishes. Providing it is strongly
+          change until the worker finishes. Providing it is strongly
           recommended so concurrent readers see "in progress" rather
           than the pre-transition state. Transitions may share one
           freely: it is written atomically with the ``TransitionMessage``
-          row, which names the exact transition in flight, so nothing has
-          to infer an owner from the state value.
+          row, which names the exact transition, so nothing has to infer
+          an owner from the state value.
     """
 
     is_background = True
@@ -101,8 +100,8 @@ class BackgroundTransition(Transition):
         return self.queue or bg_settings.default_queue()
 
     def change_state(self, state: State, **kwargs) -> UUID | None:
-        # Before the lock, and before the kwargs are serialized into a row that
-        # phase 2 would fail on for the same reason.
+        # Before the lock, and before the kwargs are serialized into a row
+        # the worker would fail on for the same reason.
         _refuse_engine_param_kwargs(self.action_name, kwargs)
         process_class = kwargs.get('process_class', '')
         process_class_name = process_class.split('.')[-1] if process_class else ''
@@ -116,8 +115,7 @@ class BackgroundTransition(Transition):
         )
 
         if not self.is_valid(state.instance, kwargs.get('user')):
-            # Same observability rule as the failed lock below (#188): a
-            # rejection with no log line leaves a Start with no explanation.
+            # A rejection with no log line leaves a Start with no explanation.
             transition_logger.info(
                 f'{kwargs.get("tr_id")} {self.action_name} '
                 f'{state.instance_key} rejected by conditions or permissions'
@@ -130,15 +128,15 @@ class BackgroundTransition(Transition):
         # The cache lock guards only this critical section (validate →
         # create the TransitionMessage → write in_progress_state). It is
         # released in the finally below; from then on the uncompleted
-        # TransitionMessage row is the durable in-flight marker. Holding
-        # the cache lock for the whole background flight would leak it if
+        # TransitionMessage row is what gates concurrent transitions.
+        # Holding the cache lock for the whole worker run would leak it if
         # a caller's surrounding transaction rolled back (a cache write
         # does not roll back with the database), and a DB row needs no TTL
         # refresh across long retries.
         if not state.lock():
-            # See Transition.change_state (#188): logged before the raise, at
-            # INFO per #154, with the instance key — a frozen instance must
-            # not read as "the transition starts and the worker drops it".
+            # Logged before the raise, at INFO, with the instance key — a
+            # frozen instance must not read as "the transition starts and
+            # the worker drops it".
             transition_logger.info(
                 f'{kwargs.get("tr_id")} {TransitionEventType.LOCK.value} '
                 f'failed {state.instance_key} — state is locked'
@@ -153,27 +151,27 @@ class BackgroundTransition(Transition):
             # the source check ran before the lock was acquired.
             self._ensure_db_state_in_sources(state)
             try:
-                tm = self._phase_one_atomic(state, kwargs, queue_name)
+                transition_message = self._enqueue_atomic(
+                    state, kwargs, queue_name)
             except AlreadyInProgress:
-                # Same liveness classification as the sync gate (#195): the
-                # constraint held by a STRANDED row is not "retry shortly" —
-                # that answer would be wrong forever, at WARNING. Queried
-                # here, after _phase_one_atomic's rolled-back atomic, so the
-                # connection is healthy; still under the cache lock. A row
-                # that completed in the window keeps AlreadyInProgress —
-                # it JUST finished, so retrying is exactly right.
-                if TransitionMessage.in_flight_liveness(
+                # Nothing is retrying a stranded row, so "try again shortly"
+                # would be wrong forever. Queried here, after
+                # _enqueue_atomic's rolled-back atomic, so the connection is
+                # healthy; still under the cache lock. A row that completed
+                # in the window keeps AlreadyInProgress — it just finished,
+                # so retrying is exactly right.
+                if TransitionMessage.retry_status(
                     state.instance, state.process_name,
-                ) == TransitionMessage.LIVENESS_STRANDED:
+                ) == TransitionMessage.STRANDED:
                     raise TransitionNotAllowed(
                         f"BackgroundTransition '{self.action_name}' is not "
-                        f"allowed: the in-flight marker for "
-                        f"{state.instance_key} is past the retry horizon — "
-                        f"stranded, not in flight. Likely causes: the "
-                        f"safety-net beat tasks are not scheduled "
-                        f"(django_logic.W002), a queue backlog or worker "
-                        f"outage longer than the horizon, or a lost broker "
-                        f"message. Re-drive or complete the row."
+                        f"allowed: an uncompleted TransitionMessage for "
+                        f"{state.instance_key} is stranded — nothing is "
+                        f"retrying it. Likely causes: the safety-net beat "
+                        f"tasks are not scheduled, a queue backlog or "
+                        f"worker outage longer than the retry window, or a "
+                        f"lost broker message. Complete the row, or start "
+                        f"the beat tasks so it is retried."
                     )
                 raise
         finally:
@@ -184,31 +182,31 @@ class BackgroundTransition(Transition):
             )
 
         from django_logic.background.dispatch import dispatch_transition
-        dispatch_transition(tm)
+        dispatch_transition(transition_message)
 
         return kwargs.get('tr_id')
 
-    def _phase_one_atomic(
+    def _enqueue_atomic(
         self, state: State, kwargs: dict, queue_name: str
     ) -> TransitionMessage:
         """Atomic: set in_progress_state + create TransitionMessage row.
 
         Raises :class:`AlreadyInProgress` if the partial unique
-        constraint fires (another uncompleted TM exists for the same
-        instance + process).
+        constraint fires (another uncompleted TransitionMessage exists
+        for the same instance + process).
         """
         instance_lookup = {
             'app_label': state.instance._meta.app_label,
             'model_name': state.instance._meta.model_name,
-            # str() so UUID / CharField / big-int PKs all round-trip through
-            # the TextField; _restore coerces it back via get(pk=...).
+            # Models use different primary-key types (int, UUID, string).
+            # Store the key as text; _restore looks it up with get(pk=...).
             'instance_id': str(state.instance.pk),
         }
         try:
             serialized = serialize_kwargs(kwargs)
         except KwargsSerializationError:
-            # Strict-mode contract violation — the message is already
-            # precise; wrapping it as "not JSON-serializable" would mislead.
+            # Re-raise so the precise strict-mode message is not wrapped
+            # as "not JSON-serializable".
             raise
         except TypeError as e:
             raise ImproperlyConfigured(
@@ -227,19 +225,20 @@ class BackgroundTransition(Transition):
             # column (CHECK, NOT NULL, FK, trigger) surface as the
             # misleading "another transition is already in progress".
             try:
-                tm = TransitionMessage.objects.create(
+                transition_message = TransitionMessage.objects.create(
                     process_name=state.process_name,
-                    # Recorded so phase 2 can reconstruct the process from
-                    # the stored process_class even when the model property
-                    # was renamed/rebound between phases.
+                    # Recorded so the worker can reconstruct the process
+                    # from the stored process_class even when the model
+                    # property was renamed or rebound in between.
                     field_name=state.field_name,
                     transition_name=self.action_name,
-                    # The (possibly nested) process class that declares this
-                    # transition, resolved by Process._get_transition_method.
-                    # Lets phase 2 pick the exact transition when an
-                    # action_name is shared across condition-disambiguated
-                    # nested processes. Empty when invoked outside that path
-                    # (e.g. a directly-constructed transition) — phase 2 then
+                    # The (possibly nested) process class that declared
+                    # this transition, resolved by
+                    # Process._get_transition_method. Lets the worker pick
+                    # the exact transition when an action_name is shared
+                    # across nested processes that use conditions to
+                    # choose. Empty when invoked outside that path (e.g. a
+                    # directly-constructed transition) — the worker then
                     # falls back to first-match by transition_name.
                     owning_process_class=kwargs.get('owning_process_class', ''),
                     queue_name=queue_name,
@@ -255,23 +254,22 @@ class BackgroundTransition(Transition):
                 ) from exc
 
             # Recheck the persisted state AFTER the create. On PostgreSQL
-            # the insert can block in a speculative-insert wait while a
-            # concurrent flight's phase 2 finishes (its row leaves the
-            # partial unique index the moment is_completed flips) — we are
-            # then admitted seconds after our under-the-lock revalidation,
-            # against an instance the finished flight has already moved to
-            # its target/failed state. Without this recheck, two concurrent
-            # phase 1s on one instance can BOTH be accepted and the
-            # transition silently re-runs from a non-source state
+            # the insert can block while a concurrent worker finishes and
+            # flips is_completed (the row then leaves the partial unique
+            # index). We are admitted after our under-the-lock
+            # revalidation, against an instance that worker has already
+            # moved to its target or failed state. Without this recheck,
+            # two concurrent enqueues on one instance can both be accepted
+            # and the transition silently re-runs from a non-source state
             # (reproduced under real worker concurrency).
             current = state.get_persisted_state()
             if current not in self.sources:
-                # The atomic block rolls the TM row back.
+                # The atomic block rolls the TransitionMessage row back.
                 raise SourceStateChanged(
                     f"BackgroundTransition '{self.action_name}' is not "
                     f"allowed: the persisted state moved to {current!r} "
-                    f"while phase 1 waited on a finishing flight — it is "
-                    f"no longer one of the source states."
+                    f"while the insert waited on the unique constraint — "
+                    f"it is no longer one of the source states."
                 )
 
             if self.in_progress_state:
@@ -286,10 +284,10 @@ class BackgroundTransition(Transition):
                 )
 
         transition_logger.info(
-            f'{kwargs.get("tr_id")} TransitionMessage#{tm.pk} created '
-            f'(queue={queue_name})'
+            f'{kwargs.get("tr_id")} TransitionMessage#{transition_message.pk} '
+            f'created (queue={queue_name})'
         )
-        return tm
+        return transition_message
 
 
 class BackgroundAction(BackgroundTransition):
@@ -328,8 +326,8 @@ class BackgroundAction(BackgroundTransition):
 
     def complete_transition(self, state: State, **kwargs):
         # Defensive no-op for direct/manual invocation only — the engine
-        # never calls this: phase 1 stops at the TransitionMessage row and
-        # phase 2 writes state / runs hooks itself (_handle_success /
+        # never calls this: enqueue stops at the TransitionMessage row and
+        # the worker writes state / runs hooks itself (_handle_success /
         # _run_success_hooks). The inherited implementation would write an
         # empty target state; an action must not change state on success.
         pass

--- a/django_logic/checks.py
+++ b/django_logic/checks.py
@@ -75,7 +75,7 @@ def check_background_app_is_installed(app_configs, **kwargs):
     ``INSTALLED_APPS`` (``django_logic.E003``).
 
     The app owns the ``TransitionMessage`` table and its migrations. Without
-    it, phase 1 has nowhere to write the outbox row, so the first background
+    it, enqueue has nowhere to write the outbox row, so the first background
     transition dies with a raw ``OperationalError: no such table`` from deep
     inside the engine — and the other background checks (E002, W002) gate on
     the very same missing app, so ``manage.py check`` said nothing at all.
@@ -90,7 +90,7 @@ def check_background_app_is_installed(app_configs, **kwargs):
     return [checks.Error(
         "Background transitions are bound on %s, but "
         "'django_logic.background' is not in INSTALLED_APPS. The app owns "
-        "the TransitionMessage table those transitions write in phase 1, so "
+        "the TransitionMessage table those transitions write in enqueue, so "
         "the first background transition fails with a missing-table "
         "database error." % ', '.join(offenders),
         hint="Add 'django_logic.background' to INSTALLED_APPS and run "
@@ -104,9 +104,9 @@ def check_background_app_is_installed(app_configs, **kwargs):
 @checks.register('django_logic')
 def check_background_database_routing(app_configs, **kwargs):
     """Database routers must not split the background engine across
-    databases (``django_logic.E002``, #148).
+    databases (``django_logic.E002``).
 
-    The durability contract is an *atomic outbox*: phase 1 writes the
+    The durability contract is an *atomic outbox*: enqueue writes the
     instance's ``in_progress_state`` and the ``TransitionMessage`` row in
     ONE transaction, and the runtime uses unqualified managers and bare
     ``transaction.atomic()`` throughout — both resolve to the ``default``
@@ -184,7 +184,7 @@ def check_safety_net_is_scheduled(app_configs, **kwargs):
     running app's beat schedule (``django_logic.W002``).
 
     They are the durability half of ``BACKGROUND_EXECUTION='celery'``: without
-    them a lost phase-2 message is never re-dispatched, an attempt that dies
+    them a lost worker message is never re-dispatched, an attempt that dies
     without raising is never terminalized, and completed rows are never pruned.
     Nothing else notices — a consumer ran seven weeks with them all silently
     unscheduled, accumulating 36 stranded rows, because
@@ -230,7 +230,7 @@ def check_safety_net_is_scheduled(app_configs, **kwargs):
         return []
     return [checks.Warning(
         "BACKGROUND_EXECUTION='celery' but these periodic safety-net tasks "
-        "are not in the Celery beat schedule: %s. Lost phase-2 messages will "
+        "are not in the Celery beat schedule: %s. Lost worker messages will "
         "never be re-dispatched and completed rows will never be pruned."
         % ', '.join(missing),
         hint="Install them with "
@@ -258,7 +258,7 @@ _REMOVED_SETTINGS = {
         'kwargs are always attached to log records now; scrub them with a '
         'logging.Filter on the "django-logic.transition" logger',
     'PHASE2_STATE_GUARD':
-        'the phase-2 state guard always enforces; there are no modes',
+        'the worker state guard always enforces; there are no modes',
     'SENTRY_TRANSACTION_NAMING':
         'Sentry transactions are always named per transition',
     'PROCESS_CLASS_ALIASES':
@@ -311,7 +311,7 @@ _KNOWN_SETTINGS = frozenset({
 @checks.register('django_logic')
 def check_no_unknown_settings(app_configs, **kwargs):
     """Report ``DJANGO_LOGIC`` keys the engine never reads
-    (``django_logic.W004``, #182).
+    (``django_logic.W004``).
 
     ``DJANGO_LOGIC`` is a plain dict with no schema, so a typo —
     ``TRANSITION_MESSAGE_MAX_ERROR``, ``LOCK_TIMOUT`` — is silently ignored

--- a/django_logic/commands.py
+++ b/django_logic/commands.py
@@ -33,7 +33,7 @@ def _deferred_unlocks(conn) -> list:
 
 
 def note_deferred_unlock(using: str, state: State) -> None:
-    """Record a DEFER_UNLOCK_UNTIL_COMMIT unlock (#141) so hook
+    """Record a DEFER_UNLOCK_UNTIL_COMMIT unlock so hook
     savepoints can release it if their rollback discards the
     ``transaction.on_commit`` registration (see ``_run_in_savepoint``).
     Called by ``Transition._release_lock`` right after registering the
@@ -86,7 +86,7 @@ def _run_in_savepoint(using: str, fn, *, require_commit: bool = False):
 
     When the savepoint rolls back, Django discards every
     ``transaction.on_commit`` hook registered inside it — including the
-    DEFER_UNLOCK_UNTIL_COMMIT unlocks (#141) of transitions the hook
+    DEFER_UNLOCK_UNTIL_COMMIT unlocks of transitions the hook
     drove. Their state writes roll back with the savepoint, so those
     locks protect nothing anymore; dropping the hooks would leak them
     until TTL *while the outer transaction commits successfully*.
@@ -153,10 +153,10 @@ def _release_dropped(registry, before) -> None:
 
 def _log_hook_error(message: str, error: BaseException, **log_kwargs) -> None:
     """Log a hook failure at ERROR — or WARNING when it is a transient
-    concurrency outcome (#154, #191).
+    concurrency outcome.
 
-    ``TransitionTemporarilyUnavailable`` means "another flight owns this
-    instance right now": the designed outcome of two drives racing, and
+    ``TransitionTemporarilyUnavailable`` means "another transition owns
+    this instance right now": the designed outcome of two drives racing, and
     the common shape when a background transition is invoked from another
     transition's side-effects. At ERROR it pages an on-call for healthy
     contention. Every other exception stays at ERROR. Consumer subclasses
@@ -228,7 +228,7 @@ class SideEffects(BaseCommand):
 class Callbacks(BaseCommand):
     """Best-effort follow-ups. Exceptions are logged and swallowed.
 
-    Each callback is isolated (#138): one failing callback does not
+    Each callback is isolated: one failing callback does not
     prevent the later ones from being attempted, and when the caller is
     inside an open transaction each callback runs in its own savepoint —
     a database error would otherwise mark the whole outer transaction
@@ -292,7 +292,7 @@ class FailureSideEffects(BaseCommand):
     the ``TransitionMessage`` (otherwise broken cleanup is invisible).
 
     When the caller is inside an open transaction, the bundle runs in a
-    savepoint that rolls back on error (#138): the same contract phase 2
+    savepoint that rolls back on error: the same contract the worker
     applies — a broken cleanup path neither poisons the outer transaction
     nor commits its partial writes. A savepoint discarded silently (a hook
     suppressing a database error without a nested ``atomic``) is returned
@@ -315,7 +315,7 @@ class FailureSideEffects(BaseCommand):
             # TransitionMessage, so a cleanup bundle whose writes were
             # silently discarded must be returned as the failure it is —
             # not left as success-shaped bookkeeping over rolled-back work
-            # (the #189 class, third savepoint).
+            # (a discarded savepoint must not look like success).
             _run_in_savepoint(using, _bundle, require_commit=True)
         except _FailureSideEffectsRollback as rollback:
             return rollback.error
@@ -347,8 +347,8 @@ class NextTransition:
     A dedicated slot because the follow-up must run in the same call
     frame, after the state unlock: side-effects run before unlock (the
     follow-up would deadlock on its own lock acquisition), and callbacks
-    execute in phase 2 on a Celery worker for background transitions —
-    only for synchronous transitions do they run inline.
+    execute on a Celery worker for background transitions — only for
+    synchronous transitions do they run inline.
     """
 
     def __init__(self, next_transition: str | None = None):
@@ -381,10 +381,10 @@ class NextTransition:
             return None
 
         if getattr(transitions[0], 'is_background', False):
-            # request is phase-1-only and unserializable; forwarding it into
-            # a background follow-up would fail phase-1 serialization under
-            # STRICT_KWARGS_SERIALIZATION — and that failure is swallowed
-            # below, silently killing the chain (#129).
+            # request is enqueue-only and unserializable; forwarding it
+            # into a background follow-up would fail kwargs serialization
+            # under STRICT_KWARGS_SERIALIZATION — and that failure is
+            # swallowed below, silently killing the chain.
             kwargs = {k: v for k, v in kwargs.items() if k != 'request'}
 
         using, in_transaction = _in_open_transaction(state.instance)
@@ -395,7 +395,7 @@ class NextTransition:
             # parent's tr_id via a direct change_state call. Failures of the
             # follow-up must not bubble into the current transition — and,
             # like Callbacks, a swallowed database error inside an open
-            # transaction must not poison it (#138), so the follow-up runs
+            # transaction must not poison it, so the follow-up runs
             # in a savepoint there.
             if in_transaction:
                 return _run_in_savepoint(

--- a/django_logic/conf.py
+++ b/django_logic/conf.py
@@ -67,7 +67,7 @@ def transition_coverage_log():
 def legacy_exception_base():
     """Dotted path of an extra base class to mix into
     ``TransitionNotAllowed`` (coexistence with a differently-named fork
-    during a migration, #190), or ``None``."""
+    during a migration), or ``None``."""
     return _conf().get('LEGACY_EXCEPTION_BASE') or None
 
 
@@ -125,8 +125,7 @@ def validate_core_settings() -> None:
 
 
 def install_legacy_exception_base() -> None:
-    """Mix the settings-declared legacy base into ``TransitionNotAllowed``
-    (#190). Idempotent — called from both apps' ``ready()``.
+    """Mix the settings-declared legacy base into ``TransitionNotAllowed``. Idempotent — called from both apps' ``ready()``.
 
     A consumer migrating off a differently-named fork must run both engines
     side by side, with shared handlers that catch the *fork's*
@@ -175,7 +174,7 @@ def install_legacy_exception_base() -> None:
     try:
         probe = TransitionNotAllowed(probe_msg)
     except BaseException as exc:
-        # BaseException, not Exception (#196): a fork __init__ that raises
+        # BaseException, not Exception: a fork __init__ that raises
         # SystemExit/KeyboardInterrupt during boot must not leave the class
         # half-mutated. Unwind always; translate only Exception.
         TransitionNotAllowed.__bases__ = original_bases
@@ -191,7 +190,7 @@ def install_legacy_exception_base() -> None:
         # A message-eating base (the `self.message = message;
         # super().__init__()` idiom) blanks str() and args for every denial,
         # and args=() breaks exception (un)pickling wherever celery/tblib
-        # serialize exception info (#196). `in`, not equality, for str(): a
+        # serialize exception info. `in`, not equality, for str(): a
         # fork __str__ that FORMATS the preserved message (prefixes, codes)
         # is a working bridge, not a broken one.
         TransitionNotAllowed.__bases__ = original_bases

--- a/django_logic/coverage.py
+++ b/django_logic/coverage.py
@@ -1,4 +1,4 @@
-"""Transition-execution coverage (#132).
+"""Transition-execution coverage.
 
 Static analysis of a consumer's test tree cannot see transitive execution
 (a test drives a view/task which calls ``instance.process.action()``) or
@@ -6,7 +6,7 @@ dynamic dispatch (``getattr(process, action_name)()``). The engine can:
 every initiation resolves ``(transition, owning_process)`` in one place and
 notifies ``django_logic.process.transition_observers``.
 
-This module records those notifications as ``(owning process class, action)``
+This module records those notifications as ``(process class that declared it, action)``
 pairs and diffs them against every transition declared by every bound
 process (``ProcessManager.bindings``, nested processes included), so a test
 run can answer "which transitions did the suite never drive?" exactly.
@@ -28,7 +28,7 @@ Two front-ends:
 Initiation semantics: a pair is recorded when a transition is *resolved* —
 an initiation refused later (lock contention, under-lock revalidation,
 ``AlreadyInProgress``) still counts as driven. Phase-2 background restore
-and retries do not re-notify — phase 1 already recorded the pair.
+and retries do not re-notify — enqueue already recorded the pair.
 
 One footgun worth knowing:
 
@@ -36,7 +36,7 @@ One footgun worth knowing:
   fresh path (or delete the old file first), or stale pairs from earlier
   runs silently count as covered.
 
-Declaration identity (#146, #153): keys carry the declaration's kind
+Declaration identity: keys carry the declaration's kind
 (sync/background), shape (sources → target), and a conditions fingerprint
 (the condition callables' sorted qualnames, plus the *configuration* of
 partials and callable instances) besides the class and action name, so

--- a/django_logic/coverage.py
+++ b/django_logic/coverage.py
@@ -27,7 +27,7 @@ Two front-ends:
 
 Initiation semantics: a pair is recorded when a transition is *resolved* —
 an initiation refused later (lock contention, under-lock revalidation,
-``AlreadyInProgress``) still counts as driven. Phase-2 background restore
+``AlreadyInProgress``) still counts as driven. Worker restore
 and retries do not re-notify — enqueue already recorded the pair.
 
 One footgun worth knowing:

--- a/django_logic/exceptions.py
+++ b/django_logic/exceptions.py
@@ -3,22 +3,22 @@ class DjangoLogicException(Exception):
 
 
 # Coexistence base: DJANGO_LOGIC['LEGACY_EXCEPTION_BASE'], applied at
-# ready() by conf.install_legacy_exception_base (#190).
+# ready() by conf.install_legacy_exception_base.
 class TransitionNotAllowed(DjangoLogicException):
     pass
 
 
 class TransitionTemporarilyUnavailable(TransitionNotAllowed):
-    """Transient refusal: the transition is permitted but another flight
-    owns the instance right now — retry shortly.
+    """Transient refusal: the transition is permitted but another
+    transition owns the instance right now — retry shortly.
 
     Catch this AHEAD of ``TransitionNotAllowed`` to answer "busy" instead
     of "forbidden". Covers the background concurrency guards
     (``AlreadyInProgress``, ``SourceStateChanged``) and the sync gate while
-    the uncompleted ``TransitionMessage`` is LIVE — all of these resolve
-    when the in-flight work completes. A row untouched past the retry
-    horizon is stranded, not busy, and raises the plain base (#195): it
-    has no TTL, so "retry shortly" would be wrong forever. Lock contention
+    the uncompleted ``TransitionMessage`` is still being retried — all of
+    these resolve when that work completes. A row nothing is retrying is
+    stranded, not busy, and raises the plain base: it has no TTL, so
+    "retry shortly" would be wrong forever. Lock contention
     ("State is locked") stays plain ``TransitionNotAllowed`` for the same
     reason: a TTL-stuck lock is not "retry shortly".
     """

--- a/django_logic/process.py
+++ b/django_logic/process.py
@@ -27,12 +27,12 @@ _transition_context: ContextVar[dict | None] = ContextVar(
 #: Transition-initiation observers. Each callable is invoked as
 #: ``observer(owning_process_cls, action_name, instance, transition)``
 #: after a transition resolves, before it executes — for every initiation
-#: path (direct calls, next_transition follow-ups, background phase 1;
-#: phase-2 restore does not re-notify). ``transition`` is the resolved
-#: declaration object, so condition-disambiguated same-name transitions
-#: are distinguishable (#146; the argument was added in 0.9 — observers
-#: written against the 0.8 three-argument form need a ``transition=None``
-#: parameter added). Observers must never break a transition: exceptions
+#: path (direct calls, next_transition follow-ups, background enqueue;
+#: worker restore does not re-notify). ``transition`` is the resolved
+#: declaration object, so same-name transitions chosen by conditions
+#: are distinguishable (observers written against the 0.8
+#: three-argument form need a ``transition=None`` parameter added).
+#: Observers must never break a transition: exceptions
 #: are logged and swallowed. Registered by ``django_logic.coverage``;
 #: open to consumer metrics/tracing hooks.
 transition_observers: list = []
@@ -81,8 +81,9 @@ class Process:
     ``process_name``, and ``state_class``.
 
     Class-time validation enforces that a background transition is
-    uniquely identifiable by ``(owning process class, action_name)``,
-    which is what phase-2 restore resolves a ``TransitionMessage`` by.
+    uniquely identifiable by ``(process class that declared it,
+    action_name)``, which is what the worker uses to restore a
+    ``TransitionMessage``.
     """
 
     nested_processes = []
@@ -159,7 +160,7 @@ class Process:
 
         # Django's template engine CALLS any callable it resolves, so
         # ``{{ order.process.approve }}`` used to drive the state machine
-        # while rendering a page and print the tr_id (#181). ``alters_data``
+        # while rendering a page and print the tr_id. ``alters_data``
         # is the framework's opt-out — the same marker Model.save/delete
         # carry — and makes the engine render '' instead of calling.
         transition_method.alters_data = True
@@ -251,13 +252,13 @@ class Process:
         ``(transition, owning_process)`` pairs.
 
         ``owning_process`` is the (possibly nested) ``Process`` instance that
-        declared the transition — what phase 1 records so phase-2 restore can
-        identify the exact background transition among condition-disambiguated
-        siblings sharing an ``action_name``. Iteration order and filtering are
-        identical to ``get_available_transitions``; that method is a thin
-        wrapper that drops the owner.
+        declared the transition — what enqueue records so the worker can
+        identify the exact background transition among siblings that share
+        an ``action_name`` and use conditions to choose. Iteration order
+        and filtering are identical to ``get_available_transitions``; that
+        method is a thin wrapper that drops the owner.
         """
-        # Visit each Process CLASS once per walk (#180). Without this, a
+        # Visit each Process CLASS once per walk. Without this, a
         # nested process reachable by two paths — a diamond, or a duplicated
         # entry in ``nested_processes`` — yielded every one of its
         # transitions twice, and ``_resolve_transition_with_owner`` rejected
@@ -304,7 +305,7 @@ class Process:
 
         Exactly one match is required, after conditions/permissions
         filtering with ``ignore_state=True``. Also returns the declaring
-        process so the caller can record the owner for phase-2 restore.
+        process so the caller can record it for worker restore.
         """
         matches = list(
             self._iter_available_with_owner(
@@ -356,7 +357,7 @@ def _iter_process_tree(process_cls, _seen=None):
 
 def _validate_action_names_not_shadowed(process_cls):
     """Reject an ``action_name`` that a real attribute of the ROOT process
-    shadows (raised at class creation, #182).
+    shadows (raised at class creation).
 
     ``__getattr__`` only runs when normal attribute lookup *fails*, so a
     transition named ``state``, ``is_valid``, ``transitions``,
@@ -404,38 +405,40 @@ def _validate_action_names_not_shadowed(process_cls):
 
 def _validate_unique_background_action_names(process_cls):
     """A background transition must be uniquely identifiable by
-    ``(owning process class, action_name)`` across a Process *and its nested
-    processes*.
+    ``(process class that declared it, action_name)`` across a Process
+    *and its nested processes*.
 
-    Phase 1 records the owning (possibly nested) process class on the
-    ``TransitionMessage`` (``owning_process_class``); phase-2 restore
+    Enqueue records the (possibly nested) process class that declared
+    the transition on the ``TransitionMessage``
+    (``owning_process_class``); worker restore
     (``runner._find_transition``) uses it to select the exact background
-    transition. So the only configuration phase 2 genuinely cannot resolve —
-    and the only one rejected here — is **two background transitions sharing
-    an ``action_name`` within a single process class**: the owner + name pair
-    no longer identifies one transition.
+    transition. So the only configuration the worker genuinely cannot
+    resolve — and the only one rejected here — is **two background
+    transitions sharing an ``action_name`` within a single process
+    class**: the class + name pair no longer identifies one transition.
 
-    Everything else is allowed, because phase 2 can always resolve it:
+    Everything else is allowed, because the worker can always resolve it:
 
-    * The same background ``action_name`` on **distinct** nested process classes
-      — the condition-disambiguated pattern (e.g. per-integration ``Gmail`` /
-      ``Dummy`` sub-processes each declaring a background
-      ``send_message_via_integration`` selected by a condition on the instance).
-      Phase 1's transition resolution picks exactly one (the
-      conditions are mutually exclusive); phase 2 restores that exact one via
-      the recorded owner.
+    * The same background ``action_name`` on **distinct** nested process
+      classes — the pattern that uses conditions to choose (e.g.
+      per-integration ``Gmail`` / ``Dummy`` sub-processes each declaring
+      a background ``send_message_via_integration``). Enqueue's
+      transition resolution picks exactly one (the conditions are
+      mutually exclusive); the worker restores that exact one via the
+      recorded class.
     * A background ``action_name`` that **coincides with a synchronous
-      ``Transition``** of the same name. Phase 2 only ever restores background
-      transitions and ``runner._find_transition`` filters to ``is_background``,
-      so a synchronous namesake is invisible to restore. Phase 1 resolves the
-      *call* by conditions/permissions exactly as it does for duplicate
-      synchronous names — a genuinely ambiguous call raises
-      ``TransitionNotAllowed`` at runtime, the same runtime-validated contract
-      that already governs duplicate synchronous ``action_name``s (courier-style
-      polymorphism).
+      ``Transition``** of the same name. The worker only ever restores
+      background transitions and ``runner._find_transition`` filters to
+      ``is_background``, so a synchronous namesake is invisible to
+      restore. Enqueue resolves the *call* by conditions/permissions
+      exactly as it does for duplicate synchronous names — a genuinely
+      ambiguous call raises ``TransitionNotAllowed`` at runtime, the
+      same runtime-validated contract that already governs duplicate
+      synchronous ``action_name``s (courier-style polymorphism).
 
-    So the single structural invariant phase 2 needs — and all this validator
-    enforces — is background-``action_name`` uniqueness *within one class*.
+    So the single structural invariant the worker needs — and all this
+    validator enforces — is background-``action_name`` uniqueness
+    *within one class*.
     """
     def _where(proc_cls, transition):
         return (
@@ -445,10 +448,11 @@ def _validate_unique_background_action_names(process_cls):
 
     for proc_cls in _iter_process_tree(process_cls):
         # Within ONE process class a background action_name must be unique —
-        # (owning class, action_name) is phase 2's whole key, so two in the
-        # same class are indistinguishable. Across classes, and against
-        # synchronous transitions, duplicates are fine (resolved by conditions
-        # at phase 1, by the owner + is_background filter at phase 2).
+        # (declaring class, action_name) is the worker's whole key, so two
+        # in the same class are indistinguishable. Across classes, and
+        # against synchronous transitions, duplicates are fine (resolved
+        # by conditions at enqueue, by the class + is_background filter
+        # at execute).
         local_background: dict[str, str] = {}
         for transition in proc_cls.transitions or []:
             if not getattr(transition, 'is_background', False):
@@ -461,9 +465,10 @@ def _validate_unique_background_action_names(process_cls):
                     f"has two background transitions sharing "
                     f"action_name='{name}' within a single process class "
                     f"({local_background[name]} and "
-                    f"{_where(proc_cls, transition)}). Phase-2 restore "
-                    f"identifies a background transition by (owning "
-                    f"process class, action_name) — two in the same class "
+                    f"{_where(proc_cls, transition)}). The worker "
+                    f"identifies a background transition by (process "
+                    f"class that declared it, action_name) — two in the "
+                    f"same class "
                     f"are indistinguishable, so background action_names "
                     f"must be unique within a process class. Move one to "
                     f"a separate nested process (duplicates across "
@@ -493,7 +498,7 @@ def _validate_hook_signatures(process_cls) -> None:
     if not offenders:
         return
     message = _hook_signature_message(offenders)
-    # Literal True only, same reasoning as STRICT_KWARGS_SERIALIZATION (#182).
+    # Literal True only, same reasoning as STRICT_KWARGS_SERIALIZATION.
     if strict_hook_signatures():
         raise ImproperlyConfigured(message)
     transition_logger.warning(message)
@@ -584,7 +589,7 @@ class ProcessManager:
         if binding in cls.bindings:
             # Identical re-bind (an AppConfig.ready() running twice, a
             # test re-import) is a harmless no-op — the model property
-            # and registry entry are already in place (#143).
+            # and registry entry are already in place.
             return
 
         # The state field must be a concrete column: a typo, a property,
@@ -609,7 +614,7 @@ class ProcessManager:
         # overwrite the model property while its registry entry kept
         # claiming the old machine — every registry consumer (coverage,
         # system checks, stranded recovery) would then disagree with
-        # runtime dispatch (#143).
+        # runtime dispatch.
         for existing in cls.bindings:
             if (existing.model is model
                     and existing.process_class.process_name

--- a/django_logic/process.py
+++ b/django_logic/process.py
@@ -199,7 +199,7 @@ class Process:
             # Record the process class that DECLARES this transition. For a
             # nested transition this differs from ``process_class`` (the bound
             # process this call entered through); for a transition on the bound
-            # process itself the two coincide. Phase-2 restore
+            # process itself the two coincide. Worker restore
             # (runner._find_transition) uses it to pick the exact background
             # transition when an ``action_name`` is shared across
             # condition-disambiguated nested processes. Overwrite, never

--- a/django_logic/state.py
+++ b/django_logic/state.py
@@ -18,7 +18,7 @@ class State(object):
 
         Subclasses must NOT override this with a cached read — it is the
         authoritative source used by the under-the-lock revalidation and
-        the phase-2 state guard.
+        the worker's state guard.
 
         Uses ``_base_manager`` so a filtered default manager (archived /
         soft-deleted rows hidden) cannot make a framework-level reload of
@@ -29,7 +29,7 @@ class State(object):
         # instance-aware (Model.save and refresh_from_db pass
         # hints={'instance': ...}; _release_lock reads instance._state.db), but
         # this read was unrouted, so on a non-default alias the under-lock
-        # revalidation and the phase-2 state guard compared against whatever
+        # revalidation and the worker's state guard compared against whatever
         # row the DEFAULT database happened to hold.
         using = self.instance._state.db or DEFAULT_DB_ALIAS
         return (

--- a/django_logic/testing/assertions.py
+++ b/django_logic/testing/assertions.py
@@ -111,7 +111,7 @@ class ScenarioAssertions:
         the hook is listed and got called — NOT that it produced the right
         domain change. Pair it with assert_changed / assert_unchanged /
         assert_related_count (or a direct DB assertion) to pin the OUTCOME the
-        side-effect is supposed to produce (issue #103)."""
+        side-effect is supposed to produce."""
         names = _names(names, 'assert_side_effects_ran')
         ran = self._tracker().side_effects_ran
         missing = [n for n in names if n not in ran]
@@ -135,7 +135,7 @@ class ScenarioAssertions:
         """WIRING check: assert the named callbacks executed — not that they
         did the right thing. For a callback whose whole purpose is a domain
         effect (e.g. deleting related rows), also assert the effect with
-        assert_related_count / assert_changed (issue #103)."""
+        assert_related_count / assert_changed."""
         names = _names(names, 'assert_callbacks_ran')
         ran = self._tracker().callbacks_ran
         missing = [n for n in names if n not in ran]
@@ -168,30 +168,30 @@ class ScenarioAssertions:
     # --- background error state ------------------------------------------
 
     def assert_error_recorded(self, instance, contains):
-        tm = latest_message(instance, process_name=self._process_name)
-        if tm is None or contains not in (tm.last_error_message or ''):
+        transition_message = latest_message(instance, process_name=self._process_name)
+        if transition_message is None or contains not in (transition_message.last_error_message or ''):
             self._record_assert(f'assert_error_recorded({contains!r})', ok=False)
             self._fail(
                 f'Expected a recorded error containing {contains!r}, but '
                 + ('no TransitionMessage exists for this instance.'
-                   if tm is None else f'last_error={tm.last_error_message!r}.'),
+                   if transition_message is None else f'last_error={transition_message.last_error_message!r}.'),
                 instance=instance,
             )
         self._record_assert(f'assert_error_recorded({contains!r})', ok=True)
 
     def assert_error_count(self, instance, expected):
-        tm = latest_message(instance, process_name=self._process_name)
-        actual = None if tm is None else tm.errors_count
+        transition_message = latest_message(instance, process_name=self._process_name)
+        actual = None if transition_message is None else transition_message.errors_count
         if actual != expected:
             self._record_assert(f'assert_error_count({expected})', ok=False)
             self._fail(
                 f'Expected errors_count={expected}, but '
-                + ('no TransitionMessage exists.' if tm is None else f'got {actual}.'),
+                + ('no TransitionMessage exists.' if transition_message is None else f'got {actual}.'),
                 instance=instance,
             )
         self._record_assert(f'assert_error_count({expected})', ok=True)
 
-    # --- domain outcome (before/after delta, issue #103) -----------------
+    # --- domain outcome (before/after delta) -----------------
 
     def capture(self, instance, fields):
         """Snapshot the named fields of ``instance`` NOW, as a baseline for a
@@ -199,7 +199,7 @@ class ScenarioAssertions:
         from the DB (via ``_base_manager`` so a filtered default manager can't
         hide it) and does NOT mutate the instance you pass in.
 
-        The point (issue #103): a scenario should assert what the object
+        The point: a scenario should assert what the object
         *became*, not merely that a hook ran. ``capture`` records the "before"
         so the "after" delta is checkable.
         """
@@ -215,8 +215,7 @@ class ScenarioAssertions:
         holds ``new`` now. Refreshes ``instance`` from the DB first.
 
         Unlike ``assert_side_effects_ran`` (a wiring check), this fails if the
-        hook was called but produced the wrong change — the gap issue #103
-        describes.
+        hook was called but produced the wrong change.
         """
         instance.refresh_from_db()
         problems = []
@@ -270,8 +269,7 @@ class ScenarioAssertions:
 
         For a hook whose whole effect is on related tables — a ``delete_*``
         callback that must drop child rows, a side-effect that must generate
-        N records — this pins the related-row delta the wiring check can't see
-        (issue #103). Pass the queryset AFTER the drive; capture the
+        N records — this pins the related-row delta the wiring check can't see. Pass the queryset AFTER the drive; capture the
         before-count with ``queryset.count()`` yourself if you need the delta.
         """
         actual = queryset.count()
@@ -388,23 +386,23 @@ class ScenarioAssertions:
         self._record_assert(f'assert_journey({len(expected_steps)} steps)',
                             ok=True)
 
-    # --- background owner (phase-2 restore discriminator) ---------------
+    # --- background owner (worker restore discriminator) ---------------
 
     def assert_transition_owner(self, instance, owner, *, transition_name=None):
         """Assert the recorded ``owning_process_class`` on the instance's
         latest ``TransitionMessage`` (or the one named ``transition_name``
-        when given). Pins the phase-2 owner discriminator — critical for
+        when given). Pins the worker owner discriminator — critical for
         chained/nested background transitions, where the follow-up must
         record its OWN owner, not the predecessor's.
         """
         if transition_name is not None:
-            tm = message_for(instance, transition_name,
+            transition_message = message_for(instance, transition_name,
                              process_name=self._process_name)
             label = f'assert_transition_owner({transition_name!r}, {owner!r})'
         else:
-            tm = latest_message(instance, process_name=self._process_name)
+            transition_message = latest_message(instance, process_name=self._process_name)
             label = f'assert_transition_owner({owner!r})'
-        actual = None if tm is None else tm.owning_process_class
+        actual = None if transition_message is None else transition_message.owning_process_class
         if actual != owner:
             self._record_assert(label, ok=False,
                                 detail=f'got {actual!r}')
@@ -412,7 +410,7 @@ class ScenarioAssertions:
                 where = 'the latest TransitionMessage'
             else:
                 where = f'TransitionMessage for {transition_name!r}'
-            suffix = '' if tm is not None else ' (no TransitionMessage exists.)'
+            suffix = '' if transition_message is not None else ' (no TransitionMessage exists.)'
             self._fail(
                 f'Expected owning_process_class={owner!r} on {where}, '
                 f'but got {actual!r}.{suffix}',

--- a/django_logic/testing/idempotency.py
+++ b/django_logic/testing/idempotency.py
@@ -1,4 +1,4 @@
-"""Idempotency assertion for background side-effects (issue #106).
+"""Idempotency assertion for background side-effects.
 
 Background side-effects re-run FROM SCRATCH on every retry (crash
 re-delivery, watchdog requeue, the periodic starter), so every side-effect

--- a/django_logic/testing/output.py
+++ b/django_logic/testing/output.py
@@ -23,21 +23,21 @@ def format_timeline(entries: list[dict]) -> str:
     return '\n'.join(lines)
 
 
-def format_tm(tm) -> str:
-    if tm is None:
+def format_transition_message(transition_message) -> str:
+    if transition_message is None:
         return ''
     return (
         '\n  TransitionMessage:\n'
-        f'    transition: {tm.transition_name}\n'
-        f'    is_completed: {tm.is_completed}\n'
-        f'    errors_count: {tm.errors_count}\n'
-        f'    last_error: {tm.last_error_message or "(none)"}'
+        f'    transition: {transition_message.transition_name}\n'
+        f'    is_completed: {transition_message.is_completed}\n'
+        f'    errors_count: {transition_message.errors_count}\n'
+        f'    last_error: {transition_message.last_error_message or "(none)"}'
     )
 
 
-def format_failure(message: str, timeline: list[dict], *, tm=None) -> str:
+def format_failure(message: str, timeline: list[dict], *, transition_message=None) -> str:
     parts = [message, '', format_timeline(timeline)]
-    tm_block = format_tm(tm)
-    if tm_block:
-        parts.append(tm_block)
+    message_block = format_transition_message(transition_message)
+    if message_block:
+        parts.append(message_block)
     return '\n'.join(parts)

--- a/django_logic/testing/runner.py
+++ b/django_logic/testing/runner.py
@@ -2,7 +2,7 @@
 retries inline, without Celery.
 
 Built on the library's own ``sync_execution()`` context manager (which forces
-phase 2 to run in-process) so tests exercise the *real* phase-1 + phase-2 code,
+the worker to run in-process) so tests exercise the *real* enqueue + worker code,
 not a reimplementation.
 """
 from __future__ import annotations
@@ -33,7 +33,7 @@ def all_transitions(process_class) -> list:
 
 
 def run_background_sync(instance, process_name, action_name, kwargs):
-    """Run a BackgroundTransition's phase 1 + phase 2 inline (no broker)."""
+    """Run a BackgroundTransition's enqueue + the worker inline (no broker)."""
     from django_logic.background import sync_execution
     with sync_execution():
         process = getattr(instance, process_name)
@@ -44,7 +44,7 @@ def _messages(instance, process_name, **filters):
     """Base queryset for one bound process's ``TransitionMessage`` rows,
     newest first. Scoping is mandatory: two processes on different state
     fields of the same model are independent state machines and their rows
-    must not be confused (#150)."""
+    must not be confused."""
     from django_logic.background.models import TransitionMessage
     return TransitionMessage.objects.filter(
         app_label=instance._meta.app_label,
@@ -72,7 +72,7 @@ def message_for(instance, transition_name, process_name):
 
     Used by ``assert_transition_owner`` to pin the recorded
     ``owning_process_class`` of a specific transition in a chained/next-
-    transition workflow, where several TMs exist for one instance.
+    transition workflow, where several TransitionMessage rows exist for one instance.
     """
     return _messages(instance, process_name,
                      transition_name=transition_name).first()

--- a/django_logic/testing/scenario.py
+++ b/django_logic/testing/scenario.py
@@ -113,9 +113,9 @@ class ProcessScenario(ScenarioAssertions, TransactionTestCase):
         self._record(label, 'OK' if ok else 'FAILED', detail)
 
     def _fail(self, message, instance=None):
-        tm = (latest_message(instance, process_name=self._process_name)
+        transition_message = (latest_message(instance, process_name=self._process_name)
               if instance is not None else None)
-        self.fail(format_failure(message, self._timeline, tm=tm))
+        self.fail(format_failure(message, self._timeline, transition_message=transition_message))
 
     def _state(self, instance):
         return getattr(instance, self.state_field)
@@ -166,7 +166,7 @@ class ProcessScenario(ScenarioAssertions, TransactionTestCase):
 
     def background_transition(self, instance, action, *, fail_side_effect=None,
                              fail_with=None, expect_raises=None, **kwargs):
-        """Run a BackgroundTransition's phase 1 + phase 2 inline (no Celery).
+        """Run a BackgroundTransition's enqueue + the worker inline (no Celery).
 
         ``fail_side_effect`` / ``fail_with`` make the named side-effect raise,
         exercising the real failure path. ``expect_raises`` pins the
@@ -181,27 +181,27 @@ class ProcessScenario(ScenarioAssertions, TransactionTestCase):
                          expect_raises=None):
         """Re-run the instance's uncompleted transition inline — what the
         periodic starter would do."""
-        tm = uncompleted_message(instance, process_name=self._process_name)
-        if tm is None:
+        transition_message = uncompleted_message(instance, process_name=self._process_name)
+        if transition_message is None:
             self._record('retry_transition', 'FAILED', 'no uncompleted TransitionMessage')
             self._fail('retry_transition(): no uncompleted TransitionMessage for '
                        'this instance — nothing to retry.', instance=instance)
-        if not transitions_for(self.process_class, tm.transition_name):
+        if not transitions_for(self.process_class, transition_message.transition_name):
             self._record('retry_transition', 'FAILED',
-                         f'no transition named {tm.transition_name!r}')
+                         f'no transition named {transition_message.transition_name!r}')
             self._fail(f'retry_transition(): the uncompleted TransitionMessage '
-                       f'names {tm.transition_name!r}, which does not exist on '
+                       f'names {transition_message.transition_name!r}, which does not exist on '
                        f'{self.process_class.__name__}.', instance=instance)
         before = self._state(instance)
         # Track the WHOLE process tree, not just the retried action — the
         # retry can run follow-up transitions (next_transition, callbacks)
-        # whose hooks the assertions must see (issue #96).
+        # whose hooks the assertions must see.
         with track(all_transitions(self.process_class),
                    fail_side_effect=fail_side_effect,
                    fail_with=fail_with) as tracker:
-            raised = self._call(lambda: rerun_message(tm.pk))
+            raised = self._call(lambda: rerun_message(transition_message.pk))
         self._finish('retry_transition', instance, tracker, raised, before,
-                     action=tm.transition_name, expect_raises=expect_raises)
+                     action=transition_message.transition_name, expect_raises=expect_raises)
         return instance
 
     # --- shared execution path ------------------------------------------
@@ -224,8 +224,8 @@ class ProcessScenario(ScenarioAssertions, TransactionTestCase):
                          'background transition')
             self._fail(
                 f'transition({action!r}) drives a BackgroundTransition — use '
-                f'background_transition({action!r}), which runs phase 1 and '
-                f'phase 2 inline. Under the global default '
+                f'background_transition({action!r}), which runs enqueue and '
+                f'the worker inline. Under the global default '
                 f"BACKGROUND_EXECUTION='celery' this call only ENQUEUES a "
                 f'Celery task (no worker runs it here), so the drive returns '
                 f'with the instance in its in_progress_state, an uncompleted '
@@ -236,7 +236,7 @@ class ProcessScenario(ScenarioAssertions, TransactionTestCase):
         # Track the WHOLE process tree, not just the named action — one drive
         # can also execute next_transition follow-ups and callback-triggered
         # transitions, and their hooks must be visible to the side-effect
-        # assertions (issue #96).
+        # assertions.
         with track(all_transitions(self.process_class),
                    fail_side_effect=fail_side_effect,
                    fail_with=fail_with) as tracker:
@@ -305,7 +305,7 @@ class ProcessScenario(ScenarioAssertions, TransactionTestCase):
                 self._fail(f'{label} raised unexpectedly: '
                            f'{type(raised).__name__}: {raised}', instance=instance)
         # A requested injection that never fired silently turns a failure
-        # test into a happy-path run (issue #94). track() already rejects
+        # test into a happy-path run. track() already rejects
         # names that exist nowhere; this catches a hook that exists but did
         # not execute during this drive (e.g. wrong action, gated earlier).
         # An exception that DID propagate is no evidence the injection fired:

--- a/django_logic/testing/snapshot.py
+++ b/django_logic/testing/snapshot.py
@@ -24,7 +24,7 @@ def _jsonable(value):
 
     Dicts/lists (JSONField values) pass through recursively — stringifying
     them produced a Python repr that round-tripped as a corrupted string
-    column (issue #95). Anything unsupported fails loudly rather than being
+    column. Anything unsupported fails loudly rather than being
     silently captured as ``str(value)``.
     """
     if isinstance(value, (datetime.datetime, datetime.date, datetime.time)):
@@ -65,33 +65,33 @@ def snapshot(instance, *, state_field: str = 'status', process_name: str = 'proc
     # The most recent TransitionMessage for this instance's process (if the
     # background app is installed and a row exists). Scoped by process_name so
     # a second process bound to another state field of the same model can't
-    # leak its row into this snapshot (issue #150).
+    # leak its row into this snapshot.
     try:
         from django_logic.testing.runner import latest_message
-        tm = latest_message(instance, process_name=process_name)
-        if tm is not None:
+        transition_message = latest_message(instance, process_name=process_name)
+        if transition_message is not None:
             data['transition_message'] = {
-                'transition_name': tm.transition_name,
-                'process_name': tm.process_name,
-                'field_name': tm.field_name,
-                'owning_process_class': tm.owning_process_class,
-                'queue_name': tm.queue_name,
-                'is_completed': tm.is_completed,
-                'errors_count': tm.errors_count,
-                'last_error_message': tm.last_error_message,
-                'timeout_seconds': tm.timeout_seconds,
-                'kwargs': tm.kwargs,
+                'transition_name': transition_message.transition_name,
+                'process_name': transition_message.process_name,
+                'field_name': transition_message.field_name,
+                'owning_process_class': transition_message.owning_process_class,
+                'queue_name': transition_message.queue_name,
+                'is_completed': transition_message.is_completed,
+                'errors_count': transition_message.errors_count,
+                'last_error_message': transition_message.last_error_message,
+                'timeout_seconds': transition_message.timeout_seconds,
+                'kwargs': transition_message.kwargs,
                 # The retry/watchdog clock. Without these a snapshot of a hung
                 # or timed-out production row replays as a pristine row: the
                 # retry backoff, the stale-attempt watchdog and the
                 # stuck-transition detector all read them, so the very
                 # behaviour the snapshot was taken to reproduce could not be
                 # reproduced.
-                'last_error_dt': _jsonable(tm.last_error_dt),
-                'failure_side_effect_error': tm.failure_side_effect_error,
-                'started_at': _jsonable(tm.started_at),
-                'completed_at': _jsonable(tm.completed_at),
-                'duration_ms': tm.duration_ms,
+                'last_error_dt': _jsonable(transition_message.last_error_dt),
+                'failure_side_effect_error': transition_message.failure_side_effect_error,
+                'started_at': _jsonable(transition_message.started_at),
+                'completed_at': _jsonable(transition_message.completed_at),
+                'duration_ms': transition_message.duration_ms,
             }
     except Exception:
         pass
@@ -125,7 +125,7 @@ def _load(data_or_path):
 def _restore_dt(value):
     """ISO string (as captured) -> ``datetime``. The DB adapter would coerce
     the string too, but the created row is read back by callers, so keep the
-    in-memory attributes real field types (issue #95's lesson)."""
+    in-memory attributes real field types."""
     if not value:
         return None
     if isinstance(value, str):
@@ -172,7 +172,7 @@ def from_snapshot(data_or_path, *, model=None):
     # the save coerced them in the DATABASE, but the in-memory instance still
     # carries the strings — a condition like ``if instance.band:`` would see
     # ``bool('0.000') == True`` where production saw ``bool(Decimal('0.000'))
-    # == False`` (issue #95). Re-read so attributes are real field types.
+    # == False``. Re-read so attributes are real field types.
     instance.refresh_from_db()
 
     tm_data = data.get('transition_message')
@@ -196,12 +196,12 @@ def from_snapshot(data_or_path, *, model=None):
             model_name=instance._meta.model_name,
             instance_id=str(instance.pk),
             process_name=tm_process_name,
-            # Restore the recorded field so phase 2 takes the same
+            # Restore the recorded field so the worker takes the same
             # recorded-field path the production row would have used
             # ('' = legacy pre-0.4 row, inference fallback).
             field_name=tm_data.get('field_name', ''),
             transition_name=tm_data['transition_name'],
-            # Restore the owning-process discriminator so phase-2 replay
+            # Restore the owning-process discriminator so worker replay
             # resolves the exact transition (blank on legacy snapshots →
             # first-match fallback, unchanged behaviour).
             owning_process_class=tm_data.get('owning_process_class', ''),

--- a/django_logic/testing/tracking.py
+++ b/django_logic/testing/tracking.py
@@ -9,7 +9,7 @@ callables on the transition's hook bundles (``side_effects``, ``callbacks``,
   running a named hook — exercising the real failure path.
 
 Transition objects are class-level and shared, and both the synchronous
-``SideEffects.execute`` path and the background phase-2 runner iterate
+``SideEffects.execute`` path and the background worker runner iterate
 ``transition.side_effects.commands`` — so wrapping ``_commands`` instruments
 both execution modes. Everything is restored on exit.
 """
@@ -38,7 +38,7 @@ class ExecutionTracker:
         self.injected_exception: BaseException | None = None
         self.failed_side_effect: str | None = None
         # What the caller ASKED to fail — so the scenario can detect an
-        # injection that never fired (issue #94: a silent no-op would turn
+        # injection that never fired (a silent no-op would turn
         # a failure test into a happy-path run).
         self.requested_fail_side_effect: str | None = None
         # Ordered sequence of states written to the instance during this
@@ -88,7 +88,7 @@ def track(transitions, *, fail_side_effect=None, fail_with=None):
 
     ``transitions`` is the list of class-level ``Transition`` objects to
     instrument — the scenario passes every transition reachable from the
-    process class (issue #96: a single drive can execute more than the named
+    process class (a single drive can execute more than the named
     action via ``next_transition`` and callback-triggered transitions, and
     those hooks must be visible to the assertions too). Yields an
     :class:`ExecutionTracker`. Injection only targets ``side_effects`` hooks.
@@ -96,7 +96,7 @@ def track(transitions, *, fail_side_effect=None, fail_with=None):
     When ``fail_side_effect`` names a hook that exists on none of the
     instrumented transitions, ``ValueError`` is raised immediately — a typo
     or a renamed hook must not silently turn a failure test into a
-    happy-path run (issue #94).
+    happy-path run.
     """
     tracker = ExecutionTracker()
     tracker.requested_fail_side_effect = fail_side_effect

--- a/django_logic/transition.py
+++ b/django_logic/transition.py
@@ -9,15 +9,12 @@ the caller's call frame — validate, lock, run, write the target state.
 still runs side-effects and can set a ``failed_state`` on failure.
 
 For background-executed transitions, see
-``django_logic.background.BackgroundTransition``. Comments in this
-module that mention "phase 1" / "phase 2" refer to the two halves of a
-*background* transition (the transactional-outbox pattern): phase 1 is
-the synchronous part that durably records the intent (write
-``in_progress_state`` + a ``TransitionMessage`` row in one transaction,
-then enqueue the Celery task), phase 2 is the worker-side part that
-executes the side-effects and writes the final state. Definitions live
-in ``django_logic.background.transitions`` (phase 1) and
-``django_logic.background.runner`` (phase 2).
+``django_logic.background.BackgroundTransition``. That path has two
+halves: enqueue (write ``in_progress_state`` + a ``TransitionMessage``
+row in one transaction, then send the Celery task) and execute (the
+worker runs the side-effects and writes the final state). Definitions
+live in ``django_logic.background.transitions`` (enqueue) and
+``django_logic.background.runner`` (execute).
 """
 import math
 from uuid import UUID
@@ -91,9 +88,9 @@ class Transition:
     The state field does not change until the transition finishes:
     ``in_progress_state`` is background-only (0.12.0), where it is written
     atomically with the durable ``TransitionMessage`` row. A synchronous run
-    that dies mid-flight rolls back to its source state and is re-drivable —
-    a visible "busy" phase, where wanted, is a real state with an explicit
-    fast transition into it, chained via ``next_transition``.
+    that dies mid-run rolls back to its source state and can be run
+    again — a visible "busy" step, where wanted, is a real state with an
+    explicit fast transition into it, chained via ``next_transition``.
     """
 
     side_effects_class = SideEffects
@@ -127,44 +124,44 @@ class Transition:
         self.sources = list(sources)
         self.in_progress_state = kwargs.get('in_progress_state')
         if self.in_progress_state and not self.is_background:
-            # Background-only (0.12.0). On a background transition the marker
-            # is written atomically with the TransitionMessage row, so every
-            # marked instance has a recovery owner (the TM safety nets). A
-            # synchronous transition wrote it under a cache lock with NO
-            # durable record: a hard-killed worker left the instance parked in
-            # a state with no outbound edges and nothing that could ever move
-            # it (#136) — the engine grew a whole sweeping subsystem to find
-            # those, and the sweep was the most defect-dense code in four
-            # review passes. Without the marker a killed sync run rolls back
-            # to its source state and is simply re-drivable: self-healing, no
-            # machinery. Model a visible "busy" phase as a real state instead:
-            # a fast transition into it, chained via next_transition to the
-            # transition that does the work (see the README migration note).
+            # Background-only (0.12.0). On a background transition the
+            # state is written atomically with the TransitionMessage row,
+            # so every marked instance names its exact transition. A
+            # synchronous transition wrote it under a cache lock with no
+            # durable record: a hard-killed worker left the instance
+            # parked in a state with no outbound edges and nothing that
+            # could ever move it. Without that write a killed sync run
+            # rolls back to its source state and can simply be run again.
+            # Model a visible "busy" step as a real state instead: a
+            # fast transition into it, chained via next_transition to the
+            # transition that does the work (see the README migration
+            # note).
             raise ImproperlyConfigured(
                 f"Transition {action_name!r}: in_progress_state is only "
                 f"supported on BackgroundTransition, where it is written "
                 f"atomically with the durable TransitionMessage row. On a "
-                f"synchronous transition the marker is a record-less dead "
-                f"end (#136). Model the busy phase as a real state with an "
+                f"synchronous transition that write is a record-less dead "
+                f"end. Model the busy step as a real state with an "
                 f"explicit transition into it, or make this transition a "
                 f"BackgroundTransition."
             )
         if self.in_progress_state and self.in_progress_state not in self.sources:
             # Treat the in-progress state as a valid source of the same
-            # transition so phase 2 / retry paths can look the transition
-            # up from an already-in-flight instance. Visible consequence:
-            # while a background transition is in flight (instance in
-            # in_progress_state, phase-1 lock already released), the action
-            # still shows up in get_available_actions() — the one-in-flight
-            # gate is enforced at invocation time (AlreadyInProgress), not
-            # at listing time.
+            # transition so the worker / retry paths can look the
+            # transition up from an already-running instance. Visible
+            # consequence: while a background transition is in progress
+            # (instance in in_progress_state, enqueue lock already
+            # released), the action still shows up in
+            # get_available_actions() — the one-uncompleted-row gate is
+            # enforced at invocation time (AlreadyInProgress), not at
+            # listing time.
             self.sources.append(self.in_progress_state)
         self.failed_state = kwargs.get('failed_state')
         if self.failed_state and self.failed_state == self.in_progress_state:
-            # The state field is what operators, UIs and the phase-2 guard
-            # read to tell "failed" from "still running"; identical, every
-            # failed instance is indistinguishable from a busy one and the
-            # terminal write is a silent no-op.
+            # The state field is what operators, UIs and the worker's
+            # state guard read to tell "failed" from "still running";
+            # identical, every failed instance is indistinguishable from
+            # a busy one and the terminal write is a silent no-op.
             raise ImproperlyConfigured(
                 f"Transition {action_name!r}: failed_state and "
                 f"in_progress_state are both {self.failed_state!r}. A failed "
@@ -177,8 +174,8 @@ class Transition:
         # legitimately run long (report generation, large exports) — size it
         # above the longest expected run so mutual exclusion holds for the
         # whole run instead of expiring mid-flight. Background
-        # transitions don't need this: their phase-1 critical section is
-        # short and their in-flight marker is the TransitionMessage row.
+        # transitions don't need this: their enqueue critical section is
+        # short and the uncompleted TransitionMessage row is the gate.
         self.lock_timeout = kwargs.get('lock_timeout')
         if self.lock_timeout is not None and (
             not isinstance(self.lock_timeout, (int, float))
@@ -248,7 +245,7 @@ class Transition:
         #
         # No-arg call when no per-transition override is configured, so
         # custom State subclasses written against the pre-lock_timeout
-        # ``lock(self)`` signature keep working (#142).
+        # ``lock(self)`` signature keep working.
         locked = (
             state.lock()
             if self.lock_timeout is None
@@ -257,10 +254,8 @@ class Transition:
         if not locked:
             # Logged BEFORE the raise, or a permanently frozen instance is
             # indistinguishable from a healthy start: both emit one Start line
-            # and nothing else (#188 — seven instances re-driven for ten days
-            # produced ~1400 Start lines and zero indication a leaked lock was
-            # the cause). INFO, not ERROR: losing the lock race is an expected
-            # concurrency outcome (#154); it is the *pattern* of failed
+            # and nothing else. INFO, not ERROR: losing the lock race is an
+            # expected concurrency outcome; it is the *pattern* of failed
             # acquisitions with no interleaved Unlock that signals a leak.
             transition_logger.info(
                 f'{kwargs.get("tr_id")} {TransitionEventType.LOCK.value} '
@@ -281,13 +276,14 @@ class Transition:
         # freezes until the lock TTL expires. (No state is written under the
         # lock before the side-effects anymore: in_progress_state is
         # background-only since 0.12.0 — a sync run that dies leaves the
-        # instance at its source state, re-drivable, with nothing to sweep.)
+        # instance at its source state, ready to run again, with nothing
+        # to sweep.)
         try:
             self._ensure_db_state_in_sources(state)
             self._ensure_no_background_in_flight(state)
         except Exception:
             state.unlock()
-            # Without this line the per-instance lifecycle (#188) shows a Lock
+            # Without this line the per-instance lifecycle shows a Lock
             # with no Unlock — a revalidation failure reading as a leak.
             transition_logger.info(
                 f'{kwargs.get("tr_id")} {TransitionEventType.UNLOCK.value} '
@@ -348,9 +344,9 @@ class Transition:
         # original side-effect exception keeps propagating out of
         # SideEffects.execute either way.
         #
-        # Deferral (#141) only applies when a state write actually
-        # happened under this lock — the failed_state written below (sync
-        # transitions write no in-progress marker since 0.12.0). A failure
+        # Deferral only applies when a state write actually happened
+        # under this lock — the failed_state written below (sync
+        # transitions write no in-progress state since 0.12.0). A failure
         # that wrote nothing has no invisible span to protect, so the unlock
         # stays immediate (deferring would only leak the lock until TTL when
         # the outer transaction rolls back).
@@ -369,7 +365,7 @@ class Transition:
                     # on DEFAULT would guard the wrong connection.
                     # require_commit: the else-branch logs SET_STATE, so a
                     # silently discarded savepoint must take the honest
-                    # except-path instead (#192, the sync analog of #189).
+                    # except-path instead.
                     _run_in_savepoint(
                         state.instance._state.db or DEFAULT_DB_ALIAS,
                         lambda: state.set_state(self.failed_state),
@@ -409,7 +405,7 @@ class Transition:
     @staticmethod
     def _release_lock(state: State, deferrable: bool = True, **kwargs):
         """Release the state lock — now, or at commit under
-        ``DJANGO_LOGIC['DEFER_UNLOCK_UNTIL_COMMIT']`` (#141).
+        ``DJANGO_LOGIC['DEFER_UNLOCK_UNTIL_COMMIT']``.
 
         Deferring extends mutual exclusion over the span where a state
         write is committed-but-invisible to other connections. The
@@ -435,10 +431,10 @@ class Transition:
                 )
                 return
         state.unlock()
-        # instance_key on the lifecycle lines (#188): Start used to be the only
-        # line carrying it, so a per-instance log filter could not show whether
-        # the lock was ever taken or released — the absence of a Lock line was
-        # invisible without a tr_id self-join.
+        # instance_key on the lifecycle lines: Start used to be the only
+        # line carrying it, so a per-instance log filter could not show
+        # whether the lock was ever taken or released — the absence of a
+        # Lock line was invisible without a tr_id self-join.
         transition_logger.info(
             f'{kwargs.get("tr_id")} {TransitionEventType.UNLOCK.value} '
             f'{state.instance_key}'
@@ -463,10 +459,10 @@ class Transition:
     @staticmethod
     def _background_in_flight(state: State) -> bool:
         """Whether an uncompleted ``TransitionMessage`` exists for this
-        instance + process — the durable in-flight marker for background
-        work (the cache lock only guards short critical sections). Only
-        meaningful while holding the lock: phase 1 needs the lock to create
-        a new row, so the answer cannot flip underneath the holder.
+        instance + process (the cache lock only guards short critical
+        sections). Only meaningful while holding the lock: enqueue needs
+        the lock to create a new row, so the answer cannot flip
+        underneath the holder.
 
         Bare existence, deliberately stricter than the public
         ``in_flight()`` probe: the Action's write-skip must never clobber
@@ -485,19 +481,19 @@ class Transition:
 
     def _ensure_no_background_in_flight(self, state: State) -> None:
         """Reject a state-changing transition while a background transition
-        is in flight on the same instance + process.
+        is in progress on the same instance + process.
 
         Without this gate a synchronous transition could interleave with
-        phase 2 and the two would overwrite each other's state writes.
+        the worker and the two would overwrite each other's state writes.
         Checked under the lock, like the source revalidation.
 
-        A LIVE row raises the transient type (#191): it clears when the
-        flight completes, so "come back in a moment" is the right answer.
-        A STRANDED row raises the plain base (#195): nothing is driving it,
-        so "retry shortly" would be wrong forever, and hook-path logging
-        must stay at ERROR — a stuck instance pages. The classification
-        (``TransitionMessage.in_flight_liveness``) is shared with phase 1's
-        constraint rejection and the public probe.
+        A row that is still being retried raises the transient type: it
+        clears when that work completes, so "come back in a moment" is
+        the right answer. A stranded row raises the plain base: nothing
+        is retrying it, so "retry shortly" would be wrong forever, and
+        hook-path logging must stay at ERROR — a stuck instance pages.
+        The classification (``TransitionMessage.retry_status``) is shared
+        with enqueue's constraint rejection and the public probe.
         """
         from django.apps import apps
 
@@ -505,19 +501,20 @@ class Transition:
             return
         from django_logic.background.models import TransitionMessage
 
-        liveness = TransitionMessage.in_flight_liveness(
+        status = TransitionMessage.retry_status(
             state.instance, state.process_name)
-        if liveness is None:
+        if status is None:
             return
-        if liveness == TransitionMessage.LIVENESS_STRANDED:
+        if status == TransitionMessage.STRANDED:
             raise TransitionNotAllowed(
                 f"Transition '{self.action_name}' is not allowed: a "
                 f"background transition for {state.instance_key} has an "
-                f"uncompleted TransitionMessage past the retry horizon — "
-                f"stranded, not in flight. Likely causes: the safety-net "
-                f"beat tasks are not scheduled (django_logic.W002), a "
-                f"queue backlog or worker outage longer than the horizon, "
-                f"or a lost broker message. Re-drive or complete the row."
+                f"uncompleted TransitionMessage that is stranded — "
+                f"nothing is retrying it. Likely causes: the safety-net "
+                f"beat tasks are not scheduled, a queue backlog or "
+                f"worker outage longer than the retry window, or a lost "
+                f"broker message. Complete the row, or start the beat "
+                f"tasks so it is retried."
             )
         raise TransitionTemporarilyUnavailable(
             f"Transition '{self.action_name}' is not allowed right now: "
@@ -531,20 +528,21 @@ class Action(Transition):
 
     Still runs side-effects and callbacks. ``failed_state`` (if set)
     is applied on failure — but only when the state is not locked by an
-    in-flight transition (see ``fail_transition``).
+    in-progress transition (see ``fail_transition``).
 
     Deliberate asymmetries vs :class:`Transition` — an Action does not
     change state, so it skips the state-change machinery entirely:
 
     * no cache lock around the side-effects, no under-the-lock source
-      revalidation, and no background-in-flight gate (Actions may run
-      while a background transition is in flight); the one lock an Action
-      takes is short-lived, scoped to the ``failed_state`` write in
-      ``fail_transition`` (#185) — and that write is skipped while an
-      uncompleted ``TransitionMessage`` exists, because phase 2 owns the
-      state field until the row completes;
-    * ``next_transition`` is NOT executed on success (note the divergence:
-      a *BackgroundAction*'s phase 2 does run ``next_transition``);
+      revalidation, and no background-in-progress gate (Actions may run
+      while a background transition is in progress); the one lock an
+      Action takes is short-lived, scoped to the ``failed_state`` write
+      in ``fail_transition`` — and that write is skipped while an
+      uncompleted ``TransitionMessage`` exists, because the worker owns
+      the state field until the row completes;
+    * ``next_transition`` is NOT executed on success (note the
+      divergence: a *BackgroundAction*'s worker path does run
+      ``next_transition``);
     * ``in_progress_state`` is rejected like any synchronous transition's
       (background-only since 0.12.0); ``BackgroundAction`` rejects it too.
     """
@@ -580,21 +578,21 @@ class Action(Transition):
         ``failed_state`` is written only under an atomically-acquired lock:
         checking ``is_locked()`` and then writing left a window for a
         concurrent transition to start between the check and the write, and
-        the Action's stale write then clobbered that flight's state (#185).
-        The cache lock only covers sync flights and phase 1, so under the
-        lock the durable in-flight marker is consulted too: while an
-        uncompleted ``TransitionMessage`` exists, phase 2 owns the state
-        field and the write is skipped — otherwise it would supersede the
-        flight (or be destroyed by its target write). Whenever the write is
-        skipped, the failure is still fully visible — the exception
-        propagates and the failure hooks run.
+        the Action's stale write then clobbered that transition's state.
+        The cache lock only covers sync runs and enqueue, so under the
+        lock the uncompleted ``TransitionMessage`` is consulted too:
+        while one exists, the worker owns the state field and the write
+        is skipped — otherwise it would supersede the worker (or be
+        destroyed by its target write). Whenever the write is skipped,
+        the failure is still fully visible — the exception propagates
+        and the failure hooks run.
         """
         if self.failed_state:
             if not state.lock():
                 transition_logger.error(
                     f'{kwargs.get("tr_id")} Action {self.action_name!r}: '
                     f'skipping failed_state={self.failed_state!r} write — '
-                    f'{state.instance_key} is locked by an in-flight '
+                    f'{state.instance_key} is locked by an in-progress '
                     f'transition and an Action must not overwrite its state.'
                 )
             else:
@@ -604,8 +602,8 @@ class Action(Transition):
                 )
                 wrote_state = False
                 try:
-                    # Probe guarded (#194): the side-effect that brought us
-                    # here may have rollback-poisoned the connection (or the
+                    # Probe guarded: the side-effect that brought us here
+                    # may have rollback-poisoned the connection (or the
                     # database may be down), in which case the probe itself
                     # raises. Escaping here replaced the original exception
                     # with the probe's and skipped both failure hook bundles
@@ -618,7 +616,7 @@ class Action(Transition):
                         transition_logger.error(
                             f'{kwargs.get("tr_id")} Action '
                             f'{self.action_name!r}: could not probe for an '
-                            f'in-flight background transition on '
+                            f'in-progress background transition on '
                             f'{state.instance_key}: '
                             f'{type(probe_error).__name__}: {probe_error}. '
                             f'Skipping the failed_state write; the original '
@@ -631,12 +629,12 @@ class Action(Transition):
                             f'{self.action_name!r}: skipping failed_state='
                             f'{self.failed_state!r} write — an uncompleted '
                             f'TransitionMessage owns the state field of '
-                            f'{state.instance_key} until its flight '
-                            f'completes.'
+                            f'{state.instance_key} until the worker '
+                            f'completes it.'
                         )
                     elif in_flight is not None:
-                        # Savepointed like Transition.fail_transition (#178):
-                        # a rejected write must not replace the original
+                        # Savepointed like Transition.fail_transition: a
+                        # rejected write must not replace the original
                         # side-effect exception on its way out, and must not
                         # log a SET_STATE line for a write that never landed.
                         previous = state.get_state()
@@ -646,7 +644,7 @@ class Action(Transition):
                             # so a savepoint opened on DEFAULT would guard
                             # the wrong connection. require_commit: a
                             # silently discarded savepoint must take the
-                            # honest except-path (#192).
+                            # honest except-path.
                             _run_in_savepoint(
                                 state.instance._state.db or DEFAULT_DB_ALIAS,
                                 lambda: state.set_state(self.failed_state),
@@ -677,8 +675,8 @@ class Action(Transition):
                             )
                 finally:
                     # The shared release path: emits the Unlock lifecycle
-                    # line (#188) and honours DEFER_UNLOCK_UNTIL_COMMIT when
-                    # a state write landed under the lock (#141).
+                    # line and honours DEFER_UNLOCK_UNTIL_COMMIT when a
+                    # state write landed under the lock.
                     self._release_lock(state, deferrable=wrote_state, **kwargs)
         self.failure_side_effects.execute(state, exception=exception, **kwargs)
         self.failure_callbacks.execute(state, exception=exception, **kwargs)

--- a/docs/TESTING_GUIDE.md
+++ b/docs/TESTING_GUIDE.md
@@ -93,8 +93,8 @@ or a direct DB read).
 
 Background transitions execute through Celery by default
 (`BACKGROUND_EXECUTION` defaults to `'celery'`). Tests opt into **sync
-execution mode**, where phase 1 (validate + persist the `TransitionMessage` +
-write `in_progress_state`) and phase 2 (side-effects + target state) run
+execution mode**, where enqueue (validate + persist the `TransitionMessage` +
+write `in_progress_state`) and execute (side-effects + target state) run
 inline in the test process — the *real* code paths, not a re-implementation:
 
 ```python
@@ -179,7 +179,7 @@ def test_order_lifecycle(self):
     self.transition(order, 'approve', user=self.staff)
     self.assert_state(order, 'approved')
 
-    self.background_transition(order, 'fulfil')   # phase 1 + 2 inline, no Celery
+    self.background_transition(order, 'fulfil')   # enqueue + execute inline, no Celery
     self.assert_state(order, 'fulfilled')
     self.assert_side_effects_ran(['reserve_stock', 'call_courier'])
     self.assert_callbacks_ran(['send_confirmation_email'])
@@ -357,12 +357,12 @@ def test_cannot_cancel_mid_fulfilment(self):
 ```
 
 Design consequence: chain follow-up background work from a *terminal* hook
-(a callback that fires after the row completes), never from inside the flight.
+(a callback that fires after the row completes), never from inside the run.
 
 ### 10. The superseded scenario (manual ops fix wins)
 
 If something external moves the instance while a background row is pending —
-a support engineer in the admin, a data migration — phase 2 must NOT undo it.
+a support engineer in the admin, a data migration — the worker must NOT undo it.
 Reproduce it by completing the ops fix between failure and retry:
 
 ```python
@@ -398,8 +398,8 @@ visible to `assert_side_effects_ran` even though you only drove `'pay'`.
 
 ### 12. Nested processes
 
-Background transitions declared on nested processes restore correctly in
-phase 2 — drive them through the parent's bound property like production code
+Background transitions declared on nested processes restore correctly on
+the worker — drive them through the parent's bound property like production code
 would:
 
 ```python
@@ -578,7 +578,7 @@ Class attributes: `process_class`, `model`, `state_field` (default
 |---|---|
 | `create_instance(**fields)` | Create a model instance (state via the `state_field` kwarg). Override for factories. |
 | `transition(obj, action, **kwargs)` | Run a synchronous transition through the normal entrypoint. |
-| `background_transition(obj, action, **kwargs)` | Run a `BackgroundTransition`/`BackgroundAction` phase 1 **and** phase 2 inline. |
+| `background_transition(obj, action, **kwargs)` | Run a `BackgroundTransition`/`BackgroundAction` enqueue **and** execute inline. |
 | `retry_transition(obj)` | Re-run the instance's uncompleted `TransitionMessage` — simulates the periodic starter. |
 | `snapshot(obj)` / `from_snapshot(data_or_path)` | Capture / rebuild instance + `TransitionMessage` state. |
 
@@ -679,7 +679,7 @@ from django_logic.background.dispatch import retry_pending
 retry_pending()   # one tick of the periodic starter, inline (sync mode)
 
 from django_logic.background.runner import run_background_transition
-run_background_transition(tm.pk)   # one phase-2 attempt for a specific row
+run_background_transition(tm.pk)   # one worker attempt for a specific row
 ```
 
 Use `TransactionTestCase` (or `ProcessScenario`, which extends it) when your
@@ -696,7 +696,7 @@ pyramid backing it:
 1. **Unit + regression suite** (`python tests/manage.py test`, SQLite,
    ~340 tests): every reproduced defect from the 0.3 stability review has a
    permanent regression test — savepoint isolation of side-effects
-   (`tests/background/test_savepoint_isolation.py`), the phase-2 state guard
+   (`tests/background/test_savepoint_isolation.py`), the worker's state guard
    (`test_phase2_state_guard.py`), the per-process in-flight constraint
    (`test_constraint_per_process.py`), restore verification
    (`test_restore_verification.py`), sync/background mutual exclusion

--- a/docs/design/BACKGROUND_TRANSITION_ANALYSIS.md
+++ b/docs/design/BACKGROUND_TRANSITION_ANALYSIS.md
@@ -3,7 +3,8 @@
 > Design document for `BackgroundTransition` / `BackgroundAction`, first
 > shipped in Django Logic v0.3.0. This file is the rationale and the
 > crash-by-crash analysis behind the chosen design; the README documents the
-> resulting API.
+> resulting API. Current docs say **enqueue** and **execute**. "Phase 1"
+> and "Phase 2" in this file mean those two halves.
 
 ---
 

--- a/docs/logger.md
+++ b/docs/logger.md
@@ -93,14 +93,14 @@ released, and `failure_callbacks` run.
 
 ## Background transitions
 
-A `BackgroundTransition` runs in two phases. Phase 1 (the synchronous call)
-logs the `Start [background queue=...]` line, then its critical section:
-`Lock`, optionally `Set State in_progress_state`, the
-`TransitionMessage#<pk> created` line, and `Unlock` (since 0.4 phase 1 holds
-the state lock only for this section — the uncompleted row is the in-flight
-marker afterwards). Phase 2 (the
-worker, or inline in Sync mode) logs `Phase2 Start`, the `SideEffect` lines,
-`Set State target`, and `Complete`.
+A `BackgroundTransition` is split into enqueue and execute. Enqueue (the
+synchronous call) logs the `Start [background queue=...]` line, then its
+critical section: `Lock`, optionally `Set State in_progress_state`, the
+`TransitionMessage#<pk> created` line, and `Unlock` (since 0.4 enqueue
+holds the state lock only for this section — the uncompleted row is the
+gate afterwards). Execute (the worker, or inline in Sync mode) logs
+`Phase2 Start`, the `SideEffect` lines, `Set State target`, and
+`Complete`. (`Phase2 Start` is the existing log event name.)
 
 All side-effects **and** the target-state write run inside a single Celery task
 (`acks_late=True`) — there is no per-callback Celery fan-out. There are no

--- a/docs/recipes/nested-processes.md
+++ b/docs/recipes/nested-processes.md
@@ -16,7 +16,7 @@ failures across state machines.
    `BackgroundTransition` with its own `failed_state`. A child failure is
    *contained* on the child row, never raised.
 2. **The parent fans out, it does not drive.** The parent transition only
-   *starts* each child's background transition (phase 1) and returns. No child
+   *starts* each child's background transition (enqueue) and returns. No child
    work runs inside the parent transition, so no child exception can reach it.
 3. **Children report back via best-effort callbacks** (`Callbacks.execute`
    swallows exceptions) that run an **idempotent, guarded completion check**.
@@ -73,7 +73,7 @@ class OrderProcess(Process):                         # the parent (synchronous)
 def fan_out(order, **kw):
     for child in order.fulfillments.all():
         try:
-            child.process.fulfill()        # phase 1 only — dispatches the child's task
+            child.process.fulfill()        # enqueue only — dispatches the child's task
         except Exception as exc:           # contain: one child that can't START ≠ failed fan-out
             log.warning('could not start fulfillment %s: %s', child.pk, exc)
 


### PR DESCRIPTION
## Summary

Closes #199. A mid-level Django developer can read `django_logic/background/transitions.py` without opening the changelog or a ticket.

This is the language pass. It also includes the Voice rule from #200 (`CLAUDE.md` + the Cursor rule), so that PR can be closed as superseded when this merges.

- Enqueue vs execute, not phase 1 / phase 2.
- Locals are full words: `transition_message`, not `tm`.
- Ticket numbers stay in `CHANGELOG.md`, not in `.py` comments or exception text.
- Stranded-row exceptions say what happened and what to do. No `retry horizon`, `re-drive`, or `W002`.
- `SourceStateChanged` says the status moved while the insert waited on the unique constraint.
- README, testing guide, logger notes, and the nested-process recipe use the same words.

Internal names:
- `_phase_one_atomic` → `_enqueue_atomic`
- `in_flight_liveness()` → `retry_status()`
- `LIVENESS_LIVE` / `LIVENESS_STRANDED` / `LIVENESS_SLACK` → `RETRYING` / `STRANDED` / `RETRY_SLACK`

Unchanged: `BackgroundTransition`, `TransitionMessage`, `in_progress_state`, `in_flight()`, the `owning_process_class` column, the `Phase2 Start` log event, and the `[superseded]` prefix. Historical changelog entries and test method names stay as they shipped.

## Test plan

- [x] `python tests/manage.py test` — 623 passed, 8 skipped
- [x] Read `django_logic/background/transitions.py` without the changelog
- [x] Confirm a stranded-row exception names the cause and the next step, with no `W002` or `re-drive`
- [x] README / TESTING_GUIDE no longer teach phase 1 / phase 2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide renames and exception-string changes across the background engine; any code importing private symbols (`in_flight_liveness`, `_phase_one_atomic`) or asserting exact error text will break, though runtime semantics are intended to be unchanged.
> 
> **Overview**
> **Documentation and voice** — README, `CLAUDE.md`, testing guides, and comments now describe background work as **enqueue** (save row + dispatch) and **execute** (worker path), not phase 1/2 or “liveness.” A new Cursor rule and a **Voice** section in `CLAUDE.md` tell contributors to use plain English and keep ticket IDs out of `.py` comments.
> 
> **Internal renames (breaking for private API callers)** — `_phase_one_atomic` → `_enqueue_atomic`; `TransitionMessage.in_flight_liveness()` → `retry_status()` with `RETRYING` / `STRANDED` / `RETRY_SLACK` replacing `LIVENESS_*`. Locals like `tm` become `transition_message` across dispatch, runner, and observability.
> 
> **Operator-facing text** — Stranded-row and sync-gate `TransitionNotAllowed` messages explain causes and next steps without `W002`, `re-drive`, or `retry horizon`. `SourceStateChanged` refers to the unique-constraint wait, not a “finishing flight.”
> 
> **Unchanged public surface** — `BackgroundTransition`, `TransitionMessage`, `in_progress_state`, `in_flight()`, `owning_process_class`, and the `Phase2 Start` log event stay as documented in the PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9573dcf699c69a56da54070d173881fb7a8e4550. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->