### PR TITLE
Schedule cleanup by crontab — a 24h interval never fires under restarting beat (#203)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,17 @@ growth defended the engine's own machinery).
   a consumer-reproduced failure, adversarial self-review capped at one
   pass, and a third fix on one defect class triggers a design cut.
 
+### Fixed
+
+- **`beat_schedule()` schedules cleanup by crontab (03:17), not a 24-hour
+  interval** (#203, reproduced on both gv Heroku apps). Interval entries
+  count from beat start-up and the default scheduler state lives on disk,
+  so a beat that restarts on every deploy — or daily, on platforms that
+  cycle dynos — never reaches a day-scale interval: completed rows piled
+  up 9–10 days deep while the short-interval tasks ran fine. The
+  ``cleanup_seconds`` keyword becomes ``cleanup_schedule`` (any Celery
+  schedule value).
+
 ### Changed
 
 - The testing-guide scenario catalog is five canonical scenarios; the

--- a/README.md
+++ b/README.md
@@ -128,7 +128,6 @@ order.process.pay()  # Changes status from 'pending' to 'paid'
 - **Action** - Similar to transition but doesn't change the state. Useful for operations that need permissions and side effects without state change.
 - **Side-effects** - Functions executed during a transition before reaching the target state. If any fail, the state does not advance (`failed_state` is applied if declared). Background transitions additionally roll back the failed attempt's database writes (savepoint); synchronous side-effect writes are **not** rolled back automatically.
 - **Callbacks** - Functions executed after successfully reaching the target state.
-- **Failure side-effects** - Functions executed when side-effects fail, before the state is unlocked. Useful for cleanup or compensation that must run while the instance is still locked.
 - **Failure callbacks** - Functions executed after side-effects fail, after the state is unlocked.
 - **Conditions** - Functions that must return True for a transition to be allowed.
 - **Permissions** - Functions that check if a user can perform a transition.
@@ -1115,7 +1114,7 @@ Celery mode has three things you **must** wire up, or the durability guarantees 
 
 **2. The four periodic safety-net tasks, scheduled via Celery beat.** They are registered automatically (`@shared_task`, names `django_logic.*`) once your Celery app imports/auto-discovers `django_logic.background.tasks`. **If you don't schedule them, retries, stuck-row finalization, the timeout watchdog, and cleanup never run** — a single lost broker message then leaves an instance waiting forever.
 
-Use the ready-made schedule — it routes all four tasks to `DJANGO_LOGIC['STARTER_QUEUE']` with the recommended intervals (retry 60s, detect-stuck 300s, watchdog 120s, cleanup daily), each overridable by keyword:
+Use the ready-made schedule — it routes all four tasks to `DJANGO_LOGIC['STARTER_QUEUE']` with the recommended schedules (retry 60s, detect-stuck 300s, watchdog 120s, cleanup at 03:17 by crontab — a wall-clock schedule, because interval entries reset on every beat restart and a day-scale interval never fires on a platform that deploys or cycles dynos daily), each overridable by keyword:
 
 ```python
 # celery.py — after the app is configured

--- a/django_logic/background/settings.py
+++ b/django_logic/background/settings.py
@@ -76,10 +76,17 @@ def beat_schedule(
     retry_seconds: float = 60.0,
     detect_stuck_seconds: float = 300.0,
     watchdog_seconds: float = 120.0,
-    cleanup_seconds: float = 86_400.0,
+    cleanup_schedule=None,
 ) -> dict:
     """Ready-made Celery beat entries for the four safety-net tasks,
     routed to ``DJANGO_LOGIC['STARTER_QUEUE']``.
+
+    Cleanup runs on a ``crontab`` (03:17 by default), not an interval.
+    Interval entries count from beat start-up, and beat restarts on every
+    deploy — plus platforms like Heroku restart dynos daily and store the
+    scheduler state on an ephemeral disk — so a day-scale interval can
+    starve forever. A crontab fires by wall clock and survives restarts.
+    Pass ``cleanup_schedule=`` to override (any Celery schedule value).
 
     Use it from your project's ``celery.py`` (after the app is configured)
     so the safety net cannot be forgotten or routed to the wrong queue::
@@ -96,9 +103,13 @@ def beat_schedule(
     first, so a plain attribute assignment is accepted and then silently
     ignored. ``django_logic.W002`` catches that.
 
-    The intervals are overridable per task; the defaults match the
+    The schedules are overridable per task; the defaults match the
     README's recommended schedule.
     """
+    from celery.schedules import crontab
+
+    if cleanup_schedule is None:
+        cleanup_schedule = crontab(hour=3, minute=17)
     queue = starter_queue()
 
     def entry(task: str, seconds: float) -> dict:
@@ -112,7 +123,7 @@ def beat_schedule(
         'django-logic-watchdog': entry(
             'django_logic.watchdog_stale_attempts', watchdog_seconds),
         'django-logic-cleanup': entry(
-            'django_logic.cleanup_completed_transitions', cleanup_seconds),
+            'django_logic.cleanup_completed_transitions', cleanup_schedule),
     }
 
 

--- a/tests/test_issue_fixes_testing.py
+++ b/tests/test_issue_fixes_testing.py
@@ -188,6 +188,13 @@ class BeatScheduleTests(ProcessScenario):
             {'task': 'django_logic.retry_stale_transitions',
              'schedule': 30.0, 'options': {'queue': 'my.starter'}},
         )
+        # Cleanup must be a wall-clock schedule, not an interval: interval
+        # entries count from beat start-up, and a beat that restarts on
+        # every deploy (or daily, on platforms that cycle dynos) never
+        # reaches a day-scale interval, so cleanup silently never ran.
+        from celery.schedules import crontab
+        self.assertIsInstance(
+            schedule['django-logic-cleanup']['schedule'], crontab)
         # Every entry names a task that actually exists in the registry.
         from django_logic.background import tasks
         registered = {


### PR DESCRIPTION
Fixes #203. Consumer-reproduced on both gv Heroku apps during the 0.14.0 release test.

Interval beat entries count from beat start-up, and the default scheduler keeps its clock on the dyno's ephemeral disk — so every deploy (and Heroku's ~daily dyno cycling) resets the timer. The three short intervals (60/120/300s) always fire; the 24-hour cleanup never does on an app that deploys daily: staging had rows 10 days past the window, production 889 rows (oldest 9 days, zero past 30 — the weekend-lottery signature).

- `django-logic-cleanup` is now `crontab(hour=3, minute=17)` — wall-clock, restart-immune.
- `cleanup_seconds=` becomes `cleanup_schedule=` (accepts any Celery schedule value); no released consumer passes the old kwarg, and 0.14.0 is unreleased, so the rename rides the same changelog block.
- The beat test pins that cleanup is a crontab, with the why.
- Rider: removes a README leftover describing the deleted failure-side-effects hook.

Suite: 574 tests OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to periodic cleanup scheduling and a keyword rename on an unreleased API; short-interval safety-net tasks are unchanged.
> 
> **Overview**
> Fixes **#203**: on Heroku (and similar deploys), Celery beat restarts reset interval timers, so the **daily cleanup task never ran** while shorter safety-net intervals kept firing—completed `TransitionMessage` rows piled up for 9–10 days.
> 
> **`beat_schedule()`** now schedules `django-logic-cleanup` with a **wall-clock `crontab` (03:17)** instead of an ~86,400s interval. The **`cleanup_seconds`** override is renamed to **`cleanup_schedule`** (any Celery schedule type).
> 
> Docs (**README**, **CHANGELOG**) and tests assert cleanup uses `crontab`, not a numeric interval. README also drops a leftover **failure side-effects** bullet from core concepts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fb083385d516d53c8bfa26578b4b7c7f1bd5cf2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->