### PR TITLE
Pull worker review fixes: the death record, the net cadence, the wording

### DIFF
--- a/django_logic/background/management/commands/dl_worker.py
+++ b/django_logic/background/management/commands/dl_worker.py
@@ -2,7 +2,7 @@
 
     python manage.py dl_worker --queues django_logic.critical,django_logic.fast
 
-One process per SLA group, like one Celery worker per queue today. The
+One process per SLA group. The
 loop also runs the safety nets (watchdog, stuck report, cleanup), so
 pull mode needs no beat schedule. See docs/design/PULL_WORKERS.md.
 """

--- a/django_logic/background/models.py
+++ b/django_logic/background/models.py
@@ -185,7 +185,7 @@ class TransitionMessage(TimeStampedModel):
         Asks with ``select_for_update(nowait=True)`` inside its own
         savepoint and gives up at once, so the probe never blocks and never
         keeps a lock. On SQLite the clause is dropped, so the answer is
-        always False there — celery mode rejects SQLite at boot, and in
+        always False there — pull mode rejects SQLite at boot, and in
         sync mode the attempt runs in the caller's own thread.
         """
         try:
@@ -284,7 +284,7 @@ class TransitionMessage(TimeStampedModel):
         Durability is mode-dependent, as for
         ``runner._mark_unrestorable_completed``:
 
-        * **Celery mode** — the worker is the top-level unit of work with
+        * **Pull mode** — the worker is the top-level unit of work with
           no surrounding transaction, so this UPDATE autocommits and is
           visible to the watchdog immediately.
         * **Sync mode inside a caller's ``atomic()``** — part of the

--- a/django_logic/background/pull.py
+++ b/django_logic/background/pull.py
@@ -147,12 +147,39 @@ def _run_attempt_in_child(pk: int) -> None:
         f'(exit {exit_code}). Its row lock died with it; the error recorded '
         f'here paces the next claim.'
     )
-    row = TransitionMessage.objects.filter(pk=pk, is_completed=False).first()
-    if row is not None:
-        row.record_error(RuntimeError(
-            f'[crashed] the attempt process died (exit {exit_code}) before '
-            f'the attempt finished'
-        ))
+    _record_child_death(pk, exit_code)
+
+
+def _record_child_death(pk: int, exit_code: int) -> None:
+    """Record a died attempt on the row — unless the row completed first.
+
+    Another worker on the same queue can claim the row the moment the
+    child's lock dies and finish it before this write. One conditional
+    UPDATE keeps the guard and the write in the same statement, so a
+    completed row can never take the death as an error.
+    """
+    from django.db.models import F
+    from django.utils import timezone
+
+    from django_logic.background.models import TransitionMessage, db_safe_text
+
+    now = timezone.now()
+    updated = TransitionMessage.objects.filter(
+        pk=pk, is_completed=False,
+    ).update(
+        errors_count=F('errors_count') + 1,
+        last_error_message=db_safe_text(
+            f'[crashed] the attempt process died (exit {exit_code}) '
+            f'before the attempt finished'
+        ),
+        last_error_dt=now,
+        modified=now,
+    )
+    if not updated:
+        logger.info(
+            f'pull: TransitionMessage#{pk} completed on another worker '
+            f'before the death could be recorded; nothing to record.'
+        )
 
 
 def _run_safety_nets() -> None:
@@ -213,11 +240,15 @@ def run_worker(queues: list[str], *, forever: bool = True) -> None:
         ran_any = False
         while run_once(queues, isolate=True):
             ran_any = True
-        now = time.monotonic()
-        if now - last_safety_net >= SAFETY_NET_SECONDS:
+            # A sustained backlog must not starve the safety nets: break
+            # out of the drain when they are due and come back after.
+            if time.monotonic() - last_safety_net >= SAFETY_NET_SECONDS:
+                break
+        if time.monotonic() - last_safety_net >= SAFETY_NET_SECONDS:
             _run_safety_nets()
-            last_safety_net = now
+            last_safety_net = time.monotonic()
+        if ran_any:
+            continue
         if not forever:
             return
-        if not ran_any:
-            _wait_for_work(POLL_SECONDS)
+        _wait_for_work(POLL_SECONDS)

--- a/django_logic/background/runner.py
+++ b/django_logic/background/runner.py
@@ -3,7 +3,7 @@
 ``run_background_transition(transition_message_id)`` owns a single attempt at executing
 a durable background transition. It runs the same way in:
 
-* the Celery task wrapper (:mod:`django_logic.background.tasks`), and
+* the pull worker loop (:mod:`django_logic.background.pull`), and
 * sync mode, directly after enqueue in the same process.
 
 Structure:
@@ -34,11 +34,10 @@ Structure:
 
 Side-effect exceptions re-raise out of ``run_background_transition``
 only in **sync mode**, so inline callers and tests can ``assertRaises``
-directly. In **Celery mode** the runner swallows them once it has
+directly. In **Pull mode** the runner swallows them once it has
 recorded the outcome on the row (``errors_count`` + ``last_error``, or
-``failed_state`` + completion). The periodic starter owns retries, and
-re-raising out of an ``acks_late`` task would raise task-failure alerts
-and let the broker redeliver the message on top of the periodic retry.
+``failed_state`` + completion). The claim's retry wait owns retries;
+re-raising out of the worker loop would only add noise.
 """
 from __future__ import annotations
 
@@ -76,7 +75,7 @@ class _Outcome:
 def run_background_transition(transition_message_id: int) -> None:
     """Run a single attempt at the transition identified by ``transition_message_id``.
 
-    Designed to be call-compatible from both a Celery task and an
+    Designed to be call-compatible from both the pull worker loop and an
     inline sync dispatcher.
     """
     # Committed BEFORE the attempt's atomic block, and deliberately not rolled
@@ -114,9 +113,9 @@ def run_background_transition(transition_message_id: int) -> None:
 
     if outcome.exception is not None:
         # Sync mode propagates so the inline caller and tests can react.
-        # Celery mode must NOT re-raise. The outcome is already recorded on the
-        # row and the periodic starter owns retries, so re-raising out of an
-        # acks_late task would only add alerts and a broker redelivery.
+        # Pull mode must NOT re-raise. The outcome is already recorded on
+        # the row and the claim's retry wait owns retries; re-raising out
+        # of the worker loop would only add noise.
         from django_logic.background.dispatch import _current_mode
         if _current_mode() == bg_settings.EXECUTION_SYNC:
             raise outcome.exception
@@ -152,7 +151,7 @@ def _mark_unrestorable_completed(transition_message_id: int, reason: str = '') -
     already exited and rolled back. What survives depends on the execution
     mode:
 
-    * Celery mode — the worker is the top-level unit of work with no
+    * Pull mode — the worker is the top-level unit of work with no
       surrounding transaction, so this UPDATE commits on its own. This is
       the path the original infinite-retry bug lived on.
     * Sync mode — enqueue (which created the row) and execute share the

--- a/django_logic/background/transitions.py
+++ b/django_logic/background/transitions.py
@@ -1,6 +1,6 @@
-"""BackgroundTransition / BackgroundAction — durable, queue-routed Celery tasks.
+"""BackgroundTransition / BackgroundAction — durable, queue-routed background work.
 
-``change_state`` enqueues the work (same steps in Celery and Sync mode):
+``change_state`` enqueues the work (same steps in Pull and Sync mode):
 
 * validate conditions + permissions,
 * acquire the state lock for the critical section and revalidate the
@@ -9,8 +9,8 @@
   and create a ``TransitionMessage`` row,
 * release the lock — from here on the uncompleted ``TransitionMessage``
   row is what gates concurrent transitions,
-* hand the row id to the dispatcher, which either ``apply_async`` the
-  Celery task (Celery mode) or executes the worker path inline (Sync mode).
+* hand off to the dispatcher, which notifies the pull workers after
+  commit (Pull mode) or executes the worker path inline (Sync mode).
 
 The worker path lives in :mod:`django_logic.background.runner` and is
 shared between both modes.
@@ -40,14 +40,14 @@ from django_logic.transition import Transition, _refuse_engine_param_kwargs
 
 
 class BackgroundTransition(Transition):
-    """State-changing transition that runs its side-effects on a Celery worker.
+    """State-changing transition that runs its side-effects on a worker process.
 
     Optional:
-        - ``queue`` — the Celery queue this transition's task is routed
-          to. Defaults to ``DJANGO_LOGIC['DEFAULT_QUEUE']``
+        - ``queue`` — the queue name this transition's row carries.
+          Defaults to ``DJANGO_LOGIC['DEFAULT_QUEUE']``
           (``'django_logic'``). Name queues per SLA (e.g. ``critical`` /
-          ``slow``) and give each its own worker to manage performance
-          per queue.
+          ``slow``) and give each its own ``dl_worker`` process to manage
+          performance per queue.
         - ``no_retry_on`` — exception types whose failures are permanent
           for this transition. When a side-effect raises one, the worker
           takes the terminal path on that attempt instead of retrying:
@@ -111,7 +111,7 @@ class BackgroundTransition(Transition):
         )
 
     def get_queue_name(self) -> str:
-        """The Celery queue this transition's task is routed to.
+        """The queue name this transition's row carries.
 
         Resolved lazily (not at class-definition time) so the declared
         ``queue=`` and the ``DEFAULT_QUEUE`` setting are read when the

--- a/django_logic/commands.py
+++ b/django_logic/commands.py
@@ -279,7 +279,7 @@ class NextTransition:
     A dedicated slot because the follow-up must run in the same call
     frame, after the state unlock: side-effects run before unlock (the
     follow-up would deadlock on its own lock acquisition), and callbacks
-    execute on a Celery worker for background transitions — only for
+    execute on a worker process for background transitions — only for
     synchronous transitions do they run inline.
     """
 

--- a/django_logic/testing/scenario.py
+++ b/django_logic/testing/scenario.py
@@ -226,8 +226,8 @@ class ProcessScenario(ScenarioAssertions, TransactionTestCase):
                 f'transition({action!r}) drives a BackgroundTransition — use '
                 f'background_transition({action!r}), which runs enqueue and '
                 f'the worker inline. Under the global default '
-                f"BACKGROUND_EXECUTION='celery' this call only ENQUEUES a "
-                f'Celery task (no worker runs it here), so the drive returns '
+                f"BACKGROUND_EXECUTION='pull' this call only ENQUEUES the "
+                f'row (no worker runs it here), so the drive returns '
                 f'with the instance in its in_progress_state, an uncompleted '
                 f'TransitionMessage left behind, and the real failure surfaces '
                 f'later as a wrong-state or already-in-flight error.',

--- a/django_logic/transition.py
+++ b/django_logic/transition.py
@@ -11,7 +11,7 @@ still runs side-effects and can set a ``failed_state`` on failure.
 For background-executed transitions, see
 ``django_logic.background.BackgroundTransition``. That path has two
 halves: enqueue (write ``in_progress_state`` + a ``TransitionMessage``
-row in one transaction, then send the Celery task) and execute (the
+row in one transaction, then notify the workers) and execute (the
 worker runs the side-effects and writes the final state). Definitions
 live in ``django_logic.background.transitions`` (enqueue) and
 ``django_logic.background.runner`` (execute).

--- a/tests/background/test_pull_workers.py
+++ b/tests/background/test_pull_workers.py
@@ -136,6 +136,37 @@ class PullClaimTests(TransactionTestCase):
         widget.refresh_from_db()
         self.assertEqual(widget.status, 'survived')
 
+    def test_a_death_is_not_recorded_on_a_row_another_worker_completed(self):
+        from django_logic.background.pull import _record_child_death
+
+        widget = Widget.objects.create(status='fulfilled')
+        row = open_transition_message(widget, 'process', 'fulfil')
+        TransitionMessage.objects.filter(pk=row.pk).update(is_completed=True)
+        _record_child_death(row.pk, 1)
+        row.refresh_from_db()
+        self.assertEqual(row.errors_count, 0)
+        self.assertEqual(row.last_error_message, '')
+
+    def test_the_safety_nets_run_during_a_sustained_backlog(self):
+        from unittest.mock import patch
+
+        first = Widget.objects.create(status='draft')
+        second = Widget.objects.create(status='draft')
+        first.process.fulfil()
+        second.process.fulfil()
+        ran = []
+        with patch('django_logic.background.pull.SAFETY_NET_SECONDS', 0), \
+                patch('django_logic.background.pull._run_safety_nets',
+                      side_effect=lambda: ran.append(1)):
+            run_worker(_CRITICAL, forever=False)
+        # Nets due after every claim: they ran at least once per drained row,
+        # not only after the backlog emptied.
+        self.assertGreaterEqual(len(ran), 2)
+        first.refresh_from_db()
+        second.refresh_from_db()
+        self.assertEqual(first.status, 'fulfilled')
+        self.assertEqual(second.status, 'fulfilled')
+
     def test_one_loop_pass_drains_and_runs_the_safety_nets(self):
         first = Widget.objects.create(status='draft')
         second = Widget.objects.create(status='draft')


### PR DESCRIPTION
Three findings from the review of the consumer re-vendor PR (gv#9639), fixed here first per the upstream-first rule.

- **A died attempt's error races a completed row.** With two workers on one queue, the second can claim and finish the row in the gap after the child's lock dies, and the parent's record then dirtied a completed success row. The record is now one conditional UPDATE (`is_completed=False` in the same statement), pinned by a test.
- **A sustained backlog starved the safety nets.** The drain loop only reached the nets when the queue went idle. It now breaks out when they are due and returns to the backlog after, pinned by a test that watches the nets fire mid-drain.
- **Stale wording**: the docstrings that still described Celery workers, Celery queues and celery mode now say what runs.

Suites: 600 SQLite, and the pull tests (10) on PostgreSQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches pull-worker crash accounting and the drain/safety-net loop—concurrency-sensitive background execution, but the changes are small and test-pinned.
> 
> **Overview**
> Fixes two pull-worker bugs found in review, plus leftover Celery wording.
> 
> **Crash vs complete race.** After a forked attempt dies, another worker can claim and finish the row before the parent writes the crash. `_record_child_death` now does a single conditional `UPDATE` (`is_completed=False`), so a completed success is never stamped with a crash error.
> 
> **Safety nets during backlog.** The drain loop used to run watchdog/stuck/cleanup only after the queue went idle. It now breaks out of the drain when `SAFETY_NET_SECONDS` is due, runs the nets, then continues. Tests cover both behaviors.
> 
> Docstrings that still said Celery mode/queues now describe pull workers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c28a1f7300ad6d84257cc23919c3917a8913795. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->