### PR TITLE
A comment says the why in words, never a linter code

### DIFF
--- a/django_logic/apps.py
+++ b/django_logic/apps.py
@@ -19,7 +19,8 @@ class DjangoLogicConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
 
     def ready(self) -> None:
-        from django_logic import checks  # noqa: F401 — registers system checks
+        # Imported for its side effect: the module registers the system checks.
+        from django_logic import checks
         from django_logic.background.apps import validate_on_ready
 
         validate_on_ready()

--- a/django_logic/models.py
+++ b/django_logic/models.py
@@ -5,4 +5,5 @@ declares ``app_label = 'django_logic_background'`` — the label is the
 address of the live table, its migration records and its content types,
 so it never changes. Importing it here registers it when the app loads.
 """
-from django_logic.background.models import TransitionMessage  # noqa: F401
+# Imported so the app registry sees the model when the app loads.
+from django_logic.background.models import TransitionMessage

--- a/django_logic/testing/scenario.py
+++ b/django_logic/testing/scenario.py
@@ -252,7 +252,8 @@ class ProcessScenario(ScenarioAssertions, TransactionTestCase):
         try:
             fn()
             return None
-        except Exception as exc:  # noqa: BLE001 — re-raised below unless injected
+        # Broad on purpose: re-raised below unless the test injected it.
+        except Exception as exc:
             return exc
 
     def _finish(self, label, instance, tracker, raised, before, *, action=None,

--- a/tests/settings_redis.py
+++ b/tests/settings_redis.py
@@ -7,7 +7,7 @@ for the full Postgres+Redis environment.
 """
 import os
 
-from tests.settings import *  # noqa: F401, F403
+from tests.settings import *
 
 CACHES = {
     'default': {

--- a/tests/settings_stability.py
+++ b/tests/settings_stability.py
@@ -10,7 +10,7 @@ These are needed for:
 """
 import os
 
-from tests.settings import *  # noqa: F401, F403
+from tests.settings import *
 
 DATABASES = {
     'default': {

--- a/tests/test_definition_validation_pins.py
+++ b/tests/test_definition_validation_pins.py
@@ -282,7 +282,8 @@ class PublicSurfaceTests(TestCase):
         self.assertIn('BackgroundTransition', str(ctx.exception))
         # The command classes are not advertised, but a direct import from
         # django_logic.commands keeps working for existing consumers.
-        from django_logic.commands import (  # noqa: F401
+        # The import itself is the assertion: it must not raise.
+        from django_logic.commands import (
             Callbacks, Conditions, Permissions, SideEffects,
         )
 


### PR DESCRIPTION
The review rule from the consumer port applies here too: nothing a person cannot read without a lookup table. The six `noqa` markers leave the repo; where the comment carried a reason ("registers system checks", "re-raised below unless injected", "the import itself is the assertion"), the reason stays in plain words. No linter runs in CI, so the markers silenced nothing. 593 tests OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only and import-style cleanup with no logic, configuration, or API changes.
> 
> **Overview**
> Removes all six `# noqa` suppressions across app bootstrap, models, test scenario helpers, stability settings, and import-surface tests. **No runtime or lint behavior changes**—CI does not run the linters those codes referred to.
> 
> Where a marker used to encode a reason (side-effect imports, broad `except` in `_call`, star-import settings modules, “import must not raise” in tests), that rationale is spelled out in normal comments instead of linter codes like `F401` or `BLE001`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4aa2e702da60b50a3b6227e18f502ba9dac184d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->