### PR TITLE
A tag creates its GitHub release, and the notes are the changelog

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,8 @@ jobs:
       # PyPI trusted publishing signs the upload with this token, so the
       # repo holds no PyPI credential.
       id-token: write
+      # The release step writes the GitHub release for the tag.
+      contents: write
     steps:
       - uses: actions/checkout@v4
 
@@ -44,3 +46,23 @@ jobs:
         with:
           # A re-run of a tag must not fail on files PyPI already has.
           skip-existing: true
+
+      - name: Create the GitHub release from the changelog
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          # The release notes are the tag's CHANGELOG section, verbatim.
+          awk -v ver="$version" '
+            $0 ~ "^## \\[" ver "\\]" {on=1; next}
+            on && /^## \[/ {exit}
+            on {print}
+          ' CHANGELOG.md > /tmp/notes.md
+          if ! [ -s /tmp/notes.md ]; then
+            echo "no CHANGELOG section for $version" >&2
+            exit 1
+          fi
+          # A re-run of a tag must not fail on a release that exists.
+          if ! gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            gh release create "$GITHUB_REF_NAME" --title "django-logic $version" --notes-file /tmp/notes.md --verify-tag
+          fi


### PR DESCRIPTION
## Summary

The publish workflow uploads to PyPI and created no GitHub release, so the release list stopped at the last hand-made one (0.17.1) while the tags kept coming. Now the same workflow creates the release: the tag's `CHANGELOG.md` section becomes the notes, verbatim — one source of truth, nothing written twice. The step fails loudly when a tag has no changelog section, and a re-run of a tag does not fail on a release that already exists (same rule as the PyPI `skip-existing`).

The four missing releases — [v0.17.2](https://github.com/Borderless360/django-logic/releases/tag/v0.17.2), [v1.0.0](https://github.com/Borderless360/django-logic/releases/tag/v1.0.0), [v1.1.0](https://github.com/Borderless360/django-logic/releases/tag/v1.1.0), [v1.2.0](https://github.com/Borderless360/django-logic/releases/tag/v1.2.0) — were created by hand from the same changelog sections, so the list is complete again.

## Validation

The awk extraction was run against the real changelog for all four versions (677 to 7,181 characters each, correct boundaries). YAML parses. The job gains `contents: write` for the release call; the PyPI half is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only the release GitHub Actions workflow; application code and PyPI trusted publishing behavior are unchanged aside from the new release step.
> 
> **Overview**
> **Tag publishes now also create a GitHub release**, so release notes stay in sync with PyPI instead of relying on hand-made releases.
> 
> After the existing PyPI upload, the publish workflow gains **`contents: write`** and a step that pulls the matching **`CHANGELOG.md`** section for the tagged version (via `awk`), fails if that section is missing, and runs **`gh release create`** with those notes—**skipping creation** when a release for the tag already exists (same idempotency idea as PyPI **`skip-existing`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 128cd9ed6014d2e84641ca6094a80e59bee1fc77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->