### PR TITLE
0.17.1 — the accounting write survives a database outage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 The two defects the consumer's adoption review of 0.17.0 found (#259,
 #260). Both sit in code 0.17.0 added, so the fix ships before any
-consumer runs it.
+consumer runs it. The wording fix came in through #261.
 
 ### Fixed
 
@@ -22,10 +22,11 @@ consumer runs it.
   pin the retry, one per verdict: a crash stays a crash and a kill
   stays a timeout.
 - **`dl_transitions` stops promising a worker that may not exist**
-  (#260). The finalizer it points at runs inside the worker loop, so
-  the MAX_ERRORS line now says the pass comes when a worker serves the
-  row's queue, and `--send` says the next worker serving that queue
-  claims the row.
+  (#260). Both lines pointed at work that only happens inside a worker
+  loop. The MAX_ERRORS line now says the finalizer's pass comes from
+  any running worker — that sweep reads every queue, not just the
+  worker's own — and `--send` says a worker claims the row once one
+  serves its queue, because the claim *is* queue-filtered.
 
 ## [0.17.0] — 2026-08-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ## [Unreleased]
 
+## [0.17.1] — 2026-08-25
+
+The two defects the consumer's adoption review of 0.17.0 found (#259,
+#260). Both sit in code 0.17.0 added, so the fix ships before any
+consumer runs it.
+
+### Fixed
+
+- **A database blip while the worker records a crash or timeout no
+  longer kills the loop or loses the accounting** (#259). The claim and
+  fork were guarded; the harvest's accounting write was not, and it
+  writes to the same database whose outage crashes attempts in the
+  first place. The write now cannot raise out of the worker loop: a
+  reaped attempt leaves the worker's books only when its write lands,
+  and every later pass retries a failed one. An unaccounted attempt
+  keeps occupying its slot, so a worker that cannot record outcomes
+  stops claiming new work until the database answers again. Two tests
+  pin the retry, one per verdict: a crash stays a crash and a kill
+  stays a timeout.
+- **`dl_transitions` stops promising a worker that may not exist**
+  (#260). The finalizer it points at runs inside the worker loop, so
+  the MAX_ERRORS line now says the pass comes when a worker serves the
+  row's queue, and `--send` says the next worker serving that queue
+  claims the row.
+
 ## [0.17.0] — 2026-08-24
 
 The cleanup after the pull cut (#221): the words now match the engine,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -176,12 +176,13 @@ consumer API is unchanged except where noted.
   unchanged.
 - **`DEFER_UNLOCK_UNTIL_COMMIT` is removed** (#244). Nothing set it.
   The knob, its deferred-unlock registry, the `deferrable=` threading
-  through every release path, and its tests are gone — 651 net lines.
+  through every release path, and its tests are gone — 646 net lines,
+  counted with the re-export removal that shared the commit.
   Locks release when the transition finishes; drive follow-up work
   from `transaction.on_commit` when it must see the caller's commit.
   The key joins the removed-settings tombstones.
 - **The top-level re-export of the command classes is removed**
-  (#244). Import `Conditions`, `Permissions`, `SideEffects`,
+  (#244). **Upgrade step**: import `Conditions`, `Permissions`, `SideEffects`,
   `Callbacks` from `django_logic.commands`. Kept, against the issue's
   list: the `*_class` swap hooks — the consumer overrides
   `Process.permissions_class` on three processes, and its

--- a/django_logic/background/pull.py
+++ b/django_logic/background/pull.py
@@ -130,12 +130,19 @@ def run_once(queues: list[str], *, isolate: bool) -> bool:
 
 @dataclass
 class _Attempt:
-    """One forked attempt process the worker is responsible for."""
+    """One forked attempt process the worker is responsible for.
+
+    ``reaped`` means the process is gone and only the accounting write
+    remains; ``exit_code`` is what the reap reported, or ``None`` when
+    something else reaped it and no status arrived.
+    """
 
     pk: int
     timeout_seconds: float | None
     deadline: float | None
     killed: bool = False
+    reaped: bool = False
+    exit_code: int | None = None
 
 
 def _start_attempt(pk: int, attempts: dict[int, _Attempt]) -> None:
@@ -190,11 +197,22 @@ def _harvest(attempts: dict[int, _Attempt], *, block: bool) -> None:
     With ``block`` the call returns after one attempt ends. It blocks in
     ``waitpid`` when no attempt carries a budget, and polls when one
     does, because a budget has to be enforced while nothing exits.
+
+    An attempt leaves ``attempts`` only when its accounting write lands.
+    The write can fail for the same reason the attempt crashed — a
+    database outage — and losing it would give a crash loop unpaced,
+    unbounded retries, so a failed write keeps the attempt as ``reaped``
+    and every later pass retries it.
     """
     while attempts:
         now = time.monotonic()
+        for pid in [p for p, a in attempts.items() if a.reaped]:
+            if _try_account(attempts[pid]):
+                del attempts[pid]
+        if not attempts:
+            return
         for pid, attempt in attempts.items():
-            if attempt.killed or attempt.deadline is None:
+            if attempt.reaped or attempt.killed or attempt.deadline is None:
                 continue
             if now < attempt.deadline:
                 continue
@@ -206,10 +224,18 @@ def _harvest(attempts: dict[int, _Attempt], *, block: bool) -> None:
                 # reaps it, and the budget passed either way, so the
                 # attempt is still charged a timeout.
                 pass
+        if all(attempt.reaped for attempt in attempts.values()):
+            # Only failed accounting writes remain — no process to wait
+            # on. Pace the retry instead of hammering the database.
+            if not block:
+                return
+            time.sleep(1.0)
+            continue
         next_deadline = min(
             (
                 attempt.deadline for attempt in attempts.values()
-                if attempt.deadline is not None and not attempt.killed
+                if attempt.deadline is not None
+                and not attempt.killed and not attempt.reaped
             ),
             default=None,
         )
@@ -219,22 +245,50 @@ def _harvest(attempts: dict[int, _Attempt], *, block: bool) -> None:
         except ChildProcessError:
             # Something else reaped them, so no exit status is coming.
             for attempt in attempts.values():
-                _account(attempt, None)
-            attempts.clear()
-            return
+                if not attempt.reaped:
+                    attempt.reaped = True
+                    attempt.exit_code = None
+                    attempt.deadline = None
+            continue
         if pid == 0:
             if not block:
                 return
             time.sleep(min(1.0, max(0.01, next_deadline - now)))
             continue
-        attempt = attempts.pop(pid, None)
+        attempt = attempts.get(pid)
         if attempt is None:
             # Not an attempt process. The worker is the only supervisor
             # here, so this is a stray child left by consumer code.
             continue
-        _account(attempt, os.waitstatus_to_exitcode(raw_status))
+        attempt.reaped = True
+        attempt.exit_code = os.waitstatus_to_exitcode(raw_status)
+        attempt.deadline = None
+        if _try_account(attempt):
+            del attempts[pid]
         if block:
             return
+
+
+def _try_account(attempt: _Attempt) -> bool:
+    """Run the accounting write for a reaped attempt. Returns whether it
+    landed.
+
+    The write must not raise out of the worker loop: the database that
+    refuses it is often the same one whose outage crashed the attempt,
+    and a worker that dies here leaves its other attempts running with
+    nothing to enforce their ``timeout=``.
+    """
+    try:
+        _account(attempt, attempt.exit_code)
+    except Exception as exc:
+        logger.error(
+            'pull: could not record how the attempt for '
+            'TransitionMessage#%s ended (%s: %s); the worker keeps it and '
+            'retries the write.',
+            attempt.pk, type(exc).__name__, exc,
+        )
+        return False
+    return True
 
 
 def _account(attempt: _Attempt, exit_code: int | None) -> None:

--- a/docs/design/PULL_WORKERS.md
+++ b/docs/design/PULL_WORKERS.md
@@ -151,9 +151,9 @@ python manage.py dl_worker --queues django_logic.critical,django_logic.fast
 ```
 
 One process per SLA group, exactly like one broker worker per queue
-before. Celery is no longer a dependency: nothing imports it, and
-`'celery'` as a mode reports its removal with the migration steps at
-boot.
+before. Celery is no longer a dependency: nothing imports it, and an
+unknown `BACKGROUND_EXECUTION` value fails loudly at boot naming the
+valid modes.
 
 `--concurrency=N` says how many attempts one worker runs at a time
 (default 1). Each attempt still runs in its own forked process, and
@@ -207,8 +207,8 @@ process alert comes first.
 ## 8. Migration path
 
 1. 0.15.0 is the last push release; 0.16.0 ships pull as the default and
-   removes the push machinery. `'celery'` reports its removal, with the
-   migration steps, at boot.
+   removes the push machinery. An unknown mode fails loudly at boot
+   naming the valid ones.
 2. The Heroku harness runs the full matrix under pull next to the
    recorded push results before 0.16.0 publishes.
 3. A consumer moves by setting `'pull'`, replacing its Celery worker and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-logic"
-version = "0.17.0"
+version = "0.17.1"
 description = "Declarative business logic & state machines for Django — sync and durable background transitions"
 readme = "README.md"
 license = { text = "MIT License" }

--- a/tests/background/test_timeout_enforcement.py
+++ b/tests/background/test_timeout_enforcement.py
@@ -206,6 +206,48 @@ class HarvestTests(TransactionTestCase):
         _harvest(attempts, block=True)
         self.assertEqual(self.recorded(), [])
 
+    def test_a_failed_accounting_write_is_retried_and_lands(self):
+        """The write can fail for the same reason the attempt crashed — a
+        database outage. It must not raise out of the worker loop, and it
+        must land once the database answers again."""
+        attempt_pid = os.fork()
+        if attempt_pid == 0:
+            os._exit(3)
+        self.record.side_effect = [
+            Exception('the connection went away'), None,
+        ]
+        attempts = self._attempt(attempt_pid)
+
+        _harvest(attempts, block=True)
+        # The write failed: the attempt stays, reaped, for the retry.
+        self.assertEqual(len(attempts), 1)
+        self.assertTrue(next(iter(attempts.values())).reaped)
+
+        _harvest(attempts, block=True)
+        self.assertEqual(attempts, {})
+        # Recorded exactly once for real; the first call raised.
+        self.assertEqual(self.record.call_count, 2)
+        self.assertIn('[crashed]', self.record.call_args.args[1])
+
+    def test_a_failed_timeout_write_keeps_its_timeout_verdict(self):
+        """A killed attempt whose write failed must still be charged a
+        timeout on the retry, not re-decided from a stale status."""
+        attempt_pid = os.fork()
+        if attempt_pid == 0:
+            time.sleep(30)
+            os._exit(0)
+        self.record.side_effect = [
+            Exception('the connection went away'), None,
+        ]
+        attempts = self._attempt(
+            attempt_pid, timeout_seconds=0.2, deadline=_PASSED)
+
+        _harvest(attempts, block=True)
+        self.assertEqual(len(attempts), 1)
+        _harvest(attempts, block=True)
+        self.assertEqual(attempts, {})
+        self.assertIn('[timeout]', self.record.call_args.args[1])
+
 
 @override_settings(DJANGO_LOGIC=_PULL_SETTINGS)
 @requires_postgres


### PR DESCRIPTION
## Summary

gv's adoption review of 0.17.0 found two defects, both in code 0.17.0 added. #261 landed the wording one (#260) with a more accurate condition than my draft had, so this carries the remaining one and the documentation corrections.

## A database blip while the worker records a crash or timeout no longer kills the loop (#259)

The claim and fork were guarded; the harvest's accounting write was not — and it writes to the same database whose outage crashes attempts in the first place. The failure is correlated, exactly as the issue says: attempts crash, the worker records the crashes against the dead database, raises, and dies while its other forked attempts still run. Nothing then enforces their `timeout=` or records how they ended.

The write cannot raise out of the worker loop now:

- A reaped attempt leaves the worker's books only when its accounting write lands. A failed write keeps it, marked `reaped`, and every later pass retries it — so the killed/crashed verdict survives the outage instead of being lost with the pop.
- When only failed writes remain there is no process to wait on, so the retry paces at one second rather than hammering the database.
- An unaccounted attempt keeps occupying its slot, so a worker that cannot record outcomes stops claiming new work until the database answers — backpressure during exactly the outage that caused it.

Two tests pin the retry, one per verdict: a crash stays `[crashed]` and a kill stays `[timeout]` across the failed write. Both were run against the unguarded code and error there.

The issue's two held observations stay held, per the release policy written on them.

## Documentation corrections

An accuracy audit of the shipped 0.17.0 against its own code found three misstatements, all fixed here:

- `docs/design/PULL_WORKERS.md` still promised a bespoke boot message for `'celery'`. The follow-up simplification pass removed it — an unknown mode now fails loudly naming the valid ones.
- The changelog credited the `DEFER_UNLOCK_UNTIL_COMMIT` removal with "651 net lines". The commit is 646 net, and that total includes the re-export removal that shared it.
- The re-export removal is a breaking change with an upgrade action, so it carries the **Upgrade step** label the `enable_sync()` change already had.

The same audit verified the whole README line by line against the package and found it fully accurate, and swept the entire `v0.16.0..v0.17.0` public surface for an undocumented break — there is none.

## Validation

- SQLite 594, PostgreSQL 313, all 14 CI jobs.
- **Heroku matrix 33 / 33** on the live rig, engine @ `3e364b45`, `worker_critical` at `--concurrency 4`. The first pass was 32/33 and the failure was the harness catching itself — three of its rows judged a remote command on its exit code alone, so any failure passed them. Details in the harness `docs/RESULTS.md` and the comment below.

Fixes #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pull-worker failure handling on the hot path where attempts are reaped and errors recorded; behavior under DB outages is intentionally different and affects worker liveness and backpressure.
> 
> **Overview**
> **0.17.1** patches a worker bug from 0.17.0: after a forked attempt ends, `_harvest` could raise on the crash/timeout **accounting** write—the same DB outage that killed the attempt—taking down the worker while other attempts kept running with no timeout enforcement.
> 
> Accounting is now **deferred and retried**: reaped attempts stay in the worker’s book with `reaped` / `exit_code` until `_try_account` succeeds; failures are logged and retried (1s pacing when only pending writes remain). Unaccounted attempts still occupy concurrency slots, so the worker stops claiming new work until the DB recovers.
> 
> Two harvest tests lock in retry behavior for `[crashed]` and `[timeout]`. Docs/changelog fixes: unknown `BACKGROUND_EXECUTION` boot behavior in `PULL_WORKERS.md`, line-count and **Upgrade step** notes for the 0.17.0 re-export removal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8318d94ccd2823aa4d4c036101e3debc7cf58b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->