### PR TITLE
0.17.2 — a failed accounting write keeps its retry pace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## [Unreleased]
 
+## [0.17.2] — 2026-08-25
+
+### Fixed
+
+- **A failed accounting write no longer waits for a sibling attempt to
+  end.** When every slot was full and a live attempt carried no
+  ``timeout=``, the worker blocked in ``waitpid``, so the retry of a
+  failed crash or timeout write waited for that sibling's whole run.
+  The worker now polls while a write is waiting, and the retry keeps
+  its one-second pace. Found by review during gv's adoption of 0.17.1.
+- **``run_once`` returns only after the accounting write lands** (#263).
+  It ran one harvest pass and dropped a failed write with its verdict;
+  it now loops until the write lands. Only tests call ``run_once``
+  today, so no deployment saw the loss.
+
 ## [0.17.1] — 2026-08-25
 
 The two defects the consumer's adoption review of 0.17.0 found (#259,

--- a/django_logic/background/pull.py
+++ b/django_logic/background/pull.py
@@ -112,7 +112,8 @@ def run_once(queues: list[str], *, isolate: bool) -> bool:
     segmentation fault, the platform's memory killer — kills the attempt,
     not the worker. The worker records the crash as an error on the row,
     so a crashing attempt gets the same paced, bounded retries as a
-    failing one.
+    failing one. The call returns only after the accounting write lands,
+    so a caller never drops a failed write.
     """
     from django_logic.background.runner import run_background_transition
 
@@ -122,7 +123,8 @@ def run_once(queues: list[str], *, isolate: bool) -> bool:
     if isolate and hasattr(os, 'fork'):
         attempts: dict[int, _Attempt] = {}
         _start_attempt(pk, attempts)
-        _harvest(attempts, block=True)
+        while attempts:
+            _harvest(attempts, block=True)
     else:
         run_background_transition(pk)
     return True
@@ -239,9 +241,15 @@ def _harvest(attempts: dict[int, _Attempt], *, block: bool) -> None:
             ),
             default=None,
         )
+        # A reaped attempt here is a failed accounting write. A blocking
+        # wait would defer its retry for a sibling's whole run, so poll
+        # while one is waiting.
+        failed_write_waiting = any(a.reaped for a in attempts.values())
         try:
             pid, raw_status = os.waitpid(
-                -1, 0 if block and next_deadline is None else os.WNOHANG)
+                -1,
+                0 if block and next_deadline is None
+                and not failed_write_waiting else os.WNOHANG)
         except ChildProcessError:
             # Something else reaped them, so no exit status is coming.
             for attempt in attempts.values():
@@ -253,7 +261,10 @@ def _harvest(attempts: dict[int, _Attempt], *, block: bool) -> None:
         if pid == 0:
             if not block:
                 return
-            time.sleep(min(1.0, max(0.01, next_deadline - now)))
+            if next_deadline is None:
+                time.sleep(1.0)
+            else:
+                time.sleep(min(1.0, max(0.01, next_deadline - now)))
             continue
         attempt = attempts.get(pid)
         if attempt is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-logic"
-version = "0.17.1"
+version = "0.17.2"
 description = "Declarative business logic & state machines for Django — sync and durable background transitions"
 readme = "README.md"
 license = { text = "MIT License" }

--- a/tests/background/test_timeout_enforcement.py
+++ b/tests/background/test_timeout_enforcement.py
@@ -199,6 +199,8 @@ class HarvestTests(TransactionTestCase):
 
         self.assertEqual(len(self.recorded()), 1)
         self.assertIn('[timeout]', self.recorded()[0])
+        # The timeout is charged to the hanging attempt's own row.
+        self.assertEqual(self.record.call_args_list[0].args[0], 1)
 
     def test_a_failed_write_retries_while_a_sibling_still_runs(self):
         """A sibling with no budget must not defer the retry of a failed

--- a/tests/background/test_timeout_enforcement.py
+++ b/tests/background/test_timeout_enforcement.py
@@ -199,7 +199,41 @@ class HarvestTests(TransactionTestCase):
 
         self.assertEqual(len(self.recorded()), 1)
         self.assertIn('[timeout]', self.recorded()[0])
-        self.assertEqual(self.record.call_args_list[0].args[0], 1)
+
+    def test_a_failed_write_retries_while_a_sibling_still_runs(self):
+        """A sibling with no budget must not defer the retry of a failed
+        accounting write for its whole run: the worker polls while a
+        write is waiting."""
+        sibling_pid = os.fork()
+        if sibling_pid == 0:
+            time.sleep(3)
+            os._exit(0)
+        landed_at = []
+        calls = {'count': 0}
+
+        def record(pk, message):
+            calls['count'] += 1
+            if calls['count'] < 3:
+                raise RuntimeError('the database refused the write')
+            landed_at.append(time.monotonic())
+
+        self.record.side_effect = record
+        attempts = {
+            sibling_pid: _Attempt(pk=1, timeout_seconds=None, deadline=None),
+            999999: _Attempt(
+                pk=2, timeout_seconds=1, deadline=_PASSED,
+                killed=True, reaped=True),
+        }
+        started = time.monotonic()
+        _harvest(attempts, block=True)
+        self.assertEqual(attempts, {})
+        self.assertEqual(len(landed_at), 1)
+        self.assertLess(
+            landed_at[0] - started, 2.5,
+            'the retry waited for the sibling instead of polling',
+        )
+        # Every retried call carries the reaped attempt's own row.
+        self.assertEqual(self.record.call_args_list[0].args[0], 2)
 
     def test_harvesting_nothing_returns_at_once(self):
         attempts = {}
@@ -275,3 +309,25 @@ class TimeoutKillTests(TransactionTestCase):
         # The instance is untouched: the killed attempt rolled back.
         widget.refresh_from_db()
         self.assertEqual(widget.status, 'fulfilling')
+
+
+@unittest.skipUnless(hasattr(os, 'fork'), 'needs os.fork')
+class RunOnceAccountingTests(TransactionTestCase):
+    """run_once returns only after the attempt's accounting write lands."""
+
+    def test_run_once_retries_a_failed_accounting_write(self):
+        from django_logic.background import pull
+
+        def crash(pk):
+            raise RuntimeError('the attempt crashes')
+
+        with patch('django_logic.background.pull.claim_next',
+                   return_value=1), \
+                patch('django_logic.background.runner.run_background_transition',
+                      side_effect=crash), \
+                patch('django_logic.background.pull._record_attempt_error',
+                      side_effect=[RuntimeError('the write is refused'),
+                                   None]) as record:
+            ran = pull.run_once(['django_logic'], isolate=True)
+        self.assertTrue(ran)
+        self.assertEqual(record.call_count, 2)


### PR DESCRIPTION
Two fixes in the accounting-retry path 0.17.1 introduced, both found reviewing 0.17.1 during gv's adoption (the vendor PR's bot flagged the first; #263 records the second).

## What changed

- **A failed accounting write no longer waits for a sibling attempt to end.** When every slot was full and a live attempt carried no `timeout=`, the worker blocked in `waitpid` — so the retry of a failed crash or timeout write waited for that sibling's whole run, and the crashed row stayed unpaced for that long. The worker now polls at the one-second pace while a write is waiting. One condition in `_harvest`.
- **`run_once` returns only after the accounting write lands** (#263). It ran one harvest pass and dropped a failed write with its verdict. It now loops until the write lands. Only tests call `run_once` today.

Two new tests pin both: the retry lands while a three-second sibling still runs, and `run_once` retries a refused write to completion.

## Scope notes

- The reclaim-race half of the bot's finding needs a second worker on the same queues; gv's target formation is one dyno, and when it does fire the charged events are all real — `errors_count` stays honest, only the message/date ordering can skew. No further machinery for it.
- Commit e90bf98 (RELEASING.md) was authored on this branch by a concurrent session or by Emil directly while the fix was being written; it is doc-only and rides along.

## Validation

- SQLite suite: 596 tests OK
- PostgreSQL (tests.background + tests.stability): 315 tests OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core worker harvest/wait logic for multi-slot workers and failed DB accounting writes; behavior is pinned by new fork-based tests but affects crash/timeout error recording in production.
> 
> **Overview**
> **Release 0.17.2** tightens pull-worker accounting when a crash/timeout write fails or when several attempts run at once.
> 
> In **`_harvest`**, if a reaped attempt still needs a database write, the worker no longer blocks in **`waitpid`** while a sibling with no **`timeout=`** runs. It polls with **`WNOHANG`** so failed writes retry on the usual ~1s cadence instead of waiting for the sibling’s full run.
> 
> **`run_once`** now loops **`_harvest`** until the attempt’s accounting write succeeds, so a single harvest pass cannot return after dropping a refused write (today only tests call **`run_once`**).
> 
> Changelog and version bump to **0.17.2**; new tests cover sibling polling and **`run_once`** retry-to-completion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f29f30a125bdca35ab2df533865c727a2077fa2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->