### PR TITLE
Docs: declarations are specifications — write processes and their usage out in full (#205)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## [Unreleased]
 
+## [0.14.1] — 2026-08-14
+
+Documentation only. No engine change, so upgrading from 0.14.0 changes no
+behaviour.
+
+### Changed
+
+- **Docs: declarations are specifications** (#205). The README states the
+  design principle — write every process and usage out in full; duplication
+  in declarations is acceptable and usually preferable — with a
+  before/after example, the data-dependent-outcome ("verdict") callback
+  pattern next to the one-in-flight gate, a note in the nested-processes
+  recipe, and the rule in CLAUDE.md for AI tools.
+
 ## [0.14.0] — 2026-08-14
 
 ### Removed (breaking) — the second diet
@@ -67,12 +81,6 @@ growth defended the engine's own machinery).
 
 ### Changed
 
-- **Docs: declarations are specifications** (#205). The README states the
-  design principle — write every process and usage out in full; duplication
-  in declarations is acceptable and usually preferable — with a
-  before/after example, the data-dependent-outcome ("verdict") callback
-  pattern next to the one-in-flight gate, a note in the nested-processes
-  recipe, and the rule in CLAUDE.md for AI tools.
 - The testing-guide scenario catalog is five canonical scenarios; the
   other shapes stay pinned in `tests/` and the guide points there.
 - Kept, deviating from the diet plan: `retry_pending` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,12 @@ growth defended the engine's own machinery).
 
 ### Changed
 
+- **Docs: declarations are specifications** (#205). The README states the
+  design principle — write every process and usage out in full; duplication
+  in declarations is acceptable and usually preferable — with a
+  before/after example, the data-dependent-outcome ("verdict") callback
+  pattern next to the one-in-flight gate, a note in the nested-processes
+  recipe, and the rule in CLAUDE.md for AI tools.
 - The testing-guide scenario catalog is five canonical scenarios; the
   other shapes stay pinned in `tests/` and the guide points there.
 - Kept, deviating from the diet plan: `retry_pending` and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,15 @@ Use `BackgroundTransition` (durable, runs side-effects on a Celery worker,
 writes target/`failed_state`) or `BackgroundAction` (same durability, no state
 change on success) for anything slow, external, or retriable.
 
+**Declarations are specifications.** Write every process and its transitions
+out in full — explicit `sources`, `target`, `conditions`, `side_effects`,
+`callbacks` per declaration, even when sibling processes repeat one shape.
+Duplication in declarations is acceptable and usually preferable: it tells
+how the process behaves; a builder that assembles transitions tells how the
+code works and hides the line a reviewer came to check. The same rule holds
+at usage sites: drive `instance.process.action(...)` literally, never through
+name-string dispatch.
+
 ## Non-negotiable rules
 
 1. **Side-effects must be idempotent against external systems.** Background

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,8 +84,8 @@ out in full — explicit `sources`, `target`, `conditions`, `side_effects`,
 Duplication in declarations is acceptable and usually preferable: it tells
 how the process behaves; a builder that assembles transitions tells how the
 code works and hides the line a reviewer came to check. The same rule holds
-at usage sites: drive `instance.process.action(...)` literally, never through
-name-string dispatch.
+where the process is used: write `instance.process.action(...)` literally,
+never `getattr(process, action_name)` with the name held in a variable.
 
 ## Non-negotiable rules
 

--- a/README.md
+++ b/README.md
@@ -314,7 +314,38 @@ These business rules do not know about each other. You can also test every
 function on its own, because Django-Logic connects them into the business
 process for you.
 
-### 7. Execute in the code
+### 7. Declarations are specifications
+
+A process declaration is read by the person asking "how does this process
+behave?" — not "how is this code structured?". Write it for that reader:
+
+- **Write every process and every transition out in full.** Explicit
+  `sources`, `target`, `conditions`, `side_effects`, `callbacks` per
+  declaration — even when sibling processes repeat the same shape.
+- **Duplication in declarations is acceptable, and usually preferable.**
+  That is abnormal for ordinary code, and deliberate here: repeated
+  declarations tell how the *process* works; a builder that assembles
+  transitions tells how the *code* works, and hides the one line the
+  reader came to check.
+- **The same rule applies where the process is used.** Code that drives a
+  process reads `instance.process.approve(...)` literally — no
+  `getattr(process, action_name_variable)` dispatch, no wrapper hiding
+  which transition runs.
+
+```python
+# Hard to review: what are refund's sources? Which hooks run on cancel?
+transitions = [_build_money_transition(name, hooks) for name, hooks in TABLE]
+
+# Reviewable: each behaviour is stated where the reader looks for it.
+transitions = [
+    Transition(action_name='refund', sources=['paid'], target='refunded',
+               side_effects=[reverse_charge], callbacks=[notify_customer]),
+    Transition(action_name='cancel', sources=['draft', 'approved'], target='cancelled',
+               side_effects=[release_stock]),
+]
+```
+
+### 8. Execute in the code
 ```python
 from invoices.models import Invoice
 
@@ -335,7 +366,7 @@ Use context to pass data between side-effects and callbacks.
 > task or a management command. It is dangerous when you forget it in an API
 > view. In a request handler, always pass `user=request.user`.
 
-### 8. Handle state field overrides
+### 9. Handle state field overrides
 If you want to override the value of the state field, it must be done explicitly. For example: 
 ```python
 Invoice.objects.filter(my_state='draft').update(my_state='approved')
@@ -346,7 +377,7 @@ invoice.save(update_fields=['my_state'])
 ```
 When you change the state field by hand, always pass `update_fields=['my_state']`, as shown above. django-logic writes the state the same way. A transition therefore touches only the state column, and it never overwrites a field that a side-effect changed. Follow the same pattern in your own code. A plain `instance.save()` still saves the field like any other field — django-logic does not intercept it.
 
-### 9. Error handling
+### 10. Error handling
 ```python 
 from django_logic.exceptions import TransitionNotAllowed
 
@@ -1061,6 +1092,30 @@ Two mechanisms serialize work on a state field, each with its own scope:
    - a synchronous `Action` still runs, because it changes no state on success. django-logic skips a failing Action's `failed_state` write while the row is uncompleted, for the same reason.
 
 The constraint is scoped **per process**. Two independent state machines bound to different fields of the same model — say `status` and `payment_status` — can both have background work in progress.
+
+**Data-dependent outcomes ("verdicts").** A background side effect cannot drive a synchronous transition on its own instance — the row it runs under is still uncompleted, so the gate above refuses it. When the leg's outcome decides the next state (a validation that ends valid or invalid), state the decided call explicitly and run it from the transition's `callbacks`, which execute after the row completes:
+
+```python
+from functools import partial
+
+def fetch_sheet(import_obj, **kwargs):
+    rows = read_sheet(import_obj)
+    if all(row.valid for row in rows):
+        import_obj.run_verdict = partial(import_obj.process.mark_as_valid, data=rows)
+    else:
+        import_obj.run_verdict = partial(import_obj.process.mark_as_invalid,
+                                         errors=errors_of(rows))
+
+def apply_verdict(import_obj, **kwargs):
+    run_verdict = import_obj.__dict__.pop('run_verdict', None)
+    if run_verdict is not None:
+        run_verdict()
+
+BackgroundAction(action_name='run_validation', sources=['validating'],
+                 side_effects=[fetch_sheet], callbacks=[apply_verdict])
+```
+
+Each decision point names the exact transition it runs — no name-string dispatch. Callbacks are best-effort: a worker that dies between completing the row and the callback loses the verdict and leaves the instance where it was — re-drivable, not corrupted.
 
 To answer "busy, try again shortly" in your own API, read the row through `in_flight()` instead of writing the filter yourself:
 

--- a/README.md
+++ b/README.md
@@ -327,10 +327,10 @@ behave?" — not "how is this code structured?". Write it for that reader:
   declarations tell how the *process* works; a builder that assembles
   transitions tells how the *code* works, and hides the one line the
   reader came to check.
-- **The same rule applies where the process is used.** Code that drives a
-  process reads `instance.process.approve(...)` literally — no
-  `getattr(process, action_name_variable)` dispatch, no wrapper hiding
-  which transition runs.
+- **The same rule applies where the process is used.** Code that runs a
+  process reads `instance.process.approve(...)` literally — not
+  `getattr(process, action_name)` with the name held in a variable, and
+  not a wrapper that hides which transition runs.
 
 ```python
 # Hard to review: what are refund's sources? Which hooks run on cancel?
@@ -1093,7 +1093,7 @@ Two mechanisms serialize work on a state field, each with its own scope:
 
 The constraint is scoped **per process**. Two independent state machines bound to different fields of the same model — say `status` and `payment_status` — can both have background work in progress.
 
-**Data-dependent outcomes ("verdicts").** A background side effect cannot drive a synchronous transition on its own instance — the row it runs under is still uncompleted, so the gate above refuses it. When the leg's outcome decides the next state (a validation that ends valid or invalid), state the decided call explicitly and run it from the transition's `callbacks`, which execute after the row completes:
+**Data-dependent outcomes ("verdicts").** A background side effect cannot run a synchronous transition on its own instance: its own row is still uncompleted, so the gate above refuses it. When the side effect's result decides the next state (a validation that ends valid or invalid), write the decided call explicitly and run it from the transition's `callbacks`, which execute after the row completes:
 
 ```python
 from functools import partial
@@ -1115,7 +1115,7 @@ BackgroundAction(action_name='run_validation', sources=['validating'],
                  side_effects=[fetch_sheet], callbacks=[apply_verdict])
 ```
 
-Each decision point names the exact transition it runs — no name-string dispatch. Callbacks are best-effort: a worker that dies between completing the row and the callback loses the verdict and leaves the instance where it was — re-drivable, not corrupted.
+Each decision point names the exact transition it runs. Callbacks are best-effort: a worker that dies between completing the row and the callback loses the verdict. The instance stays in its current state, and the operator can run the action again — nothing is corrupted.
 
 To answer "busy, try again shortly" in your own API, read the row through `in_flight()` instead of writing the filter yourself:
 

--- a/docs/recipes/nested-processes.md
+++ b/docs/recipes/nested-processes.md
@@ -118,3 +118,13 @@ its callback fires when it finally reaches a terminal state.
 A full, tested implementation lives in the validation harness:
 [django-logic-test `fulfillment/`](https://github.com/Borderless360/django-logic-test/tree/main/fulfillment)
 + `docs/design/NESTED_PROCESS_ERROR_HANDLING.md`.
+
+
+## Write each sibling in full
+
+Condition-disambiguated siblings are the strongest case for explicit
+declarations. When several nested processes share an action name and a
+condition picks one, the full declaration — sources, condition, hooks,
+queue — is what makes each sibling's behaviour reviewable on its own.
+Do not fold the siblings into a builder to remove the repetition: the
+repetition is the specification.

--- a/docs/recipes/nested-processes.md
+++ b/docs/recipes/nested-processes.md
@@ -120,11 +120,13 @@ A full, tested implementation lives in the validation harness:
 + `docs/design/NESTED_PROCESS_ERROR_HANDLING.md`.
 
 
-## Write each sibling in full
+## Write each sibling process in full
 
-Condition-disambiguated siblings are the strongest case for explicit
-declarations. When several nested processes share an action name and a
-condition picks one, the full declaration — sources, condition, hooks,
-queue — is what makes each sibling's behaviour reviewable on its own.
-Do not fold the siblings into a builder to remove the repetition: the
-repetition is the specification.
+Some designs go further than this sketch: several nested processes declare
+the **same** action name, and each carries a condition that selects it for
+its own kind of instance — say, one `send_message` per integration type.
+That shared-name case is the strongest reason to write each sibling out in
+full: its sources, its condition, its side effects, its queue. A reader can
+then review one sibling's behaviour without reconstructing it from a
+helper. Do not fold the siblings into a builder to remove the repetition —
+the repetition is the specification.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-logic"
-version = "0.14.0"
+version = "0.14.1"
 description = "Declarative business logic & state machines for Django — sync and durable background transitions"
 readme = "README.md"
 license = { text = "MIT License" }


### PR DESCRIPTION
Closes #205. The design principle django-logic was built on, stated in the docs for the first time — re-learned on the gv import_app port (Borderless360/gv#9565), where a transitions builder and a name-string verdict dispatcher both had to be unrolled in review.

## What it adds

- **README → Usage → "Declarations are specifications"**: write every process and every transition out in full; duplication across sibling declarations is acceptable and usually preferable — repeated declarations tell how the *process* works, a builder tells how the *code* works and hides the line a reviewer came to check. Same rule at usage sites: `instance.process.approve(...)` literally, no `getattr(process, name_variable)` dispatch. With a compact before/after.
- **README → Background → the "verdict" pattern**, placed right next to the one-in-flight gate it exists for: a background side effect cannot drive a synchronous transition on its own instance while its row is open, so a data-dependent outcome states the decided call explicitly (`partial(import_obj.process.mark_as_valid, data=rows)`) and a named callback runs it after the row completes. Includes the honest failure note (a crash between completion and callback loses the verdict, leaving the instance re-drivable, not corrupted).
- **Nested-processes recipe**: condition-disambiguated siblings sharing an action name are the strongest case — each sibling's full declaration is what makes its behaviour reviewable on its own; the repetition is the specification.
- **CLAUDE.md**: the same rule under "What to generate", where AI tools writing consumer code will actually read it.

Docs-only; suite 574 OK. Consumer-driven per the release policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and version metadata only; no runtime or API changes.
> 
> **Overview**
> **Documentation-only release (0.14.1).** No library code changes; behaviour matches 0.14.0.
> 
> The docs now state a design principle that was implicit in the project: **process declarations are specifications**, not DRY code. Reviewers should see every transition spelled out (`sources`, `target`, hooks) and call sites should use literal `instance.process.action(...)`, not builders or `getattr(process, name)` dispatch. The README adds section **“Declarations are specifications”** with a before/after example, renumbers later usage sections, and documents the **verdict** pattern (`partial` on the chosen transition + a named callback after the background row completes) next to the one-in-flight gate. The nested-processes recipe adds guidance for condition-disambiguated siblings that share an action name. **CLAUDE.md** carries the same rule for AI-generated consumer code. **CHANGELOG** records 0.14.1 accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a5d5426dd596c133b513089ee02943664403248. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->