### PR TITLE
#242 — one INSTALLED_APPS entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **One `INSTALLED_APPS` entry** (#242). The documented install is
+  `'django_logic.background'` alone. That entry always owned the
+  `TransitionMessage` table and its migrations, the `dl_worker` and
+  `dl_transitions` commands, and every system check, and its boot gate
+  is a strict superset of the base app's — the second entry was never
+  load-bearing. The consumer has run this shape in production for
+  months.
+- No code changed, no migration ran, and no app label or table name
+  moved. An install that keeps `'django_logic'` boots and behaves
+  identically, so delete that line whenever you like.
+- `'django_logic'` alone stays the sync-only shape — also one entry, and
+  the one to keep if you run no background transitions. It has no table,
+  no worker, and no boot check on the database or the cache.
+- The test suite now runs the documented shape. It installed both
+  entries, so 596 tests exercised a configuration no consumer had.
+- This does **not** fold `TransitionMessage` into the `django_logic` app
+  and does **not** squash the nine migrations (#233). Folding would move
+  the app label, which is the address of the live table and of every
+  row in `django_migrations`, to make one settings line prettier.
+
 ## [0.17.2] — 2026-08-25
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -33,15 +33,29 @@ pip install django-logic
 Add `[redis]` if your settings name `django_redis.cache.RedisCache`. That
 extra installs the third-party backend for you.
 
-Add two entries to `INSTALLED_APPS` and create the table:
+Add one entry to `INSTALLED_APPS` and create the table:
 
 ```python
 INSTALLED_APPS = [
     ...,
-    'django_logic',
     'django_logic.background',
 ]
 ```
+
+That one entry is the whole library. It owns the `TransitionMessage`
+table and its migrations, the `dl_worker` and `dl_transitions` commands,
+and every system check. `import django_logic` works as normal — a Python
+package needs no `INSTALLED_APPS` entry to be importable.
+
+Upgrading from a release that asked for a second entry, `'django_logic'`?
+Delete that line whenever you like. Keeping it is supported and changes
+nothing: it is a real app and both boot hooks are idempotent.
+
+Running no background transitions at all? Install `'django_logic'` alone
+instead — also one entry. That shape has no table, no worker and no boot
+check on the database or the cache, so it runs on SQLite with Django's
+default cache. `manage.py check` names the missing app the moment you
+bind a `BackgroundTransition`.
 
 ```bash
 python manage.py migrate

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -7,7 +7,6 @@ SECRET_KEY = 'django_logic'
 INSTALLED_APPS = [
     'django.contrib.auth',
     'django.contrib.contenttypes',
-    'django_logic',
     'django_logic.background',
     'tests',
     'tests.stability',

--- a/tests/test_core_settings_validation.py
+++ b/tests/test_core_settings_validation.py
@@ -9,7 +9,11 @@ import math
 
 from django.apps import apps
 from django.core.exceptions import ImproperlyConfigured
-from django.test import SimpleTestCase, override_settings
+from django.test import (
+    SimpleTestCase,
+    modify_settings,
+    override_settings,
+)
 
 from django_logic.conf import (
     lock_timeout,
@@ -43,6 +47,7 @@ class CoreSettingsValidationTests(SimpleTestCase):
             validate_core_settings()
             self.assertEqual(lock_timeout(), 7200)
 
+    @modify_settings(INSTALLED_APPS={'append': 'django_logic'})
     def test_core_app_ready_runs_the_gate(self):
         """The gate fires from the CORE AppConfig — a sync-only install
         (no django_logic.background) fails fast at boot too."""

--- a/tests/test_settings_and_shadowing_checks.py
+++ b/tests/test_settings_and_shadowing_checks.py
@@ -127,6 +127,7 @@ class NonDictSettingsBlockTests(SimpleTestCase):
                 bg_settings.background_execution()
         self.assertIn('DJANGO_LOGIC must be a dict', str(ctx.exception))
 
+    @modify_settings(INSTALLED_APPS={'append': 'django_logic'})
     def test_both_ready_hooks_fail_with_the_setting_named(self):
         for label in ('django_logic', 'django_logic_background'):
             with self.subTest(app=label):


### PR DESCRIPTION
## Summary

The README asked consumers for two entries. Only one was ever load-bearing, so the defect was the sentence and not the code. **Zero library code changes here.** No migration, no app label change, no table change.

`'django_logic.background'` already owns the `TransitionMessage` table and its nine migrations, the `dl_worker` and `dl_transitions` commands, and every system check — and its boot gate is a strict superset of the base app's. gv has run that single entry in production for months (`gv/settings/base.py` lists it and nothing else).

## What changed

- **README**: one entry, plus the two things a reader needs to know — an existing install can delete the old `'django_logic'` line whenever it likes, and `'django_logic'` **alone** is the sync-only shape, which is also one entry.
- **`tests/settings.py`**: installs the documented entry. It installed both, so 596 tests exercised a configuration no consumer had. The two tests that assert the base app's own `ready()` now install it for their own duration with `@modify_settings`, which turns the superset relation into something CI checks rather than an accident.
- **CHANGELOG**.

## Why the sync-only paragraph is not optional

Measured on Django 6.1, default pull mode, SQLite, per-process cache, `DEBUG=False`:

- `INSTALLED_APPS = ['django_logic']` → boots.
- `INSTALLED_APPS = ['django_logic.background']` → `ImproperlyConfigured` from the pull-mode boot gate.

A consumer running no background transitions needs the *other* single entry. Saying "one entry" without saying which would cost them their dev box.

## Why the fold is declined, not deferred

The plan on #242 was to move `TransitionMessage` into the `django_logic` app label. That was designed out in full and measured end to end — it works — and it is still the wrong trade:

- The app label is the address of the live table and of every row in `django_migrations`. Moving it buys a prettier `INSTALLED_APPS` line.
- It costs nine permanent `replaces` literals, a `db_table` pin that becomes load-bearing with no test defending it, doubled ledger rows on every fresh install, and a forced settings edit on every existing consumer under threat of a boot failure.
- It can silently re-route `TransitionMessage` for any consumer whose database router keys on `app_label == 'django_logic_background'` — a shape the system checks literally instruct consumers to build.

The release policy in `CLAUDE.md` bans machinery without a consumer-reproduced defect. Nobody has reported one caused by the label. The label is ugly, not broken.

**#233 is unaffected** and stays open as a normal same-label `squashmigrations` job, with no dependency on this.

## Validation

- SQLite 596 OK, PostgreSQL 315 OK — under the single documented entry.
- The sync-only shape verified booting on SQLite with the default cache.
- Both `@modify_settings` decorators verified load-bearing: without them those two tests fail with `LookupError: No installed app with label 'django_logic'`.

Fixes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and test settings only; existing dual-entry installs remain supported with identical behavior.
> 
> **Overview**
> Documents **one** `INSTALLED_APPS` line for the full library: **`django_logic.background`** alone. The README and changelog state that entry already owns migrations, worker commands, and system checks, and that keeping the old **`django_logic`** line is harmless but optional.
> 
> **Sync-only** installs are documented separately: **`django_logic`** alone (no table, worker, or DB/cache boot checks).
> 
> **No runtime or migration changes** — app labels and tables stay as they are; folding `TransitionMessage` into the base app is explicitly out of scope.
> 
> The **test suite** now matches the documented install by dropping **`django_logic`** from `tests/settings.py`. Two tests that exercise the base app’s `ready()` hook temporarily append **`django_logic`** with `@modify_settings` so CI still verifies that path without running the whole suite under the old dual-entry setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61b0e0066e9e92337dfb760ff86c58f3470b5963. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->