### PR TITLE
Voice: writing to people — no riddles

### DIFF
--- a/.cursor/rules/readable-names-and-comments.mdc
+++ b/.cursor/rules/readable-names-and-comments.mdc
@@ -75,4 +75,8 @@ A comment says the non-obvious *why* in one or two sentences.
 
 Exception text and log text are for the operator on call at 3am. Say what happened and what to do. No internal jargon.
 
+## Writing to people — no riddles
+
+A summary, a pull-request description, a review reply, or a chat message must stand on its own. The reader did not watch the work happen. Say the thing, not a name for the thing. Do not coin labels for plans or findings — no letters, no code names, no wave or phase numbers. If a name is unavoidable, define it in the same message, every time it appears. Before you send, ask: does every word work for someone who did not watch the work?
+
 If you would not say it out loud, rewrite it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **The Voice rule covers writing to people.** A summary, a pull-request
+  description, a review reply, or a chat message must stand on its own:
+  say the thing, not a self-coined label for the thing, and define any
+  unavoidable name in the same message. Added to `CLAUDE.md` and the
+  Cursor rule.
+
 ## [0.14.1] — 2026-08-14
 
 Documentation only. No engine change, so upgrading from 0.14.0 changes no

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,21 @@ uncompleted, in progress.
 docs. It skips `CHANGELOG.md` on purpose: the changelog is a historical
 record, so it must keep naming the words and APIs that shipped at the time.
 
+### Writing to people — no riddles
+
+A summary, a pull-request description, a review reply, or a chat message must
+stand on its own. The reader did not watch the work happen.
+
+- Say the thing, not a name for the thing. Write "the two engine cleanups we
+  postponed", never a label from an earlier report.
+- Do not coin labels for plans, findings, or work items. No letters, no code
+  names, no wave or phase numbers. If a name is unavoidable, define it in the
+  same message, every time it appears.
+- Short is good only when the meaning survives. Cut what the reader does not
+  need. Do not replace an explanation with a token the reader must decode.
+- Before you send, ask: does every word work for someone who did not watch
+  the work? If not, rewrite.
+
 ## What to generate
 
 Model a workflow as a `Process` subclass: a list of `transitions` (edges).


### PR DESCRIPTION
The Voice rule covers code prose. This adds the same discipline for everything written **to a person**: summaries, pull-request descriptions, review replies, chat messages.

The rule, in the CLAUDE.md Voice section and the Cursor rule:

- A message must stand on its own — the reader did not watch the work happen.
- Say the thing, not a name for the thing: "the two engine cleanups we postponed", never a label from an earlier report.
- Do not coin labels for plans, findings, or work items — no letters, no code names, no wave or phase numbers. If a name is unavoidable, define it in the same message, every time it appears.
- Short is good only when the meaning survives: cut what the reader does not need, do not replace an explanation with a token the reader must decode.

Prompted by a real failure: a status summary that read "await the team's sign-off, and Vector B plus the coupled-core wave stay parked as the next slices" — every term a private label from the writer's own notes. The same failure mode 0.14.0 removed from the code, reproduced in conversation.

Docs-only. Suite 577 OK (including `test_voice.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only guidance in CLAUDE.md, Cursor rules, and CHANGELOG; no library behavior or CI enforcement changes in the diff.
> 
> **Overview**
> **Extends the Voice rule from code comments to anything written to a person** (summaries, pull-request text, review replies, chat). The reader did not watch the work; say the concrete thing instead of self-coined labels for plans or findings, and define any unavoidable name in the same message.
> 
> The **full guidance** lands in `CLAUDE.md` (bullets on labels, brevity, and a pre-send check). The **Cursor rule** `readable-names-and-comments.mdc` gets a shorter **“Writing to people — no riddles”** section. **`CHANGELOG.md`** records the change under **[Unreleased]**.
> 
> **No runtime or test changes** in this diff—`test_voice.py` still enforces retired *code* dialect only, not this new people-facing rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b48a168761fe240e982d638f1e7b642920cff6fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->