### PR TITLE
1.2.0 — the recorded class, and may_enqueue for API seams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ## [Unreleased]
 
+## [1.2.0] — 2026-08-26
+
+### Added
+
+- **`django_logic.background.may_enqueue(process, action_name)`.** A
+  generic caller — an API layer that holds a ``request`` and calls an
+  action by name — must not pass ``request`` to a declaration that
+  enqueues, and it cannot know which declaration a name resolves to (a
+  nested process can put a background declaration behind a name that is
+  synchronous on the base process). This answers that question: a
+  static walk over the declarations, nested processes included. Raised
+  from the consumer's port review, where the walk had been written
+  consumer-side.
+
+### Changed
+
+- **`TransitionMessage.driving_model_label` is now
+  `recorded_model_label`**, and the prose says "the class that recorded
+  the row" instead of "the class the caller drove". The review of the
+  1.0.0 consumer port called the old name confusing: at every read site
+  the value is simply what the row recorded. The column
+  (`proxy_model_label`) and the schema are unchanged.
+- The retired-entry error says "is not a valid INSTALLED_APPS entry"
+  instead of "left INSTALLED_APPS", which read two ways.
+
 ## [1.1.0] — 2026-08-26
 
 ### Changed

--- a/django_logic/background/__init__.py
+++ b/django_logic/background/__init__.py
@@ -8,6 +8,9 @@ Public API:
 * :func:`sync_execution` — context manager that forces the current block
   to run the worker path inline (for tests, management commands, the shell).
 * :func:`retry_pending` — run every claimable row inline, once.
+* :func:`may_enqueue` — whether driving an action name on a process can
+  enqueue a background transition. API seams that hold a ``request`` ask
+  this and keep ``request`` off the calls that answer True.
 * :func:`in_flight` — racy read of whether an uncompleted row is still
   being retried, for shaping "busy, try again shortly" answers at API
   seams.
@@ -29,6 +32,7 @@ _PUBLIC = {
     'sync_execution': ('django_logic.conf', 'sync_execution'),
     'retry_pending': ('django_logic.background.safety_nets', 'retry_pending'),
     'in_flight': ('django_logic.background.models', 'in_flight'),
+    'may_enqueue': ('django_logic.background.transitions', 'may_enqueue'),
     'PermanentFailure': ('django_logic.background.exceptions', 'PermanentFailure'),
     'run_worker': ('django_logic.background.pull', 'run_worker'),
 }

--- a/django_logic/background/apps.py
+++ b/django_logic/background/apps.py
@@ -53,9 +53,9 @@ class BackgroundConfig(AppConfig):
 
     def __init__(self, *args, **kwargs):
         raise ImproperlyConfigured(
-            "'django_logic.background' left INSTALLED_APPS in 1.1.0. "
-            "Install 'django_logic' alone. It keeps the same app label, "
-            "table and migration history, so nothing else changes: "
-            "replace this entry (and a 'django_logic' duplicate, if "
-            "present) with one 'django_logic' line."
+            "Since 1.1.0 'django_logic.background' is not a valid "
+            "INSTALLED_APPS entry. Install 'django_logic' alone. It keeps "
+            "the same app label, table and migration history, so nothing "
+            "else changes: replace this entry (and a 'django_logic' "
+            "duplicate, if present) with one 'django_logic' line."
         )

--- a/django_logic/background/models.py
+++ b/django_logic/background/models.py
@@ -14,9 +14,9 @@ both have background work in progress.
 
 The key columns name the concrete model. A proxy and the model it
 proxies are one physical row, so they must collide in the constraint
-the way they already share one state lock. The class the caller drove
-the transition through is recorded separately, on
-``proxy_model_label``, and restore instantiates that class.
+the way they already share one state lock. The class that recorded the
+row is kept separately, on ``proxy_model_label``, and restore
+instantiates that class.
 """
 from __future__ import annotations
 
@@ -93,8 +93,8 @@ class TransitionMessage(TimeStampedModel):
     # default managers), which coerces the string back to the model's
     # real pk type.
     instance_id = models.CharField(max_length=255)
-    # 'app_label.modelname' of the proxy class the caller drove the
-    # transition through. Blank when the caller drove the concrete model.
+    # 'app_label.modelname' of the proxy class that recorded the row.
+    # Blank when the concrete model recorded it.
     # The key columns above always name the concrete model, so this is
     # what lets the worker restore the class the caller used — proxy
     # methods and overrides stay visible to side-effects and callbacks.
@@ -153,17 +153,17 @@ class TransitionMessage(TimeStampedModel):
         ]
 
     @property
-    def driving_model_label(self) -> str:
-        """'app_label.modelname' of the class the caller drove: the
+    def recorded_model_label(self) -> str:
+        """'app_label.modelname' of the class that recorded the row: the
         recorded proxy when there is one, else the concrete key. Restore
-        and every operator-facing line read this, so a proxy-driven row
+        and every operator-facing line read this, so a proxy-recorded row
         keeps naming the workflow the operator knows."""
         return self.proxy_model_label or f'{self.app_label}.{self.model_name}'
 
     def __str__(self) -> str:
         return (
             f'TransitionMessage#{self.pk} '
-            f'{self.driving_model_label}#{self.instance_id} '
+            f'{self.recorded_model_label}#{self.instance_id} '
             f'{self.transition_name} on {self.queue_name}'
         )
 
@@ -175,7 +175,7 @@ class TransitionMessage(TimeStampedModel):
         Keyed on the concrete model: a proxy and the model it proxies
         write and read one row here, so two enqueues on one physical row
         collide in the uncompleted-row constraint no matter which class
-        the caller drove.
+        recorded them.
         """
         concrete = instance._meta.concrete_model._meta
         return {
@@ -187,7 +187,7 @@ class TransitionMessage(TimeStampedModel):
 
     @classmethod
     def proxy_label_for(cls, instance) -> str:
-        """Value for ``proxy_model_label``: the driving class's
+        """Value for ``proxy_model_label``: the recording class's
         'app_label.modelname' when it is a proxy, else blank."""
         return instance._meta.label_lower if instance._meta.proxy else ''
 

--- a/django_logic/background/observability.py
+++ b/django_logic/background/observability.py
@@ -17,11 +17,11 @@ def set_sentry_context(transition_message) -> None:
     try:
         import sentry_sdk
 
-        # Tag the class the caller drove, not the concrete key: two
+        # Tag the class that recorded the row, not the concrete key: two
         # workflows behind two proxies of one model must stay two Sentry
         # issues.
         app_label, _, model_name = (
-            transition_message.driving_model_label.partition('.'))
+            transition_message.recorded_model_label.partition('.'))
         scope = sentry_sdk.get_current_scope()
         scope.set_transaction_name(
             f'django_logic.{app_label}.'

--- a/django_logic/background/runner.py
+++ b/django_logic/background/runner.py
@@ -202,7 +202,7 @@ def finalize_stuck_attempt(transition_message_id: int) -> bool:
 
         transition_logger.warning(
             f'Stuck transition: TransitionMessage#{transition_message.pk} '
-            f'{transition_message.driving_model_label}#{transition_message.instance_id} '
+            f'{transition_message.recorded_model_label}#{transition_message.instance_id} '
             f'{transition_message.transition_name} queue={transition_message.queue_name} '
             f'errors={transition_message.errors_count} '
             f'last_error={transition_message.last_error_message!r}; forcing terminal state'
@@ -778,12 +778,12 @@ def _state_guard_matches(transition, state) -> tuple[bool, str, str]:
 
 def _restore(transition_message: TransitionMessage):
     """Resolve ``(instance, process, transition)`` from a TransitionMessage row."""
-    # The key columns name the concrete model; driving_model_label names
-    # the class the caller drove. Restore that class, so proxy methods and
-    # overrides stay visible to side-effects and callbacks. Rows written
-    # before proxy_model_label existed record the driving class in
+    # The key columns name the concrete model; recorded_model_label names
+    # the class that recorded the row. Restore that class, so proxy
+    # methods and overrides stay visible to side-effects and callbacks.
+    # Rows written before proxy_model_label existed record that class in
     # model_name, so the same read restores them unchanged.
-    recorded_model = transition_message.driving_model_label
+    recorded_model = transition_message.recorded_model_label
     try:
         model = apps.get_model(recorded_model)
     except LookupError as exc:

--- a/django_logic/background/transitions.py
+++ b/django_logic/background/transitions.py
@@ -41,6 +41,38 @@ from django_logic.state import State
 from django_logic.transition import Transition, _refuse_engine_param_kwargs
 
 
+
+def may_enqueue(process, action_name: str) -> bool:
+    """Whether driving ``action_name`` on this process can enqueue a
+    background transition.
+
+    A generic caller — an API layer that holds a ``request`` and calls an
+    action by name — must not pass ``request`` to a declaration that
+    enqueues: enqueue refuses it. The caller cannot know which declaration
+    a name resolves to (a nested process can put a background declaration
+    behind a name that is synchronous on the base process), so it asks
+    here and keeps ``request`` off the call when the answer is True.
+
+    A static walk over the class-level declarations, nested processes
+    included: no conditions run, no queries. A process from another
+    engine, with no ``is_background`` on its transitions, answers False.
+    """
+    seen = set()
+
+    def walk(node) -> bool:
+        if id(node) in seen:
+            return False
+        seen.add(id(node))
+        for transition in getattr(node, 'transitions', None) or []:
+            if (getattr(transition, 'action_name', None) == action_name
+                    and getattr(transition, 'is_background', False)):
+                return True
+        return any(walk(nested)
+                   for nested in getattr(node, 'nested_processes', None) or [])
+
+    return walk(process)
+
+
 class BackgroundTransition(Transition):
     """Transition that runs its side-effects on a worker process.
 
@@ -249,9 +281,9 @@ class BackgroundTransition(Transition):
             # misleading "another transition is already in progress".
             try:
                 transition_message = TransitionMessage.objects.create(
-                    # The key columns name the concrete model; the class
-                    # the caller drove is recorded on proxy_model_label
-                    # so the worker restores that class.
+                    # The key columns name the concrete model; the
+                    # recording class goes on proxy_model_label so the
+                    # worker restores that class.
                     **TransitionMessage.instance_key(
                         state.instance, state.process_name),
                     proxy_model_label=TransitionMessage.proxy_label_for(

--- a/django_logic/management/commands/dl_transitions.py
+++ b/django_logic/management/commands/dl_transitions.py
@@ -64,7 +64,7 @@ class Command(BaseCommand):
             why = self._why(
                 row, claimable, max_errors, report_after, age_minutes)
             self.stdout.write(
-                f'#{row.pk} {row.driving_model_label}'
+                f'#{row.pk} {row.recorded_model_label}'
                 f'#{row.instance_id} {row.process_name}.{row.transition_name} '
                 f'queue={row.queue_name} errors={row.errors_count} '
                 f'age={age_minutes}m — {why}'

--- a/django_logic/migrations/0010_proxy_model_label.py
+++ b/django_logic/migrations/0010_proxy_model_label.py
@@ -4,7 +4,7 @@ from django.db import migrations, models
 def normalize_uncompleted_proxy_rows(apps_registry, schema_editor):
     """Rewrite uncompleted rows keyed on a proxy's name to the concrete key.
 
-    The key columns now name the concrete model, and the driving proxy
+    The key columns now name the concrete model, and the recording proxy
     class moves to ``proxy_model_label``. Rows written before this release
     carry the proxy's own name in ``model_name``, so the uncompleted-row
     guard and the ``in_flight`` probes would stop seeing them.
@@ -51,7 +51,7 @@ def normalize_uncompleted_proxy_rows(apps_registry, schema_editor):
 
 
 def restore_proxy_keys(apps_registry, schema_editor):
-    """Put the driving class back into the key columns, so code from
+    """Put the recording class back into the key columns, so code from
     before this release reads its rows again after an unapply. Runs
     before the column drops. The same clash rule as the forward pass:
     an uncompleted row whose old key another uncompleted row now holds
@@ -88,7 +88,7 @@ class Migration(migrations.Migration):
         # The key columns (app_label, model_name, instance_id) now name the
         # concrete model, so a proxy and the model it proxies collide in
         # the uncompleted-row constraint. This column records the proxy
-        # class the caller drove, so the worker restores that class.
+        # class that recorded the row, so the worker restores that class.
         migrations.AddField(
             model_name='transitionmessage',
             name='proxy_model_label',

--- a/django_logic/testing/snapshot.py
+++ b/django_logic/testing/snapshot.py
@@ -73,7 +73,7 @@ def snapshot(instance, *, state_field: str = 'status', process_name: str = 'proc
             data['transition_message'] = {
                 'transition_name': transition_message.transition_name,
                 'process_name': transition_message.process_name,
-                # The class the caller drove. Captured from the row, not
+                # The class that recorded the row. Captured from it, not
                 # derived from the snapshot instance: the row lookup keys
                 # on the concrete model, so a snapshot taken through
                 # another class of the same table must still replay the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-logic"
-version = "1.1.0"
+version = "1.2.0"
 description = "Declarative business logic & state machines for Django — sync and durable background transitions"
 readme = "README.md"
 license = { text = "MIT License" }

--- a/tests/test_settings_and_shadowing_checks.py
+++ b/tests/test_settings_and_shadowing_checks.py
@@ -122,6 +122,30 @@ class MissingAppGuardTests(_BindingHelper, SimpleTestCase):
         self.bind(Invoice, _SyncOnlyProcess)
 
 
+class MayEnqueueTests(SimpleTestCase):
+    def test_a_background_name_answers_true_and_a_sync_name_false(self):
+        from django_logic.background import may_enqueue
+        self.assertTrue(may_enqueue(_BackgroundBoundProcess, 'bg_run'))
+        self.assertFalse(may_enqueue(_SyncOnlyProcess, 'sync_run'))
+        self.assertFalse(may_enqueue(_BackgroundBoundProcess, 'missing'))
+
+    def test_a_nested_background_declaration_behind_a_sync_name_answers_true(self):
+        from django_logic.background import may_enqueue
+
+        class _Nested(Process):
+            process_name = 'pass4_nested'
+            nested_processes = [_BackgroundBoundProcess]
+            transitions = [
+                Transition('bg_run', sources=['other'], target='done'),
+            ]
+
+        self.assertTrue(may_enqueue(_Nested, 'bg_run'))
+
+    def test_an_object_without_engine_attributes_answers_false(self):
+        from django_logic.background import may_enqueue
+        self.assertFalse(may_enqueue(object(), 'anything'))
+
+
 class PullModeInfrastructureCheckTests(_BindingHelper, SimpleTestCase):
     _PULL = dict(dl_settings(), BACKGROUND_EXECUTION='pull')
     _SQLITE = {'default': {'ENGINE': 'django.db.backends.sqlite3',


### PR DESCRIPTION
## Summary

Both changes come from review comments on the 1.0.0 consumer port.

**`driving_model_label` → `recorded_model_label`** (review: "confusing name — it's actually the recorded model"). At every read site — restore, `__str__`, Sentry tags, `dl_transitions` — the value is simply what the row recorded: the proxy when one recorded it, else the concrete key. The whole prose family moves with it ("the class the caller drove" → "the class that recorded the row"). The `proxy_model_label` column and the schema are unchanged; no migration.

**`django_logic.background.may_enqueue(process, action_name)`** (review on the consumer seam: "should that be in the django logic?" — yes). A generic caller that holds a `request` and calls an action by name must not pass `request` to a declaration that enqueues, and it cannot know which declaration a name resolves to: a nested process can put a background declaration behind a name that is synchronous on the base process. The engine owns that answer now: a static walk over the declarations, nested processes included, False for foreign objects. Pinned for the base, nested, missing and foreign cases.

Also: the retired-entry error now says the old entry "is not a valid INSTALLED_APPS entry" — the old wording ("left INSTALLED_APPS") read two ways.

## Validation

SQLite 595 OK, PostgreSQL 276 + 49 OK, voice OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly additive API and a documented property rename with no schema migration; upgrade risk is limited to consumers that still reference `driving_model_label`.
> 
> **Overview**
> **Release 1.2.0** adds **`django_logic.background.may_enqueue(process, action_name)`** and renames **`TransitionMessage.driving_model_label`** to **`recorded_model_label`** everywhere (restore, logging, Sentry, `dl_transitions`, tests/docs). The **`proxy_model_label`** column is unchanged.
> 
> **`may_enqueue`** answers whether driving that action on a process tree can hit a **`BackgroundTransition`**: a static walk over class-level `transitions` and **`nested_processes`** (cycle-safe), matching **`action_name`** and **`is_background`**, with no conditions or DB. Generic API layers that hold **`request`** can call it before dispatch so they omit **`request`** when enqueue would refuse it—especially when a nested process exposes a background action under a name that is sync on the parent.
> 
> **`recorded_model_label`** is naming-only: it reflects the class that wrote the row (proxy label or concrete key), not “who drove” at call time.
> 
> The retired **`django_logic.background`** `INSTALLED_APPS` boot error now says the entry **is not a valid INSTALLED_APPS entry** instead of “left INSTALLED_APPS”.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88a44cf3f3e563d0d157e2d137150e9c739402de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->