### PR TITLE
2.0.0 — a transition never takes the request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 ## [Unreleased]
 
+## [2.0.0] — 2026-08-26
+
+### Removed
+
+- **A transition never takes the request.** Every transition —
+  synchronous or background — refuses a caller-passed `request=` at the
+  call with a `TypeError` that says what to do instead: resolve what the
+  hook needs at the call site and pass plain values (the engine already
+  carries `user=` and restores it on the worker). Until now `request`
+  was legal on synchronous transitions and refused only at a background
+  enqueue, so a declaration could not change shape without changing its
+  callers — and a nested process could hide a background declaration
+  behind a synchronous name, turning a legal call into a refusal.
+- **A hook that names a `request` parameter fails at bind time.** It
+  waits for a value that can never arrive. Same machinery as the
+  instance-first signature validation.
+- **`may_enqueue` is removed.** It shipped in 1.2.0 for one purpose:
+  telling a request-holding caller which calls to keep `request` off.
+  With `request` refused everywhere, the question is gone, and so is
+  the API.
+- The chain hop stops stripping `request` (nothing can carry one);
+  it still strips `user_id`, the engine's wire form for `user`, which
+  stays ordinary data on a synchronous transition.
+
 ## [1.2.0] — 2026-08-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -200,6 +200,10 @@ order.process.approve(user=request.user)
   default.
 - Pass `user=` in a request handler. A call without `user=` is a system call,
   and it skips every permission check.
+- Never pass the request. A transition refuses `request=` at the call:
+  hooks are `fn(instance, **kwargs)` and run on a worker for a background
+  transition, where no request exists. Resolve what a hook needs in the
+  view and pass plain values.
 - `order.process.get_available_actions(user=request.user)` lists what this user
   may run right now.
 - A refused transition raises `TransitionNotAllowed` from

--- a/django_logic/background/__init__.py
+++ b/django_logic/background/__init__.py
@@ -8,9 +8,6 @@ Public API:
 * :func:`sync_execution` — context manager that forces the current block
   to run the worker path inline (for tests, management commands, the shell).
 * :func:`retry_pending` — run every claimable row inline, once.
-* :func:`may_enqueue` — whether driving an action name on a process can
-  enqueue a background transition. API seams that hold a ``request`` ask
-  this and keep ``request`` off the calls that answer True.
 * :func:`in_flight` — racy read of whether an uncompleted row is still
   being retried, for shaping "busy, try again shortly" answers at API
   seams.
@@ -32,7 +29,6 @@ _PUBLIC = {
     'sync_execution': ('django_logic.conf', 'sync_execution'),
     'retry_pending': ('django_logic.background.safety_nets', 'retry_pending'),
     'in_flight': ('django_logic.background.models', 'in_flight'),
-    'may_enqueue': ('django_logic.background.transitions', 'may_enqueue'),
     'PermanentFailure': ('django_logic.background.exceptions', 'PermanentFailure'),
     'run_worker': ('django_logic.background.pull', 'run_worker'),
 }

--- a/django_logic/background/transitions.py
+++ b/django_logic/background/transitions.py
@@ -41,38 +41,6 @@ from django_logic.state import State
 from django_logic.transition import Transition, _refuse_engine_param_kwargs
 
 
-
-def may_enqueue(process, action_name: str) -> bool:
-    """Whether driving ``action_name`` on this process can enqueue a
-    background transition.
-
-    A generic caller — an API layer that holds a ``request`` and calls an
-    action by name — must not pass ``request`` to a declaration that
-    enqueues: enqueue refuses it. The caller cannot know which declaration
-    a name resolves to (a nested process can put a background declaration
-    behind a name that is synchronous on the base process), so it asks
-    here and keeps ``request`` off the call when the answer is True.
-
-    A static walk over the class-level declarations, nested processes
-    included: no conditions run, no queries. A process from another
-    engine, with no ``is_background`` on its transitions, answers False.
-    """
-    seen = set()
-
-    def walk(node) -> bool:
-        if id(node) in seen:
-            return False
-        seen.add(id(node))
-        for transition in getattr(node, 'transitions', None) or []:
-            if (getattr(transition, 'action_name', None) == action_name
-                    and getattr(transition, 'is_background', False)):
-                return True
-        return any(walk(nested)
-                   for nested in getattr(node, 'nested_processes', None) or [])
-
-    return walk(process)
-
-
 class BackgroundTransition(Transition):
     """Transition that runs its side-effects on a worker process.
 

--- a/django_logic/commands.py
+++ b/django_logic/commands.py
@@ -272,14 +272,14 @@ class NextTransition:
             return None
 
         if getattr(transitions[0], 'is_background', False):
-            # request and user_id are refused at enqueue; forwarding
-            # either into a background follow-up would fail kwargs
-            # serialization — and that failure is swallowed below,
-            # silently killing the chain. The caller did nothing wrong:
-            # both are legal on the synchronous transition that chains,
-            # so the engine drops them at the boundary it created.
-            kwargs = {k: v for k, v in kwargs.items()
-                      if k not in ('request', 'user_id')}
+            # user_id is refused at enqueue; forwarding it into a
+            # background follow-up would fail kwargs serialization — and
+            # that failure is swallowed below, silently killing the
+            # chain. The caller did nothing wrong: it is legal on the
+            # synchronous transition that chains, so the engine drops it
+            # at the boundary it created. (request cannot arrive here:
+            # every transition refuses it at the call.)
+            kwargs = {k: v for k, v in kwargs.items() if k != 'user_id'}
 
         using, in_transaction = _in_open_transaction(state.instance)
         try:

--- a/django_logic/process.py
+++ b/django_logic/process.py
@@ -429,16 +429,24 @@ def _validate_hook_signatures(process_cls) -> None:
     bind time.
     """
     offenders = collect_hook_signature_offenders(process_cls)
-    if not offenders:
-        return
-    raise ImproperlyConfigured(
-        'FSM hooks without a named instance-first parameter — the engine '
-        'calls hooks as fn(instance, **kwargs) (permissions as '
-        'fn(instance, user, **kwargs)), so give each hook a named first '
-        'parameter, e.g. def hook(instance, **kwargs); decorated hooks '
-        'need functools.wraps to expose the real signature: '
-        f'{"; ".join(sorted(set(offenders)))}'
-    )
+    if offenders:
+        raise ImproperlyConfigured(
+            'FSM hooks without a named instance-first parameter — the engine '
+            'calls hooks as fn(instance, **kwargs) (permissions as '
+            'fn(instance, user, **kwargs)), so give each hook a named first '
+            'parameter, e.g. def hook(instance, **kwargs); decorated hooks '
+            'need functools.wraps to expose the real signature: '
+            f'{"; ".join(sorted(set(offenders)))}'
+        )
+    request_readers = collect_request_param_offenders(process_cls)
+    if request_readers:
+        raise ImproperlyConfigured(
+            'FSM hooks that name a request parameter — a transition never '
+            'takes the request (it is refused at the call, and a worker has '
+            'none), so a hook can never receive one. Resolve what the hook '
+            'needs at the call site and pass plain values: '
+            f'{"; ".join(sorted(set(request_readers)))}'
+        )
 
 
 def collect_hook_signature_offenders(process_cls) -> list:
@@ -481,6 +489,44 @@ def collect_hook_signature_offenders(process_cls) -> list:
         for transition in proc_cls.transitions or []:
             # getattr-guarded: a duck-typed custom transition that the
             # engine never asks for one of these must not fail to bind.
+            for attr in _HOOK_ATTRS:
+                wrapper = getattr(transition, attr, None)
+                for fn in getattr(wrapper, 'commands', None) or []:
+                    check(fn, f'{owner}.{getattr(transition, "action_name", "?")}')
+    return offenders
+
+
+def collect_request_param_offenders(process_cls) -> list:
+    """Every hook across ``process_cls``'s tree that names a ``request``
+    parameter, as ``module.qualname (on Owner[.action])`` strings. A
+    transition never takes the request, so such a hook waits for a value
+    that can never arrive. Pure collection — bind-time validation enforces.
+    """
+    offenders = []
+
+    def check(fn, owner):
+        try:
+            params = inspect.signature(fn).parameters
+        except (TypeError, ValueError):
+            return
+        if 'request' in params:
+            offenders.append(
+                f'{getattr(fn, "__module__", "?")}.'
+                f'{getattr(fn, "__qualname__", fn)} (on {owner})'
+            )
+
+    _HOOK_ATTRS = (
+        'side_effects', 'callbacks', 'failure_callbacks',
+        'conditions', 'permissions',
+    )
+    for proc_cls in _iter_process_tree(process_cls):
+        owner = f'{proc_cls.__module__}.{proc_cls.__name__}'
+        for attr in ('conditions', 'permissions'):
+            hooks = getattr(proc_cls, attr, None)
+            if isinstance(hooks, (list, tuple)):
+                for fn in hooks:
+                    check(fn, owner)
+        for transition in proc_cls.transitions or []:
             for attr in _HOOK_ATTRS:
                 wrapper = getattr(transition, attr, None)
                 for fn in getattr(wrapper, 'commands', None) or []:

--- a/django_logic/transition.py
+++ b/django_logic/transition.py
@@ -55,6 +55,15 @@ _ENGINE_PARAM_KWARGS = frozenset({'state', 'exception'})
 
 
 def _refuse_engine_param_kwargs(action_name: str, kwargs: dict) -> None:
+    if 'request' in kwargs:
+        raise TypeError(
+            f"{action_name}() received 'request'. A transition never takes "
+            f"the request: hooks are fn(instance, **kwargs) and run on a "
+            f"worker for a background transition, where no request exists. "
+            f"Resolve what you need at the call site and pass plain values "
+            f"— the engine already carries user= and restores it on the "
+            f"worker."
+        )
     clashing = sorted(_ENGINE_PARAM_KWARGS & kwargs.keys())
     if clashing:
         raise TypeError(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-logic"
-version = "1.2.0"
+version = "2.0.0"
 description = "Declarative business logic & state machines for Django — sync and durable background transitions"
 readme = "README.md"
 license = { text = "MIT License" }

--- a/tests/background/test_bg_chain.py
+++ b/tests/background/test_bg_chain.py
@@ -196,10 +196,10 @@ def _record_chain_kwargs(instance, **kwargs):
 
 @override_settings(DJANGO_LOGIC=_SYNC_SETTINGS)
 class SyncToBackgroundRequestChainTests(TestCase):
-    """A sync transition's next_transition into a BACKGROUND follow-up
-    must not forward ``request`` — the follow-up's refusal at enqueue is
-    swallowed by NextTransition, silently killing the chain. Sync
-    follow-ups keep receiving request."""
+    """Every transition refuses ``request`` at the call. ``user_id`` is
+    ordinary data on a synchronous transition, so the hop into a
+    BACKGROUND follow-up strips it — the follow-up's refusal at enqueue
+    is swallowed by NextTransition, silently killing the chain."""
 
     @classmethod
     def setUpClass(cls):
@@ -240,25 +240,26 @@ class SyncToBackgroundRequestChainTests(TestCase):
         _CHAIN_SEEN.clear()
         self.widget = Widget.objects.create(status='draft')
 
-    def test_background_follow_up_runs_despite_request(self):
-        self.widget.request_chain_process.kick(request=object())
+    def test_a_request_kwarg_is_refused_before_anything_runs(self):
+        with self.assertRaises(TypeError) as ctx:
+            self.widget.request_chain_process.kick(request=object())
+        self.assertIn('never takes the request', str(ctx.exception))
         self.widget.refresh_from_db()
-        self.assertEqual(self.widget.status, 'done')
-        self.assertNotIn('request', _CHAIN_SEEN)
+        self.assertEqual(self.widget.status, 'draft')
+        self.assertEqual(_CHAIN_SEEN, {})
 
     def test_background_follow_up_runs_despite_user_id(self):
         # user_id is refused at a direct enqueue (it is the engine's wire
         # form for user), but it is ordinary data on the synchronous
-        # transition that chains — so the hop strips it the same way it
-        # strips request, instead of silently killing the chain.
+        # transition that chains — so the hop strips it instead of
+        # silently killing the chain.
         self.widget.request_chain_process.kick(user_id=42)
         self.widget.refresh_from_db()
         self.assertEqual(self.widget.status, 'done')
         self.assertNotIn('user_id', _CHAIN_SEEN)
 
-    def test_sync_follow_up_still_receives_request(self):
-        sentinel = object()
-        self.widget.request_chain_process.kick_sync(request=sentinel)
+    def test_a_sync_follow_up_refuses_request_the_same_way(self):
+        with self.assertRaises(TypeError):
+            self.widget.request_chain_process.kick_sync(request=object())
         self.widget.refresh_from_db()
-        self.assertEqual(self.widget.status, 'done')
-        self.assertIs(_CHAIN_SEEN.get('request'), sentinel)
+        self.assertEqual(self.widget.status, 'draft')

--- a/tests/background/test_kwargs_roundtrip.py
+++ b/tests/background/test_kwargs_roundtrip.py
@@ -63,12 +63,11 @@ class KwargsRoundTripTests(TestCase):
         )
 
     def test_request_refusal_reaches_the_caller_as_its_own_error(self):
-        # The caller sees KwargsSerializationError, not the dispatcher's
-        # generic "not JSON-serializable" error.
+        # Refused at the call, before the lock and before any write. The
+        # serializer keeps its own refusal as defense for internal paths.
         with self.assertRaisesMessage(
-                KwargsSerializationError, "'request' cannot be passed"):
+                TypeError, 'never takes the request'):
             self.widget.process.fulfil(request=object())
-        # Enqueue failed before it saved anything.
         self.assertFalse(TransitionMessage.objects.exists())
 
     def test_owning_process_class_kept_out_of_nested_side_effect_kwargs(self):

--- a/tests/background/test_parity_matrix.py
+++ b/tests/background/test_parity_matrix.py
@@ -9,8 +9,7 @@ difference fails a test here.
 Pinned for every shape:
 
 * hook kwargs — the same values and the same Python types, plus a live ``user``;
-* ``request`` reaches synchronous hooks; a direct background drive
-  refuses it at enqueue, and that is the one deliberate difference;
+* ``request`` is refused at the call, identically in all four shapes;
 * every background drive serializes kwargs, so an unserializable kwarg fails at
   enqueue — inline sync-mode execution included;
 * failure routing — a synchronous transition raises to the caller and writes
@@ -176,22 +175,16 @@ class ParityMatrixTests(TestCase):
             for key, value in TYPED_KWARGS.items():
                 self.assertIs(type(results[action][key]), type(value), f'{action}.{key}')
 
-    def test_request_reaches_sync_hooks_and_is_refused_at_enqueue(self):
-        # A live request cannot be serialized into the row. A synchronous
-        # hook receives it; a direct background drive refuses it at
-        # enqueue. The engine's own chain hop is the exception: it strips
-        # request before a background follow-up (see test_bg_chain).
-        from django_logic.background.serializers import (
-            KwargsSerializationError,
-        )
-
+    def test_request_is_refused_at_the_call_in_all_four_shapes(self):
+        # A transition never takes the request: hooks run on a worker for
+        # a background transition, where no request exists, and the sync
+        # shapes follow the same rule so a declaration can change shape
+        # without changing its callers.
         sentinel = object()
-        for action in SYNC_ACTIONS:
-            _drive(self._fresh(), action, request=sentinel)
-            self.assertIs(SEEN.get('request'), sentinel, action)
-        for action in BACKGROUND_ACTIONS:
-            with self.assertRaises(KwargsSerializationError):
+        for action in SYNC_ACTIONS + BACKGROUND_ACTIONS:
+            with self.assertRaisesMessage(TypeError, 'never takes the request'):
                 _drive(self._fresh(), action, request=sentinel)
+            self.assertNotIn('request', SEEN)
 
     def test_unserializable_kwarg_fails_at_enqueue_for_background_only(self):
         # Every background drive serializes kwargs, inline sync-mode execution
@@ -278,17 +271,12 @@ class ParityMatrixTests(TestCase):
 
     def test_next_transition_chains_equivalently_across_all_four_shapes(self):
         # The parent's shape must not change what the follow-up receives:
-        # the same typed kwargs, a live user, and never a request. Every
-        # shape chains — a transition with no target included.
+        # the same typed kwargs and a live user. Every shape chains — a
+        # transition with no target included.
         for parent in CHAIN_PARENTS:
             HOP_SEEN.clear()
             widget = self._fresh()
             kwargs = dict(TYPED_KWARGS)
-            if parent.startswith('sync'):
-                # request is legal on a synchronous parent; the engine
-                # strips it before the background hop. A background
-                # parent refuses it at its own enqueue, so it gets none.
-                kwargs['request'] = object()
             _drive(widget, parent, user=self.user, **kwargs)
             widget.refresh_from_db()
             self.assertEqual(widget.status, 'chained', parent)

--- a/tests/test_settings_and_shadowing_checks.py
+++ b/tests/test_settings_and_shadowing_checks.py
@@ -108,6 +108,25 @@ class OneEntryInstallTests(_BindingHelper, SimpleTestCase):
         self.assertIn('alone', message)
 
 
+class RequestParamHookTests(_BindingHelper, SimpleTestCase):
+    def test_a_hook_naming_request_fails_at_bind(self):
+        def with_request(instance, request=None, **kwargs):
+            pass
+
+        class _RequestReadingProcess(Process):
+            process_name = 'pass4_request_reader'
+            transitions = [
+                Transition('run', sources=['draft'], target='done',
+                           side_effects=[with_request]),
+            ]
+
+        with self.assertRaises(ImproperlyConfigured) as ctx:
+            self.bind(Invoice, _RequestReadingProcess)
+        message = str(ctx.exception)
+        self.assertIn('request', message)
+        self.assertIn('with_request', message)
+
+
 class MissingAppGuardTests(_BindingHelper, SimpleTestCase):
     @modify_settings(INSTALLED_APPS={'remove': 'django_logic'})
     def test_a_background_binding_without_the_app_is_refused(self):
@@ -120,30 +139,6 @@ class MissingAppGuardTests(_BindingHelper, SimpleTestCase):
     @modify_settings(INSTALLED_APPS={'remove': 'django_logic'})
     def test_a_sync_only_binding_without_the_app_still_binds(self):
         self.bind(Invoice, _SyncOnlyProcess)
-
-
-class MayEnqueueTests(SimpleTestCase):
-    def test_a_background_name_answers_true_and_a_sync_name_false(self):
-        from django_logic.background import may_enqueue
-        self.assertTrue(may_enqueue(_BackgroundBoundProcess, 'bg_run'))
-        self.assertFalse(may_enqueue(_SyncOnlyProcess, 'sync_run'))
-        self.assertFalse(may_enqueue(_BackgroundBoundProcess, 'missing'))
-
-    def test_a_nested_background_declaration_behind_a_sync_name_answers_true(self):
-        from django_logic.background import may_enqueue
-
-        class _Nested(Process):
-            process_name = 'pass4_nested'
-            nested_processes = [_BackgroundBoundProcess]
-            transitions = [
-                Transition('bg_run', sources=['other'], target='done'),
-            ]
-
-        self.assertTrue(may_enqueue(_Nested, 'bg_run'))
-
-    def test_an_object_without_engine_attributes_answers_false(self):
-        from django_logic.background import may_enqueue
-        self.assertFalse(may_enqueue(object(), 'anything'))
 
 
 class PullModeInfrastructureCheckTests(_BindingHelper, SimpleTestCase):


### PR DESCRIPTION
## Summary

The review of the consumer port landed on the principle: we should not be passing the request to transitions. This release makes the engine enforce it.

**Every transition refuses `request=` at the call**, synchronous or background, with a `TypeError` naming the remedy: resolve what the hook needs at the call site and pass plain values — the engine already carries `user=` and restores it on the worker. The old split (legal on sync, refused at enqueue) meant a declaration could not change shape without changing its callers, and a nested process could hide a background declaration behind a synchronous name, turning a legal call into a refusal the caller could not predict.

**A hook that names a `request` parameter fails at bind time** — it waits for a value that can never arrive. Same machinery and error shape as the instance-first signature validation.

**`may_enqueue` is removed.** It shipped in 1.2.0 for exactly one purpose — telling a request-holding caller which calls to keep `request` off. With `request` refused everywhere the question is gone, so the API goes with it rather than surviving as dead surface.

**The chain hop** stops stripping `request` (nothing can carry one) and keeps stripping `user_id`, which stays ordinary data on a synchronous transition.

## Consumer note

gv resolves the hijack-audit identity at its seams (the actual admin behind an impersonated session) and stops passing `request`; its port rides the open re-vendor PRs. The serializer's own `request` refusal stays as defense on internal paths.

## Validation

SQLite 593 OK, PostgreSQL 276 + 49 OK, voice OK. Rewritten pins: the four-shape parity matrix pins the refusal identically in all shapes; the chain tests pin refusal-before-anything-runs and the surviving `user_id` strip; a new bind-time pin covers the `request`-parameter hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Breaking change for any code that passes `request=` to transitions or imports `may_enqueue`, plus new bind-time failures for hooks that name `request`; consumers must resolve request-derived data at the view/API layer before calling actions.
> 
> **Overview**
> **2.0.0** makes the transition API consistent: **`request=` is rejected on every transition call** (sync and background) with a `TypeError` that tells callers to pass plain values and rely on `user=`. That removes the old split where sync allowed `request` but background refused it at enqueue—so changing a declaration between sync and background no longer changes what callers may pass.
> 
> **Bind time**, any FSM hook that declares a `request` parameter now raises **`ImproperlyConfigured`**, using the same pattern as instance-first signature checks.
> 
> **`django_logic.background.may_enqueue`** is dropped from the public API (it only existed to decide when not to pass `request`). **`next_transition`** into a background follow-up still strips **`user_id`** at the chain boundary but no longer strips `request`, since callers cannot pass one.
> 
> Docs, changelog, and tests (parity matrix, chain, kwargs roundtrip) are updated; package version is **2.0.0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f039c53f24044382c6d5ff3718ec9f1c56687972. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->